### PR TITLE
[WIP] bootkube: integrate bootkube render/start as a module

### DIFF
--- a/bootkube/assets.tf
+++ b/bootkube/assets.tf
@@ -1,0 +1,117 @@
+# Kubernetes Manifests, ordered alphabetically.
+
+## manifests/kube-apiserver.yaml
+data "template_file" "kube-apiserver" {
+  template = "${file("${path.module}/resources/manifests/kube-apiserver.yaml.tpl")}"
+
+  vars {
+    cloud_provider = "${var.cloud_provider}"
+    etcd_servers = "${join(",", var.etcd_servers)}"
+    hyperkube_image = "${var.hyperkube_image}"
+    service_cidr = "${var.service_cidr}"
+  }
+}
+
+## manifests/kube-apiserver-secret.yaml
+data "template_file" "kube-apiserver-secret" {
+  template = "${file("${path.module}/resources/manifests/kube-apiserver-secret.yaml.tpl")}"
+
+  vars {
+    apiserver_key = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
+    apiserver_cert = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
+    serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
+    ca_cert = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
+  }
+}
+
+## manifests/kube-controller-manager.yaml
+data "template_file" "kube-controller-manager" {
+  template = "${file("${path.module}/resources/manifests/kube-controller-manager.yaml.tpl")}"
+
+  vars {
+    cloud_provider = "${var.cloud_provider}"
+    cluster_cidr = "${var.cluster_cidr}"
+    hyperkube_image = "${var.hyperkube_image}"
+  }
+}
+
+## manifests/kube-controller-manager-secret.yaml
+data "template_file" "kube-controller-manager-secret" {
+  template = "${file("${path.module}/resources/manifests/kube-controller-manager-secret.yaml.tpl")}"
+
+  vars {
+    serviceaccount_key = "${base64encode(tls_private_key.service-account.private_key_pem)}"
+    ca_cert = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
+  }
+}
+
+## manifests/kube-dns.yaml
+data "template_file" "kube-dns" {
+  template = "${file("${path.module}/resources/manifests/kube-dns.yaml.tpl")}"
+
+  vars {
+    kube_dns_service_ip = "${var.kube_dns_service_ip}"
+  }
+}
+
+## manifests/kube-flannel.yaml
+data "template_file" "kube-flannel" {
+  template = "${file("${path.module}/resources/manifests/kube-flannel.yaml.tpl")}"
+
+  vars {
+    cluster_cidr = "${var.cluster_cidr}"
+  }
+}
+
+## manifests/kube-proxy.yaml
+data "template_file" "kube-proxy" {
+  template = "${file("${path.module}/resources/manifests/kube-proxy.yaml.tpl")}"
+
+  vars {
+    cluster_cidr = "${var.cluster_cidr}"
+    hyperkube_image = "${var.hyperkube_image}"
+  }
+}
+
+## manifests/kube-scheduler.yaml
+data "template_file" "kube-scheduler" {
+  template = "${file("${path.module}/resources/manifests/kube-scheduler.yaml.tpl")}"
+
+  vars {
+    hyperkube_image = "${var.hyperkube_image}"
+  }
+}
+
+## manifests/pod-checkpoint-installer.yaml
+data "template_file" "pod-checkpoint-installer" {
+  template = "${file("${path.module}/resources/manifests/pod-checkpoint-installer.yaml.tpl")}"
+
+  vars {
+    pod_checkpointer_image = "${var.pod_checkpointer_image}"
+  }
+}
+
+# Other assets
+
+## kubeconfig
+data "template_file" "kubeconfig" {
+  template = "${file("${path.module}/resources/kubeconfig.tpl")}"
+
+  vars {
+    ca_cert = "${base64encode(tls_self_signed_cert.kube-ca.cert_pem)}"
+    kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}}"
+    kubelet_key = "${base64encode(tls_private_key.kubelet.private_key_pem)}}"
+    server = "${var.kube_apiserver_url}"
+  }
+}
+
+## bootkube.service
+data "template_file" "bootkube-service" {
+  template = "${file("${path.module}/resources/bootkube.service.tpl")}"
+
+  vars {
+    "assets_path" = "${var.assets_path}"
+    "bootkube_image" = "${var.bootkube_image}"
+    "etcd_endpoint" = "${var.etcd_servers[0]}"
+  }
+}

