### PR TITLE
tectonic: update Nginx Ingress image

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -19,7 +19,7 @@ variable "tectonic_container_images" {
     stats_emitter             = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender            = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     error_server              = "quay.io/coreos/tectonic-error-server:1.0"
-    ingress_controller        = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.2"
+    ingress_controller        = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3"
     kubedns                   = "gcr.io/google_containers/kubedns-amd64:1.9"
     kubednsmasq               = "gcr.io/google_containers/kube-dnsmasq-amd64:1.4"
     dnsmasq_metrics           = "gcr.io/google_containers/dnsmasq-metrics-amd64:1.0"


### PR DESCRIPTION
actually, there is a fresher version that drops an issue fetching *api.Node.