### PR TITLE
neutron: add ports and set up allowed_address_pairs

### DIFF
--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -118,4 +118,6 @@ module "network" {
   worker_count        = "${var.tectonic_worker_count}"
   external_gateway_id = "${var.tectonic_openstack_external_gateway_id}"
   cluster_name        = "${var.tectonic_cluster_name}"
+  service_cidr        = "${var.tectonic_service_cidr}"
+  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }

--- a/platforms/openstack/neutron/network/variables.tf
+++ b/platforms/openstack/neutron/network/variables.tf
@@ -15,12 +15,43 @@ variable "external_gateway_id" {
   type = "string"
 }
 
+variable "service_cidr" {
+  type = "string"
+}
+
+variable "cluster_cidr" {
+  type = "string"
+}
+
+variable "floatingip_pool" {
+  type    = "string"
+  default = "public"
+}
+
+variable "subnet_cidr" {
+  type    = "string"
+  default = "192.168.1.0/24"
+}
+
+variable "dns_nameservers" {
+  type    = "list"
+  default = ["8.8.8.8", "8.8.4.4"]
+}
+
+output "master_ports" {
+  value = ["${openstack_networking_port_v2.master.*.id}"]
+}
+
 output "master_floating_ips" {
-  value = ["${openstack_compute_floatingip_v2.master.*.address}"]
+  value = ["${openstack_networking_floatingip_v2.master.*.address}"]
+}
+
+output "worker_ports" {
+  value = ["${openstack_networking_port_v2.worker.*.id}"]
 }
 
 output "worker_floating_ips" {
-  value = ["${openstack_compute_floatingip_v2.worker.*.address}"]
+  value = ["${openstack_networking_floatingip_v2.worker.*.address}"]
 }
 
 output "id" {


### PR DESCRIPTION
This fixes the non-functioning flannel network on OpenStack.

see https://docs.openstack.org/developer/dragonflow/specs/allowed_address_pairs.html, https://docs.openstack.org/developer/dragonflow/specs/mac_spoofing.html

/cc @alekssaul