--- a/bootkube/assets_tls.tf
+++ b/bootkube/assets_tls.tf
@@ -1,0 +1,97 @@
+# Kubernetes CA
+resource "tls_private_key" "kube-ca" {
+  algorithm = "ECDSA"
+}
+
+resource "tls_self_signed_cert" "kube-ca" {
+  key_algorithm = "${tls_private_key.kube-ca.algorithm}"
+  private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+
+  subject {
+    common_name = "kube-ca"
+    organization = "bootkube"
+  }
+
+  is_ca_certificate = true
+  validity_period_hours = 8760
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "cert_signing",
+  ]
+}
+
+# Kubernetes API Server
+resource "tls_private_key" "apiserver" {
+  algorithm = "ECDSA"
+}
+
+resource "tls_cert_request" "apiserver" {
+  key_algorithm = "${tls_private_key.apiserver.algorithm}"
+  private_key_pem = "${tls_private_key.apiserver.private_key_pem}"
+
+  subject {
+    common_name = "kube-apiserver"
+    organization = "kube-master"
+  }
+
+  dns_names = [
+    "${var.kube_apiserver_service_ip}",
+    "kubernetes",
+    "kubernetes.default",
+    "kubernetes.default.svc",
+    "kubernetes.default.svc.cluster.local",
+  ]
+}
+
+resource "tls_locally_signed_cert" "apiserver" {
+  cert_request_pem = "${tls_cert_request.apiserver.cert_request_pem}"
+
+  ca_key_algorithm = "${tls_self_signed_cert.kube-ca.key_algorithm}"
+  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+  ca_cert_pem = "${tls_self_signed_cert.kube-ca.cert_pem}"
+
+  validity_period_hours = 8760
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+  ]
+}
+
+# Kubernete's Service Account
+resource "tls_private_key" "service-account" {
+  algorithm = "ECDSA"
+}
+
+# Kubelet
+resource "tls_private_key" "kubelet" {
+  algorithm = "ECDSA"
+}
+
+resource "tls_cert_request" "kubelet" {
+  key_algorithm = "${tls_private_key.kubelet.algorithm}"
+  private_key_pem = "${tls_private_key.kubelet.private_key_pem}"
+
+  subject {
+    common_name = "kubelet"
+    organization = "system:masters"
+  }
+}
+
+resource "tls_locally_signed_cert" "kubelet" {
+  cert_request_pem = "${tls_cert_request.kubelet.cert_request_pem}"
+
+  ca_key_algorithm = "${tls_self_signed_cert.kube-ca.key_algorithm}"
+  ca_private_key_pem = "${tls_private_key.kube-ca.private_key_pem}"
+  ca_cert_pem = "${tls_self_signed_cert.kube-ca.cert_pem}"
+
+  validity_period_hours = 8760
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+  ]
+}

