### PR TITLE
*: use paths to specify tectonic_ca_key/tectonic_ca_cert

### DIFF
--- a/Documentation/platforms/azure/README.md
+++ b/Documentation/platforms/azure/README.md
@@ -98,9 +98,9 @@ tectonic_admin_email = "first.last@example.com"
 
 tectonic_admin_password_hash = "<redacted - generate with bcrypt tool>"
 
-tectonic_ca_cert = "" # path on disk, keep empty to generate one
+tectonic_ca_cert_path = "" # path on disk, keep empty to generate one
 
-tectonic_ca_key = "" # path on disk, keep empty to generate one
+tectonic_ca_key_path = "" # path on disk, keep empty to generate one
 
 tectonic_azure_ssh_key = "/Users/coreos/.ssh/id_rsa.pub"
 

--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -8,9 +8,9 @@ All the common Tectonic SDK variables used for *all* platforms.
 | tectonic_admin_email | e-mail address used to login to Tectonic | - | yes |
 | tectonic_admin_password_hash | bcrypt hash of admin password to use with Tectonic Console | - | yes |
 | tectonic_base_domain | Base address used to access the Tectonic Console, without protocol nor trailing forward slash | - | yes |
-| tectonic_ca_cert | PEM-encoded CA certificate, used to generate Tectonic Console's server certificate. Optional, if left blank, a CA certificate will be automatically generated. | - | yes |
-| tectonic_ca_key | PEM-encoded CA key, used to generate Tectonic Console's server certificate. Optional if tectonic_ca_cert is left blank | - | yes |
-| tectonic_ca_key_alg | Algorithm used to generate tectonic_ca_key. Optional if tectonic_ca_cert is left blank. | `RSA` | no |
+| tectonic_ca_cert_path | Path to a PEM-encoded CA certificate, used to generate Tectonic Console's server certificate. Optional, if left blank, a CA certificate will be automatically generated. | - | yes |
+| tectonic_ca_key_path | Path to a PEM-encoded CA key, used to generate Tectonic Console's server certificate. Optional if tectonic_ca_cert_path is left blank. | - | yes |
+| tectonic_ca_key_alg | Algorithm used to generate the key present in tectonic_ca_key_path. Optional if tectonic_ca_cert_path is left blank. | `RSA` | no |
 | tectonic_cl_channel |  | `stable` | no |
 | tectonic_cluster_cidr | A CIDR notation IP range from which to assign pod IPs | `10.2.0.0/16` | no |
 | tectonic_cluster_name | The name of the cluster. This will be prepended to `tectonic_base_domain` resulting in the URL to the Tectonic console. | - | yes |

--- a/config.tf
+++ b/config.tf
@@ -155,21 +155,21 @@ variable "tectonic_ingress_type" {
   default     = "HostPort"
 }
 
-variable "tectonic_ca_cert" {
+variable "tectonic_ca_cert_path" {
   type        = "string"
-  description = "PEM-encoded CA certificate, used to generate Tectonic Console's server certificate. Optional, if left blank, a CA certificate will be automatically generated."
+  description = "Path to a PEM-encoded CA certificate, used to generate Tectonic Console's server certificate. Optional, if left blank, a CA certificate will be automatically generated."
   default = ""
 }
 
-variable "tectonic_ca_key" {
+variable "tectonic_ca_key_path" {
   type        = "string"
-  description = "PEM-encoded CA key, used to generate Tectonic Console's server certificate. Optional if tectonic_ca_cert is left blank"
+  description = "Path to a PEM-encoded CA key, used to generate Tectonic Console's server certificate. Optional if tectonic_ca_cert_path is left blank."
   default = ""
 }
 
 variable "tectonic_ca_key_alg" {
   type        = "string"
-  description = "Algorithm used to generate tectonic_ca_key. Optional if tectonic_ca_cert is left blank."
+  description = "Algorithm used to generate the key present in tectonic_ca_key_path. Optional if tectonic_ca_cert_path is left blank."
   default     = "RSA"
 }
 

--- a/convert.sh
+++ b/convert.sh
@@ -68,8 +68,8 @@ tectonic_assets_dir = "$(dirname ${2})"
 
 tectonic_admin_email = ""
 tectonic_admin_password_hash = ""
-tectonic_ca_cert = ""
-tectonic_ca_key = ""
+tectonic_ca_cert_path = ""
+tectonic_ca_key_path = ""
 tectonic_etcd_servers = [ "" ]
 tectonic_license_path = ""
 tectonic_pull_secret_path = ""

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -8,8 +8,8 @@ module "bootkube" {
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
 
-  ca_cert    = "${var.tectonic_ca_cert}"
-  ca_key     = "${var.tectonic_ca_key}"
+  ca_cert    = "${length(var.tectonic_ca_cert_path) > 0 ? file(var.tectonic_ca_cert_path) : ""}"
+  ca_key     = "${length(var.tectonic_ca_key_path) > 0 ? file(var.tectonic_ca_key_path) : ""}"
   ca_key_alg = "${var.tectonic_ca_key_alg}"
 
   service_cidr = "${var.tectonic_service_cidr}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -8,8 +8,8 @@ module "bootkube" {
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
 
-  ca_cert    = "${var.tectonic_ca_cert}"
-  ca_key     = "${var.tectonic_ca_key}"
+  ca_cert    = "${length(var.tectonic_ca_cert_path) > 0 ? file(var.tectonic_ca_cert_path) : ""}"
+  ca_key     = "${length(var.tectonic_ca_key_path) > 0 ? file(var.tectonic_ca_key_path) : ""}"
   ca_key_alg = "${var.tectonic_ca_key_alg}"
 
   service_cidr = "${var.tectonic_service_cidr}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -8,8 +8,8 @@ module "bootkube" {
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
 
-  ca_cert    = "${var.tectonic_ca_cert}"
-  ca_key     = "${var.tectonic_ca_key}"
+  ca_cert    = "${length(var.tectonic_ca_cert_path) > 0 ? file(var.tectonic_ca_cert_path) : ""}"
+  ca_key     = "${length(var.tectonic_ca_key_path) > 0 ? file(var.tectonic_ca_key_path) : ""}"
   ca_key_alg = "${var.tectonic_ca_key_alg}"
 
   service_cidr = "${var.tectonic_service_cidr}"

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -8,8 +8,8 @@ module "bootkube" {
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
 
-  ca_cert    = "${var.tectonic_ca_cert}"
-  ca_key     = "${var.tectonic_ca_key}"
+  ca_cert    = "${length(var.tectonic_ca_cert_path) > 0 ? file(var.tectonic_ca_cert_path) : ""}"
+  ca_key     = "${length(var.tectonic_ca_key_path) > 0 ? file(var.tectonic_ca_key_path) : ""}"
   ca_key_alg = "${var.tectonic_ca_key_alg}"
 
   service_cidr = "${var.tectonic_service_cidr}"


### PR DESCRIPTION
Because PEM certificates/keys are multi-lines and multi-lines variables
are not convenient at all to define.