### PR TITLE
modules/tectonic: use base_address instead of domain

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -36,10 +36,10 @@ resource "template_folder" "tectonic" {
     admin_email = "${var.admin_email}"
     admin_password_hash = "${var.admin_password_hash}"
 
-    console_base_address = "https://${var.domain}"
+    console_base_address = "https://${var.base_address}"
     console_client_id = "${var.console_client_id}"
     console_secret = "${random_id.console_secret.b64}"
-    console_callback = "https://${var.domain}/auth/callback"
+    console_callback = "https://${var.base_address}/auth/callback"
 
     ingress_kind = "${var.ingress_kind}"
     ingress_tls_cert = "${base64encode(tls_locally_signed_cert.ingress.cert_pem)}"
@@ -54,7 +54,7 @@ resource "template_folder" "tectonic" {
     kubectl_secret = "${random_id.kubectl_secret.b64}"
 
     kube_apiserver_url = "${var.kube_apiserver_url}"
-    oidc_issuer_url = "https://${var.domain}/identity"
+    oidc_issuer_url = "https://${var.base_address}/identity"
 
     cluster_id = "${uuid()}"
     platform = "${var.platform}"

--- a/modules/tectonic/crypto.tf
+++ b/modules/tectonic/crypto.tf
@@ -24,7 +24,7 @@ resource "tls_cert_request" "ingress" {
   private_key_pem = "${tls_private_key.ingress.private_key_pem}"
 
   subject {
-    common_name = "${var.domain}"
+    common_name = "${element(split(":", var.base_address), 0)}"
   }
 }
 

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -48,8 +48,8 @@ variable "ca_key" {
     type        = "string"
 }
 
-variable "domain" {
-    description = "Base address used to access the Tectonic Console, without protocol nor trailing forward slash"
+variable "base_address" {
+    description = "Base address used to access the Tectonic Console, without protocol nor trailing forward slash (may contain a port)"
     type        = "string"
 }
 

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -32,7 +32,7 @@ module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "aws"
 
-  domain             = "${module.dns.ingress_internal_fqdn}"
+  base_address       = "${module.dns.ingress_internal_fqdn}"
   kube_apiserver_url = "https://${module.dns.api_internal_fqdn}:443"
 
   # Platform-independent variables wiring, do not modify.

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -32,7 +32,7 @@ module "tectonic" {
   source   = "../../../modules/tectonic"
   platform = "aws"
 
-  domain             = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}:32000"
+  base_address       = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}:32000"
   kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
 
   # Platform-independent variables wiring, do not modify.

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -32,7 +32,7 @@ module "tectonic" {
   source   = "../../../modules/tectonic"
   platform = "aws"
 
-  domain             = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}:32000"
+  base_address       = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}:32000"
   kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
 
   # Platform-independent variables wiring, do not modify.


### PR DESCRIPTION
This solves an issue where the port must be included for a few endpoints
when using NodePort without LB, therefore breaking the CN of the Ingress
certificate.