### PR TITLE
openstack: use coreos-metadata to fetch addresses

### DIFF
--- a/modules/openstack/etcd/ignition.tf
+++ b/modules/openstack/etcd/ignition.tf
@@ -15,17 +15,21 @@ resource "ignition_systemd_unit" "etcd_member" {
     name = "40-etcd-cluster.conf"
 
     content = <<EOF
+[Unit]
+Requires=coreos-metadata.service
+After=coreos-metadata.service
+
 [Service]
+EnvironmentFile=/run/metadata/coreos
 Environment="ETCD_IMAGE_TAG=v3.1.0"
-ExecStartPre=/usr/bin/sh -c '/usr/bin/systemctl set-environment COREOS_PRIVATE_IPV4=$$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)'
 ExecStart=
 ExecStart=/usr/lib/coreos/etcd-wrapper \
 --name=etcd \
---advertise-client-urls=http://$${COREOS_PRIVATE_IPV4}:2379 \
---initial-advertise-peer-urls=http://$${COREOS_PRIVATE_IPV4}:2380 \
+--advertise-client-urls=http://$${COREOS_OPENSTACK_IPV4_LOCAL}:2379 \
+--initial-advertise-peer-urls=http://$${COREOS_OPENSTACK_IPV4_LOCAL}:2380 \
 --listen-client-urls=http://0.0.0.0:2379 \
 --listen-peer-urls=http://0.0.0.0:2380 \
---initial-cluster=etcd=http://$${COREOS_PRIVATE_IPV4}:2380
+--initial-cluster=etcd=http://$${COREOS_OPENSTACK_IPV4_LOCAL}:2380
 EOF
   }
 }


### PR DESCRIPTION
coreos-metadata is a bit more robust toward network failures and will
fetch public addresses as well (making it easier to customize). This
probably shouldn't be used until coreos-metadata v0.7.0 (the first
version to support OpenStack) is more widely deployed.