### PR TITLE
config.tf/convert.sh/Documentation: nuke unused tectonic_dns_name var

### DIFF
--- a/Documentation/platforms/azure/README.md
+++ b/Documentation/platforms/azure/README.md
@@ -86,8 +86,6 @@ tectonic_base_domain = "azure.example.com"
 
 tectonic_cluster_name = "mycluster"
 
-tectonic_dns_name = "mycluster"
-
 tectonic_pull_secret_path = "/Users/coreos/Downloads/config.json"
 
 tectonic_license_path = "/Users/coreos/Downloads/tectonic-license.txt"

--- a/config.tf
+++ b/config.tf
@@ -172,7 +172,3 @@ variable "tectonic_ca_key_alg" {
   description = "Algorithm used to generate tectonic_ca_key. Optional if tectonic_ca_cert is left blank."
   default     = "RSA"
 }
-
-variable "tectonic_dns_name" {
-  type = "string"
-}

--- a/convert.sh
+++ b/convert.sh
@@ -51,7 +51,6 @@ function tfvars {
             local tectonic_base_domain=$(echo "${tectonic_domain}" | cut -d '.' -f 2-)
             local tectonic_kube_version=$(tectonic_kube_version "${cloud_formation}")
             local tectonic_aws_ssh_key=$(jq -r .Resources.LaunchConfigurationController.Properties.KeyName "${cloud_formation}")
-            local tectonic_dns_name=$(jq -r .Resources.TectonicDomain.Properties.Name "${cloud_formation}" | cut -d '.' -f 1)
             cat <<EOF
 tectonic_aws_az_count = ${tectonic_aws_az_count}
 tectonic_worker_count = ${tectonic_worker_count}
@@ -75,7 +74,6 @@ tectonic_license_path = ""
 tectonic_pull_secret_path = ""
 tectonic_aws_ssh_key = "${tectonic_aws_ssh_key}"
 tectonic_cl_channel = "stable"
-tectonic_dns_name = "${tectonic_dns_name}"
 EOF
             ;;
         azure)


### PR DESCRIPTION
This variable was introduced by mistake early on when comparing the
existing installer and that one: there is a distinction between cluster
name and DNS name on the existing one due to constraint with the
CloudFormation stack naming (policies). However, this does not apply
to this installer specifically as CloudFormation is not used.
Additionally, the cluster name is used everywhere to generate the DNS
records.