--- a/bootkube/bootkube.tf
+++ b/bootkube/bootkube.tf
@@ -1,0 +1,148 @@
+# TODO: Add support for user-provided CA
+
+resource "null_resource" "bootkube" {
+  triggers {
+    host = "${var.host}"
+  }
+
+  connection {
+    host = "${var.host}"
+    user = "${var.user}"
+    private_key = "${var.private_key}"
+    agent = true
+  }
+
+  ## Assets folder
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p ${var.assets_path}/manifests ${var.assets_path}/tls",
+    ]
+  }
+
+  # Kubernetes Assets
+  # Manifests are ordered alphabetically.
+
+  ## manifests/kube-apiserver.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-apiserver.rendered}"
+    destination = "${var.assets_path}/manifests/kube-apiserver.yaml"
+  }
+
+  ## manifests/kube-apiserver-secret.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-apiserver-secret.rendered}"
+    destination = "${var.assets_path}/manifests/kube-apiserver-secret.yaml"
+  }
+
+  ## manifests/kube-controller-manager.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-controller-manager.rendered}"
+    destination = "${var.assets_path}/manifests/kube-controller-manager.yaml"
+  }
+
+  ## manifests/kube-controller-manager-disruption.yaml
+  provisioner "file" {
+    source = "${path.module}/resources/manifests/kube-controller-manager-disruption.yaml"
+    destination = "${var.assets_path}/manifests/kube-controller-manager-disruption.yaml"
+  }
+
+  ## manifests/kube-controller-manager-secret.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-controller-manager-secret.rendered}"
+    destination = "${var.assets_path}/manifests/kube-controller-manager-secret.yaml"
+  }
+
+  ## manifests/kube-dns.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-dns.rendered}"
+    destination = "${var.assets_path}/manifests/kube-dns.yaml"
+  }
+
+  ## manifests/kube-flannel.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-flannel.rendered}"
+    destination = "${var.assets_path}/manifests/kube-flannel.yaml"
+  }
+
+  ## manifests/kube-proxy.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-proxy.rendered}"
+    destination = "${var.assets_path}/manifests/kube-proxy.yaml"
+  }
+
+  ## manifests/kube-scheduler.yaml
+  provisioner "file" {
+    content = "${data.template_file.kube-scheduler.rendered}"
+    destination = "${var.assets_path}/manifests/kube-scheduler.yaml"
+  }
+
+  ## manifests/kube-scheduler-disruption.yaml
+  provisioner "file" {
+    source = "${path.module}/resources/manifests/kube-scheduler-disruption.yaml"
+    destination = "${var.assets_path}/manifests/kube-scheduler-disruption.yaml"
+  }
+
+  ## manifests/kube-system-rbac-role-binding.yaml
+  provisioner "file" {
+    source = "${path.module}/resources/manifests/kube-system-rbac-role-binding.yaml"
+    destination = "${var.assets_path}/manifests/kube-system-rbac-role-binding.yaml"
+  }
+
+  ## manifests/pod-checkpoint-installer.yaml
+  provisioner "file" {
+    content = "${data.template_file.pod-checkpoint-installer.rendered}"
+    destination = "${var.assets_path}/manifests/pod-checkpoint-installer.yaml"
+  }
+
+  # TLS Assets required by bootkube's temporary servers
+
+  ## tls/apiserver.key
+  provisioner "file" {
+    content = "${tls_private_key.apiserver.private_key_pem}"
+    destination = "${var.assets_path}/tls/apiserver.key"
+  }
+
+  ## tls/apiserver.crt
+  provisioner "file" {
+    content = "${tls_locally_signed_cert.apiserver.cert_pem}"
+    destination = "${var.assets_path}/tls/apiserver.crt"
+  }
+
+  ## tls/ca.crt
+  provisioner "file" {
+    content = "${tls_self_signed_cert.kube-ca.cert_pem}"
+    destination = "${var.assets_path}/tls/ca.crt"
+  }
+
+  ## tls/service-account.key
+  provisioner "file" {
+    content = "${tls_private_key.service-account.private_key_pem}"
+    destination = "${var.assets_path}/tls/service-account.key"
+  }
+
+  ## tls/service-account.pub
+  provisioner "file" {
+    content = "${tls_private_key.service-account.public_key_pem}"
+    destination = "${var.assets_path}/tls/service-account.pub"
+  }
+
+  # Execute bootkube as a systemd unit
+
+  provisioner "file" "bootkube.service" {
+    content = "${data.template_file.bootkube-service.rendered}"
+    destination = "${var.assets_path}/bootkube.service"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv ${var.assets_path}/bootkube.service /etc/systemd/system/",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo systemctl daemon-reload",
+      "sudo systemctl start bootkube",
+    ]
+  }
+}

--- a/bootkube/resources/bootkube.service.tpl
+++ b/bootkube/resources/bootkube.service.tpl
@@ -1,0 +1,9 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/rkt run \
+  --trust-keys-from-https \
+  --volume assets,kind=host,source=${assets_path} \
+  --mount volume=assets,target=/assets \
+  ${bootkube_image} \
+  --net=host \
+  --exec=/bootkube -- start --asset-dir=/assets --etcd-server="${etcd_endpoint}"

--- a/bootkube/resources/kubeconfig.tpl
+++ b/bootkube/resources/kubeconfig.tpl
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: ${server}
+    certificate-authority-data: ${ca_cert}
+users:
+- name: kubelet
+  user:
+    client-certificate-data: ${kubelet_cert}
+    client-key-data: ${kubelet_key}
+contexts:
+- context:
+    cluster: local
+    user: kubelet

--- a/bootkube/resources/manifests/kube-apiserver-secret.yaml.tpl
+++ b/bootkube/resources/manifests/kube-apiserver-secret.yaml.tpl
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-apiserver-secret
+  namespace: kube-system
+type: Opaque
+data:
+  apiserver.key: ${apiserver_key}
+  apiserver.crt: ${apiserver_cert}
+  service-account.pub: ${serviceaccount_pub}
+  ca.crt: ${ca_cert}

