### PR TITLE
config.tf/Documentation: tectonic_etcd_servers expects hostnames/IPs

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -16,7 +16,7 @@ All the common Tectonic SDK variables used for *all* platforms.
 | tectonic_cluster_name | The name of the cluster. This will be prepended to `tectonic_base_domain` resulting in the URL to the Tectonic console. | - | yes |
 | tectonic_container_images | Container images to use | `<map>` | no |
 | tectonic_etcd_count | The number of etcd nodes to be created. | `1` | no |
-| tectonic_etcd_servers | List of extenral etcd v3 servers to connect with (scheme://ip:port). Optionally use if providing external etcd. | - | yes |
+| tectonic_etcd_servers | List of external etcd v3 servers to connect with (hostnames/IPs only). Optionally used if using an external etcd cluster. | - | yes |
 | tectonic_ingress_type | Type of Ingress mapping to use (e.g. HostPort, NodePort) | `HostPort` | no |
 | tectonic_kube_apiserver_service_ip | Service IP used to reach kube-apiserver inside the cluster | `10.3.0.1` | no |
 | tectonic_kube_apiserver_url | URL used to reach kube-apiserver | `https://10.1.1.1:443` | no |

--- a/config.tf
+++ b/config.tf
@@ -94,7 +94,7 @@ variable "tectonic_etcd_count" {
 }
 
 variable "tectonic_etcd_servers" {
-  description = "List of external etcd v3 servers to connect with (scheme://ip:port). Optionally use if providing external etcd."
+  description = "List of external etcd v3 servers to connect with (hostnames/IPs only). Optionally used if using an external etcd cluster."
   type        = "list"
   default     = [""]
 }


### PR DESCRIPTION
The only platform that uses `tectonic_etcd_servers` is AWS, more
specifically the `platforms/aws/etcd` module, which either returns
the list of FQDNs for the provisioned etcd nodes, or that list.
For the output to be consistent, we must return the hostnames/IPs
only. Users of that output expects to format that list to add the
port / scheme as necessary, which is more flexible.