### PR TITLE
platform-aws-noasg: fix typo in resource name

### DIFF
--- a/platform-aws-noasg/etcd/dns.tf
+++ b/platform-aws-noasg/etcd/dns.tf
@@ -2,7 +2,7 @@ resource "aws_route53_record" "etcd_srv_discover" {
   name    = "_etcd-server._tcp"
   type    = "SRV"
   zone_id = "${var.dns_zone}"
-  records = ["${formatlist("0 0 2380 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
+  records = ["${formatlist("0 0 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
   ttl     = "300"
 }
 
@@ -10,11 +10,11 @@ resource "aws_route53_record" "etcd_srv_client" {
   name    = "_etcd-client._tcp"
   type    = "SRV"
   zone_id = "${var.dns_zone}"
-  records = ["${formatlist("0 0 2379 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
+  records = ["${formatlist("0 0 2379 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
   ttl     = "60"
 }
 
-resource "aws_route53_record" "etc_a_nodes" {
+resource "aws_route53_record" "etcd_a_nodes" {
   count   = "${var.node_count}"
   type    = "A"
   ttl     = "60"


### PR DESCRIPTION
etc_a to etcd_a