--- a/bootkube/resources/manifests/kube-apiserver.yaml.tpl
+++ b/bootkube/resources/manifests/kube-apiserver.yaml.tpl
@@ -1,0 +1,70 @@
+apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: kube-apiserver
+  namespace: kube-system
+  labels:
+    k8s-app: kube-apiserver
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-apiserver
+      annotations:
+        checkpointer.alpha.coreos.com/checkpoint: "true"
+    spec:
+      nodeSelector:
+        master: "true"
+      hostNetwork: true
+      containers:
+      - name: kube-apiserver
+        image: ${hyperkube_image}
+        command:
+        - /usr/bin/flock
+        - --exclusive
+        - --timeout=30
+        - /var/lock/api-server.lock
+        - /hyperkube
+        - apiserver
+        - --bind-address=0.0.0.0
+        - --secure-port=443
+        - --insecure-port=8080
+        - --advertise-address=$(POD_IP)
+        - --etcd-servers=${etcd_servers}
+        - --storage-backend=etcd3
+        - --allow-privileged=true
+        - --service-cluster-ip-range=${service_cidr}
+        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
+        - --runtime-config=api/all=true
+        - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
+        - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
+        - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
+        - --client-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --authorization-mode=RBAC
+        - --cloud-provider=${cloud_provider}
+        - --anonymous-auth=false
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs-host
+          readOnly: true
+        - mountPath: /etc/kubernetes/secrets
+          name: secrets
+          readOnly: true
+        - mountPath: /var/lock
+          name: var-lock
+          readOnly: false
+      volumes:
+      - name: ssl-certs-host
+        hostPath:
+          path: /usr/share/ca-certificates
+      - name: secrets
+        secret:
+          secretName: kube-apiserver
+      - name: var-lock
+        hostPath:
+          path: /var/lock

--- a/bootkube/resources/manifests/kube-controller-manager-disruption.yaml
+++ b/bootkube/resources/manifests/kube-controller-manager-disruption.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-controller-manager

--- a/bootkube/resources/manifests/kube-controller-manager-secret.yaml.tpl
+++ b/bootkube/resources/manifests/kube-controller-manager-secret.yaml.tpl
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-controller-manager-secret
+  namespace: kube-system
+type: Opaque
+data:
+  service-account.key: ${serviceaccount_key}
+  ca.crt: ${ca_cert}

--- a/bootkube/resources/manifests/kube-controller-manager.yaml.tpl
+++ b/bootkube/resources/manifests/kube-controller-manager.yaml.tpl
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: kube-controller-manager
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-controller-manager
+    spec:
+      nodeSelector:
+        master: "true"
+      containers:
+      - name: kube-controller-manager
+        image: ${hyperkube_image}
+        command:
+        - ./hyperkube
+        - controller-manager
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=false
+        - --cluster-cidr=${cluster_cidr}
+        - --root-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        - --leader-elect=true
+        - --cloud-provider=${cloud_provider}
+        volumeMounts:
+        - name: secrets
+          mountPath: /etc/kubernetes/secrets
+          readOnly: true
+        - name: ssl-host
+          mountPath: /etc/ssl/certs
+          readOnly: true
+      volumes:
+      - name: secrets
+        secret:
+          secretName: kube-controller-manager
+      - name: ssl-host
+        hostPath:
+          path: /usr/share/ca-certificates
+      dnsPolicy: Default # Don't use cluster DNS.

