### PR TITLE
AWS: Add support for BYO etcd cluster

### DIFF
--- a/modules/aws/etcd/dns.tf
+++ b/modules/aws/etcd/dns.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_record" "etcd_srv_discover" {
+  count   = "${length(var.external_endpoints) == 0 ? 1 : 0}"
   name    = "_etcd-server._tcp"
   type    = "SRV"
   zone_id = "${var.dns_zone}"
@@ -7,6 +8,7 @@ resource "aws_route53_record" "etcd_srv_discover" {
 }
 
 resource "aws_route53_record" "etcd_srv_client" {
+  count   = "${length(var.external_endpoints) == 0 ? 1 : 0}"
   name    = "_etcd-client._tcp"
   type    = "SRV"
   zone_id = "${var.dns_zone}"
@@ -15,7 +17,7 @@ resource "aws_route53_record" "etcd_srv_client" {
 }
 
 resource "aws_route53_record" "etc_a_nodes" {
-  count   = "${var.node_count}"
+  count   = "${length(var.external_endpoints) == 0 ? var.node_count : 0}"
   type    = "A"
   ttl     = "60"
   zone_id = "${var.dns_zone}"

--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -1,5 +1,5 @@
 resource "ignition_config" "etcd" {
-  count = "${var.node_count}"
+  count = "${length(var.external_endpoints) == 0 ? var.node_count : 0}"
 
   systemd = [
     "${ignition_systemd_unit.locksmithd.id}",
@@ -14,7 +14,7 @@ resource "ignition_config" "etcd" {
 }
 
 resource "ignition_file" "node_hostname" {
-  count      = "${var.node_count}"
+  count      = "${length(var.external_endpoints) == 0 ? var.node_count : 0}"
   path       = "/etc/hostname"
   mode       = 0644
   filesystem = "root"
@@ -25,6 +25,8 @@ resource "ignition_file" "node_hostname" {
 }
 
 resource "ignition_systemd_unit" "locksmithd" {
+  count = "${length(var.external_endpoints) == 0 ? 1 : 0}"
+
   name   = "locksmithd.service"
   enable = true
 
@@ -37,7 +39,8 @@ resource "ignition_systemd_unit" "locksmithd" {
 }
 
 resource "ignition_systemd_unit" "etcd3" {
-  count  = "${var.node_count}"
+  count = "${length(var.external_endpoints) == 0 ? var.node_count : 0}"
+
   name   = "etcd-member.service"
   enable = true
 
@@ -62,11 +65,15 @@ EOF
 }
 
 resource "ignition_systemd_unit" "etcd2" {
+  count = "${length(var.external_endpoints) == 0 ? 1 : 0}"
+
   name   = "etcd2.service"
   enable = false
 }
 
 resource "ignition_systemd_unit" "etcd" {
+  count = "${length(var.external_endpoints) == 0 ? 1 : 0}"
+
   name   = "etcd.service"
   enable = false
 }

--- a/modules/aws/etcd/network.tf
+++ b/modules/aws/etcd/network.tf
@@ -1,5 +1,6 @@
 resource "aws_security_group" "etcd_sec_group" {
   vpc_id = "${var.vpc_id}"
+  count  = "${length(var.external_endpoints) == 0 ? 1 : 0}"
 
   tags {
     Name              = "${var.tectonic_cluster_name}_etcd_sg"

--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -23,7 +23,7 @@ data "aws_ami" "coreos_ami" {
 }
 
 resource "aws_instance" "etcd_node" {
-  count                  = "${var.node_count}"
+  count                  = "${length(var.external_endpoints) == 0 ? var.node_count : 0}"
   ami                    = "${data.aws_ami.coreos_ami.image_id}"
   instance_type          = "t2.medium"
   subnet_id              = "${var.etcd_subnets[count.index]}"

--- a/modules/aws/etcd/outputs.tf
+++ b/modules/aws/etcd/outputs.tf
@@ -1,3 +1,3 @@
 output "endpoints" {
-  value = ["${aws_route53_record.etc_a_nodes.*.fqdn}"]
+  value = ["${length(var.external_endpoints) == 0 ? aws_route53_record.etc_a_nodes.*.fqdn : var.external_endpoints}"]
 }


### PR DESCRIPTION
This had somehow gotten lost in the refactoring.
It implements the ability to provide endpoints to an external etcd cluster and skips creating one via terraform.

Needs some testing though.
