### PR TITLE
Tectonic systemd unit: be nice and don't look your dead

### DIFF
--- a/modules/aws/master-asg/ignition.tf
+++ b/modules/aws/master-asg/ignition.tf
@@ -107,6 +107,7 @@ resource "ignition_systemd_unit" "tectonic" {
 Description=Bootstrap a Tectonic cluster
 [Service]
 Type=oneshot
+RemainAfterExit=true
 WorkingDirectory=/opt/tectonic
 ExecStart=/usr/bin/bash /opt/tectonic/bootkube.sh
 ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic

--- a/modules/aws/worker-asg/ignition.tf
+++ b/modules/aws/worker-asg/ignition.tf
@@ -96,18 +96,3 @@ resource "ignition_file" "max-user-watches" {
     content = "fs.inotify.max_user_watches=16184"
   }
 }
-
-resource "ignition_systemd_unit" "tectonic" {
-  name   = "tectonic.service"
-  enable = true
-
-  content = <<EOF
-[Unit]
-Description=Bootstrap a Tectonic cluster
-[Service]
-Type=oneshot
-WorkingDirectory=/opt/tectonic
-ExecStart=/usr/bin/bash /opt/tectonic/bootkube.sh
-ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic
-EOF
-}

--- a/modules/azure/master/ignition-master.tf
+++ b/modules/azure/master/ignition-master.tf
@@ -120,6 +120,7 @@ resource "ignition_systemd_unit" "tectonic" {
 Description=Bootstrap a Tectonic cluster
 [Service]
 Type=oneshot
+RemainAfterExit=true
 WorkingDirectory=/opt/tectonic
 ExecStart=/usr/bin/bash /opt/tectonic/bootkube.sh
 ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic

--- a/modules/azure/worker/ignition-worker.tf
+++ b/modules/azure/worker/ignition-worker.tf
@@ -102,21 +102,6 @@ resource "ignition_file" "max-user-watches" {
   }
 }
 
-resource "ignition_systemd_unit" "tectonic" {
-  name   = "tectonic.service"
-  enable = true
-
-  content = <<EOF
-[Unit]
-Description=Bootstrap a Tectonic cluster
-[Service]
-Type=oneshot
-WorkingDirectory=/opt/tectonic
-ExecStart=/usr/bin/bash /opt/tectonic/bootkube.sh
-ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic
-EOF
-}
-
 resource "ignition_user" "core" {
   name = "core"
 

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -192,6 +192,7 @@ resource "ignition_systemd_unit" "tectonic" {
 Description=Bootstrap a Tectonic cluster
 [Service]
 Type=oneshot
+RemainAfterExit=true
 WorkingDirectory=/opt/tectonic
 ExecStart=/usr/bin/bash /opt/tectonic/bootkube.sh
 ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic


### PR DESCRIPTION
Adding the `RemainAfterExit=true` is necessary so that the tectonic unit doesn't block systemd from declaring the multi-user target as "running". Otherwise the system looks like it hasn't booted cleanly and something is still in progress.

@s-urbaniak @Quentin-M 