--- a/bootkube/resources/manifests/kube-dns.yaml.tpl
+++ b/bootkube/resources/manifests/kube-dns.yaml.tpl
@@ -1,0 +1,172 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: ${kube_dns_service_ip}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+spec:
+  # replicas: not specified here:
+  # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+  # 2. Default is 1.
+  # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-dns
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+    spec:
+      containers:
+      - name: kubedns
+        image: gcr.io/google_containers/kubedns-amd64:1.9
+        resources:
+          # TODO: Set memory limits when we've profiled the container for large
+          # clusters, then set request = limit to keep this container in
+          # guaranteed class. Currently, this container falls into the
+          # "burstable" category so the kubelet doesn't backoff from restarting it.
+          limits:
+            memory: 170Mi
+          requests:
+            cpu: 100m
+            memory: 70Mi
+        livenessProbe:
+          httpGet:
+            path: /healthz-kubedns
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 8081
+            scheme: HTTP
+          # we poll on pod startup for the Kubernetes master service and
+          # only setup the /readiness HTTP server once that's available.
+          initialDelaySeconds: 3
+          timeoutSeconds: 5
+        args:
+        - --domain=cluster.local.
+        - --dns-port=10053
+        - --config-map=kube-dns
+        # This should be set to v=2 only after the new image (cut from 1.5) has
+        # been released, otherwise we will flood the logs.
+        - --v=0
+        env:
+        - name: PROMETHEUS_PORT
+          value: "10055"
+        ports:
+        - containerPort: 10053
+          name: dns-local
+          protocol: UDP
+        - containerPort: 10053
+          name: dns-tcp-local
+          protocol: TCP
+        - containerPort: 10055
+          name: metrics
+          protocol: TCP
+      - name: dnsmasq
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - --cache-size=1000
+        - --no-resolv
+        - --server=127.0.0.1#10053
+        - --log-facility=-
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 10Mi
+      - name: dnsmasq-metrics
+        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 10054
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        args:
+        - --v=2
+        - --logtostderr
+        ports:
+        - containerPort: 10054
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            memory: 10Mi
+      - name: healthz
+        image: gcr.io/google_containers/exechealthz-amd64:1.2
+        resources:
+          limits:
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            # Note that this container shouldn't really need 50Mi of memory. The
+            # limits are set higher than expected pending investigation on #29688.
+            # The extra memory was stolen from the kubedns container to keep the
+            # net memory requested by the pod constant.
+            memory: 50Mi
+        args:
+        - --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+      dnsPolicy: Default  # Don't use cluster DNS.

