### PR TITLE
Makefile: Removed extra "-" before "-var-file"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ $(BUILD_DIR)/.terraform:
 	cd $(BUILD_DIR) && terraform get $(TOP_DIR)/platforms/$(PLATFORM)
 
 plan: $(BUILD_DIR)/config.tfvars $(BUILD_DIR)/.terraform
-	cd $(BUILD_DIR) && terraform plan --var-file=config.tfvars $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && terraform plan -var-file=config.tfvars $(TOP_DIR)/platforms/$(PLATFORM)
 
 apply: $(BUILD_DIR)/config.tfvars $(BUILD_DIR)/.terraform
-	cd $(BUILD_DIR) && terraform apply --var-file=config.tfvars $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && terraform apply -var-file=config.tfvars $(TOP_DIR)/platforms/$(PLATFORM)
 
 destroy: $(BUILD_DIR)/config.tfvars
-	cd $(BUILD_DIR) && terraform destroy --var-file=config.tfvars $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && terraform destroy -var-file=config.tfvars $(TOP_DIR)/platforms/$(PLATFORM)
 
 Documentation/%.md: *.tf
 	if ! type "terraform-docs" &> /dev/null; then


### PR DESCRIPTION
Makefile: Removed extra "-" before "-var-file"

Terraform doesn't use the standard "--<option>" option convention, rather, it uses "-<option>". "--var-file" breaks the installation.