### PR TITLE
Make node role labels consistent with other probjects

### DIFF
--- a/Documentation/generic-platform.md
+++ b/Documentation/generic-platform.md
@@ -33,8 +33,8 @@ Master nodes run most, if not all, control plane components including the API se
   - MUST have any necessary API access for k8s cloud plugin functionality (i.e. AWS node IAM Role) 
 
 - **Cloud-init/Ignition:**
-  - MUST run the kubelet with label node-role.kubernetes.io/master=true 
-  - MAY run the kubelet with label with label node-role.kubernetes.io/node=true 
+  - MUST run the kubelet with label node-role.kubernetes.io/master 
+  - MAY run the kubelet with label with label node-role.kubernetes.io/node 
 
 
 ### Infra Nodes (Optional) or Load Balancers


### PR DESCRIPTION
To be consistent with other tools in community:

https://github.com/kubernetes/kubeadm/issues/150#issuecomment-280986966
https://github.com/kubernetes/kubernetes/pull/41835

Original discussion: https://github.com/kubernetes/kubernetes/pull/39112

Originally a value of `true` was proposed, but looks like it might be extraneous and other tools (kubeadm, for example) are not populating the value.

/cc @philips 