--- a/bootkube/resources/manifests/kube-flannel.yaml.tpl
+++ b/bootkube/resources/manifests/kube-flannel.yaml.tpl
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "type": "flannel",
+      "delegate": {
+        "isDefaultGateway": true
+      }
+    }
+  net-conf.json: |
+    {
+      "Network": "${cluster_cidr}",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      hostNetwork: true
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.7.0-amd64
+        command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr", "--iface=$(POD_IP)"]
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      - name: install-cni
+        image: busybox
+        command: [ "/bin/sh", "-c", "set -e -x; TMP=/etc/cni/net.d/.tmp-flannel-cfg; cp /etc/kube-flannel/cni-conf.json $TMP; mv $TMP /etc/cni/net.d/10-flannel.conf; while :; do sleep 3600; done" ]
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/kubernetes/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/bootkube/resources/manifests/kube-proxy.yaml.tpl
+++ b/bootkube/resources/manifests/kube-proxy.yaml.tpl
@@ -1,0 +1,45 @@
+apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: kube-proxy
+  namespace: kube-system
+  labels:
+    k8s-app: kube-proxy
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+    spec:
+      hostNetwork: true
+      containers:
+      - name: kube-proxy
+        image: ${hyperkube_image}
+        command:
+        - /hyperkube
+        - proxy
+        - --kubeconfig=/etc/kubernetes/kubeconfig
+        - --proxy-mode=iptables
+        - --hostname-override=$(NODE_NAME)
+        - --cluster-cidr=${cluster_cidr}
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ssl-certs-host
+          readOnly: true
+        - name: etc-kubernetes
+          mountPath: /etc/kubernetes
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /usr/share/ca-certificates
+        name: ssl-certs-host
+      - name: etc-kubernetes
+        hostPath:
+          path: /etc/kubernetes

--- a/bootkube/resources/manifests/kube-scheduler-disruption.yaml
+++ b/bootkube/resources/manifests/kube-scheduler-disruption.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-scheduler

--- a/bootkube/resources/manifests/kube-scheduler.yaml.tpl
+++ b/bootkube/resources/manifests/kube-scheduler.yaml.tpl
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-scheduler
+  namespace: kube-system
+  labels:
+    k8s-app: kube-scheduler
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-scheduler
+    spec:
+      nodeSelector:
+        master: "true"
+      containers:
+      - name: kube-scheduler
+        image: ${hyperkube_image}
+        command:
+        - ./hyperkube
+        - scheduler
+        - --leader-elect=true

--- a/bootkube/resources/manifests/kube-system-rbac-role-binding.yaml
+++ b/bootkube/resources/manifests/kube-system-rbac-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: system:default-sa
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/bootkube/resources/manifests/pod-checkpoint-installer.yaml.tpl
+++ b/bootkube/resources/manifests/pod-checkpoint-installer.yaml.tpl
@@ -1,0 +1,28 @@
+apiVersion: "extensions/v1beta1"
+kind: DaemonSet
+metadata:
+  name: checkpoint-installer
+  namespace: kube-system
+  labels:
+    k8s-app: pod-checkpoint-installer
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: pod-checkpoint-installer
+    spec:
+      nodeSelector:
+        master: "true"
+      hostNetwork: true
+      containers:
+      - name: checkpoint-installer
+        image: ${pod_checkpointer_image}
+        command:
+        - /checkpoint-installer.sh
+        volumeMounts:
+        - mountPath: /etc/kubernetes/manifests
+          name: etc-k8s-manifests
+      volumes:
+      - name: etc-k8s-manifests
+        hostPath:
+          path: /etc/kubernetes/manifests

--- a/bootkube/variables.tf
+++ b/bootkube/variables.tf
@@ -1,0 +1,92 @@
+# General configuration used by the module
+
+variable "host" {
+    description = "Host on which the assets will be generated and where bootkube will run"
+    type        = "string"
+}
+
+variable "user" {
+    description = "User that should be used to connect to the host"
+    type        = "string"
+    default     = "core"
+}
+
+variable "private_key" {
+    description = "Private key that should be used to connect to the host"
+    type        = "string"
+    default     = ""
+}
+
+variable "assets_path" {
+    description = "Absolute path in which the assets should be stored"
+    type        = "string"
+    default     = "/home/core/bootkube"
+}
+
+variable "bootkube_image" {
+    description = "Bootkube image to run"
+    type        = "string"
+    default     = "quay.io/coreos/bootkube:v0.3.9"
+}
+
+# Configuration used for the assets generation
+
+variable "hyperkube_image" {
+    description = "Hyperkube image to use for Kubernetes components"
+    type        = "string"
+    default     = "quay.io/coreos/hyperkube:v1.5.3_coreos.0"
+}
+
+variable "pod_checkpointer_image" {
+    description = "Checkpointer image to use"
+    type        = "string"
+    default     = "quay.io/coreos/pod-checkpointer:5b585a2d731173713fa6871c436f6c53fa17f754"
+}
+
+variable "kube_apiserver_url" {
+    description = "URL used to reach kube-apiserver"
+    type        = "string"
+    default     = "https://127.0.0.1:443"
+}
+
+variable "kube_apiserver_service_ip" {
+    description = "Service IP used to reach kube-apiserver"
+    type        = "string"
+    default     = "10.3.0.1"
+}
+
+variable "kube_dns_service_ip" {
+    description = "Service IP used to reach kube-dns"
+    type        = "string"
+    default     = "10.3.0.10"
+}
+
+variable "etcd_servers" {
+    description = "List of etcd servers to connect with (scheme://ip:port)"
+    type        = "list"
+    default     = ["http://127.0.0.1:2379"]
+}
+
+variable "cloud_provider" {
+    description = "The provider for cloud services (empty string for no provider)"
+    type        = "string"
+    default     = ""
+}
+
+variable "service_cidr" {
+    description = "A CIDR notation IP range from which to assign service cluster IPs"
+    type        = "string"
+    default     = "10.3.0.0/16"
+}
+
+variable "cluster_cidr" {
+    description = "A CIDR notation IP range from which to assign pod IPs"
+    type        = "string"
+    default     = "10.2.0.0/16"
+}
+
+# Output
+
+output "kubeconfig" {
+    value = "${data.template_file.kubeconfig.rendered}"
+}


### PR DESCRIPTION
**Disclaimer**: This is my first TerraForm commit ever. I'm looking for feedbacks on both architecture/design and TerraForm practices.

As discussed over the past weeks between the Tectonic and bootkube teams, we'd like to stop using `bootkube render` and generate our own assets, all the time. Eventually, bootkube will use these assets for the temporary components as well [[1]](https://github.com/kubernetes-incubator/bootkube/issues/168). This PR is an attempt at creating an independent TerraForm module for the assets generation and execution of bootkube as a systemd unit. 

The module takes the following inputs:
- host / user / private key / assets path: to connect to the host where the assets will be uploaded and bootkube executed
- bootkube_image / hyperkube_image / pod_checkpointer_image: in order to increase re-usability and testability as these are often changed
- etcd_servers / cloud provider / service CIDR / cluster CIDR / etc: to generate the self-hosted assets

And provides the kubelet kubeconfig as its output.

The module is as infrastructure independent as it can be and makes a few assumptions:
- an SSH connection can be established to the target node and that node/connection is secure enough to transfer the assets
- the target node has rkt (we could actually switch to docker)
- there is an etcd cluster available somewhere (configurable)
- a configured kubelet will come up somewhere during the execution of bootkube

/cc @alexsomesan @sym3tri @pbx0 