### PR TITLE
Makefile: remove legacy targets and introduce TerraForm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ assets*.zip
 build/**
 config.tfvars
 generated/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean
+include terraform.mk
 
 CLUSTER ?= demo
 ASSETS ?= assets-$(CLUSTER).zip
@@ -12,7 +12,6 @@ all: apply
 
 $(BUILD_DIR)/$(ASSETS):
 	@echo "Assets '$(ASSETS)' not found!\nPlace assets zip from installer in $(BUILD_DIR)\n"
-	exit 1
 
 $(BUILD_DIR)/config.tfvars: $(BUILD_DIR)/assets
 	$(TOP_DIR)/convert.sh tfvars $(PLATFORM) $(BUILD_DIR)/assets/cloud-formation.json > $(BUILD_DIR)/config.tfvars
@@ -33,21 +32,22 @@ apply: $(BUILD_DIR)/assets $(BUILD_DIR)/config.tfvars $(BUILD_DIR)/.terraform
 destroy: $(BUILD_DIR)/assets $(BUILD_DIR)/config.tfvars
 	cd $(BUILD_DIR) && terraform destroy --var-file=config.tfvars $(TOP_DIR)/modules/platforms/$(PLATFORM)
 
-# You need to have https://github.com/segmentio/terraform-docs installed
-Documentation/variables/%.md: **/*.tf
-	echo '# Terraform variables: $*' >$@
-	echo 'The Tectonic SDK variables used for: $*.' >>$@
-	terraform-docs markdown ./$* >>$@
+Documentation/%.md: *.tf
+	if ! type "terraform-docs" &> /dev/null; then
+		@echo "terraform-docs is required (https://github.com/segmentio/terraform-docs)"
+		exit 1
+	fi
 
-# You need to have https://github.com/segmentio/terraform-docs installed
-Documentation/variables/config.md: *.tf
-	echo '# Common Tectonic Terraform variables' >$@
-	echo 'All the common Tectonic SDK variables used for *all* platforms.' >>$@
+	echo '# Terraform variables' >$@
+	echo 'This document gives an overview of the variables used in the different platforms of the Tectonic SDK.' >>$@
 	terraform-docs markdown . >>$@
 
 docs: Documentation/variables/config.md Documentation/variables/platform-aws.md Documentation/variables/platform-azure.md
 
 clean:
 	cd $(BUILD_DIR) && \
-	rm -rf .terraform assets \
+	rm -rf .terraform assets && \
 	rm -f config.tfvars terraform.tfstate terraform.tfstate.backup
+	make terraform-clean
+
+.PHONY: make clean terraform terraform-dev

--- a/terraform.mk
+++ b/terraform.mk
@@ -1,0 +1,66 @@
+TERRAFORM_REPOSITORY=https://github.com/coreos/terraform.git
+TERRAFORM_RELEASE_URL=https://api.github.com/repos/coreos/terraform/releases/latest
+TERRAFORM_BRANCH=v0.8.8-coreos
+TERRAFORM_BUILD_DIR=$(TOP_DIR)/build/terraform
+TERRAFORM_BINS_DIR=$(TOP_DIR)/bin/terraform
+TERRAFORM_GO_IMAGE=golang:1.8
+TERRAFORM_GO_OS=linux darwin windows
+TERRAFORM_GOARCH=386 amd64
+
+ifeq ($(OS), Windows_NT)
+    GOOS = windows
+    ifeq ($(PROCESSOR_ARCHITECTURE), AMD64)
+        GOARCH = amd64
+    else ifeq ($(PROCESSOR_ARCHITECTURE), x86)
+        GOARCH = 386
+    endif
+else
+    OS := $(shell uname -s)
+    ARCH := $(shell uname -m)
+    ifeq ($(OS), Linux)
+        GOOS = linux
+    else ifeq ($(OS), Darwin)
+        GOOS = darwin
+    endif
+    ifeq ($(ARCH), x86_64)
+        GOARCH = amd64
+    else ifneq ($(filter %86, $(ARCH)),)
+        GOARCH = 386
+    else ifneq ($(findstring arm, $(ARCH)),)
+        GOARCH = arm
+    endif
+endif
+
+$(TERRAFORM_BINS_DIR):
+	mkdir -p $(TERRAFORM_BINS_DIR)
+
+$(TERRAFORM_BUILD_DIR):
+	git clone -b $(TERRAFORM_BRANCH) $(TERRAFORM_REPOSITORY) $(TERRAFORM_BUILD_DIR)
+
+terraform-dev:
+	make terraform TERRAFORM_GO_OS=$(GOOS) TERRAFORM_GOARCH=$(GOARCH)
+
+terraform: $(TERRAFORM_BUILD_DIR) $(TERRAFORM_BINS_DIR)
+	docker run --rm -v $(TERRAFORM_BUILD_DIR):/go/src/github.com/hashicorp/terraform \
+		-w /go/src/github.com/hashicorp/terraform \
+		-e XC_OS="$(TERRAFORM_GO_OS)" -e XC_ARCH="$(TERRAFORM_GOARCH)" \
+		$(TERRAFORM_GO_IMAGE) make bin
+
+	cp -r $(TERRAFORM_BUILD_DIR)/pkg/* $(TERRAFORM_BINS_DIR)
+	cp $(TERRAFORM_BUILD_DIR)/pkg/$(GOOS)_$(GOARCH)/terraform $(TERRAFORM_BINS_DIR)
+
+	cd $(TERRAFORM_BINS_DIR) && zip -r terraform.zip */
+
+	echo -e "\n--> TerraForm built successfully for [$(TERRAFORM_GO_OS)] / [$(TERRAFORM_GOARCH)] in $(TERRAFORM_BINS_DIR)"
+	echo "--> To start using TerraForm for your platform, modify your PATH: export PATH=$$PATH:$(TERRAFORM_BINS_DIR))"
+
+terraform-download: $(TERRAFORM_BINS_DIR)
+	curl -L `curl -s $(TERRAFORM_RELEASE_URL) | grep browser_download_url | head -n 1 | cut -d '"' -f 4` > $(TERRAFORM_BINS_DIR)/terraform.zip
+
+	cd $(TERRAFORM_BINS_DIR) && unzip -f terraform.zip
+	cp $(TERRAFORM_BUILD_DIR)/pkg/$(GOOS)_$(GOARCH)/terraform $(TERRAFORM_BINS_DIR)
+
+	echo "--> To start using TerraForm for your platform, modify your PATH: export PATH=$$PATH:$(TERRAFORM_BINS_DIR))"
+
+terraform-clean:
+	rm -rf $(TERRAFORM_BUILD_DIR) $(TERRAFORM_BINS_DIR)


### PR DESCRIPTION
- **make terraform-download**: downloads the binaries from the latest TerraForm release on GitHub
- **make terraform-dev**: clones the latest TerraForm sources in build/terraform and builds it for your platform in a Docker environment
- **make terraform**: clones the latest TerraForm sources in build/terraform, builds it for all platforms and makes a release archive
- **make terraform-clean**: removes the TerraForm sources and binaries

 ```
bin/terraform/darwin_amd64/terraform
bin/terraform/linux_386/terraform
bin/terraform/linux_amd64/terraform
bin/terraform/windows_386/terraform.exe
bin/terraform/windows_amd64/terraform.exe
bin/terraform/terraform.zip
bin/terraform/terraform
```

The binary for your platform is always available at `bin/terraform/terraform`. Make suggests the command to modify your path so you can use it.

Pulling requires nothing but curl.
Building requires nothing but git and docker.