### PR TITLE
Fixes for BYO VPC

### DIFF
--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -1,5 +1,5 @@
 output "vpc_id" {
-  value = "${length(var.external_vpc_id) > 0 ? var.external_vpc_id : aws_vpc.new_vpc.id}"
+  value = "${length(var.external_vpc_id) > 0 ? var.external_vpc_id : join(" ", aws_vpc.new_vpc.*.id)}"
 }
 
 output "cluster_default_sg" {

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -15,9 +15,9 @@ variable "external_vpc_id" {
 }
 
 variable "external_master_subnets" {
-  type    = "list"
+  type = "list"
 }
 
 variable "external_worker_subnets" {
-  type    = "list"
+  type = "list"
 }

--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -14,6 +14,7 @@ resource "aws_route_table" "default" {
 }
 
 resource "aws_main_route_table_association" "main_vpc_routes" {
+  count          = "${var.external_vpc_id == "" ? 1 : 0}"
   vpc_id         = "${data.aws_vpc.cluster_vpc.id}"
   route_table_id = "${aws_route_table.default.id}"
 }

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -1,13 +1,8 @@
 data "aws_availability_zones" "azs" {}
 
 resource "aws_vpc" "new_vpc" {
-  # count                = "${length(var.external_vpc_id) > 0 ? 0 : 1}"
-  #
-  # We can't yet use the count gate here because of terraform issues:
-  # https://github.com/hashicorp/hil/issues/50
-  # https://github.com/hashicorp/terraform/issues/11566
-  # This should be re-enabled when above issues are fixed.
-  #
+  count = "${var.external_vpc_id == "" ? 0 : 1}"
+
   cidr_block = "${var.cidr_block}"
 
   enable_dns_hostnames = true
@@ -20,5 +15,5 @@ resource "aws_vpc" "new_vpc" {
 }
 
 data "aws_vpc" "cluster_vpc" {
-  id = "${var.external_vpc_id == "" ? aws_vpc.new_vpc.id : var.external_vpc_id }"
+  id = "${var.external_vpc_id == "" ? join(" ", aws_vpc.new_vpc.*.id) : var.external_vpc_id }"
 }

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -1,14 +1,21 @@
 data "aws_availability_zones" "azs" {}
 
 resource "aws_vpc" "new_vpc" {
-  count                = "${length(var.external_vpc_id) > 0 ? 0 : 1}"
-  cidr_block           = "${var.cidr_block}"
+  # count                = "${length(var.external_vpc_id) > 0 ? 0 : 1}"
+  #
+  # We can't yet use the count gate here because of terraform issues:
+  # https://github.com/hashicorp/hil/issues/50
+  # https://github.com/hashicorp/terraform/issues/11566
+  # This should be re-enabled when above issues are fixed.
+  #
+  cidr_block = "${var.cidr_block}"
+
   enable_dns_hostnames = true
   enable_dns_support   = true
 
   tags {
-    Name              = "${var.cluster_name}"
-    KubernetesCluster = "${var.cluster_name}"
+    Name              = "${var.external_vpc_id == "" ? var.cluster_name : "${var.cluster_name}-side-effect"}"
+    KubernetesCluster = "${var.external_vpc_id == "" ? var.cluster_name : "${var.cluster_name}-side-effect"}"
   }
 }
 

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -1,19 +1,24 @@
 data "aws_availability_zones" "azs" {}
 
 resource "aws_vpc" "new_vpc" {
-  count = "${var.external_vpc_id == "" ? 0 : 1}"
-
-  cidr_block = "${var.cidr_block}"
-
+  count                = "${var.external_vpc_id == "" ? 0 : 1}"
+  cidr_block           = "${var.cidr_block}"
   enable_dns_hostnames = true
   enable_dns_support   = true
 
   tags {
-    Name              = "${var.external_vpc_id == "" ? var.cluster_name : "${var.cluster_name}-side-effect"}"
-    KubernetesCluster = "${var.external_vpc_id == "" ? var.cluster_name : "${var.cluster_name}-side-effect"}"
+    Name              = "${var.cluster_name}"
+    KubernetesCluster = "${var.cluster_name}"
   }
 }
 
 data "aws_vpc" "cluster_vpc" {
+  # The join() hack is required because currently the ternary operator
+  # evaluates the expressions on both branches of the condition before
+  # returning a value. When providing and external VPC, the template VPC
+  # resource gets a count of zero which triggers an evaluation error.
+  #
+  # This is tracked upstream: https://github.com/hashicorp/hil/issues/50
+  #
   id = "${var.external_vpc_id == "" ? join(" ", aws_vpc.new_vpc.*.id) : var.external_vpc_id }"
 }

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -8,8 +8,8 @@ module "vpc" {
   cluster_name = "${var.tectonic_cluster_name}"
 
   external_vpc_id         = "${var.tectonic_aws_external_vpc_id}"
-  external_master_subnets = ["${compact(var.tectonic_aws_external_master_subnets)}"]
-  external_worker_subnets = ["${compact(var.tectonic_aws_external_worker_subnets)}"]
+  external_master_subnets = ["${compact(var.tectonic_aws_external_master_subnet_ids)}"]
+  external_worker_subnets = ["${compact(var.tectonic_aws_external_worker_subnet_ids)}"]
 }
 
 module "etcd" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -1,15 +1,15 @@
 data "aws_availability_zones" "azs" {}
 
 module "vpc" {
-  source                       = "../../modules/aws/vpc"
+  source = "../../modules/aws/vpc"
 
   az_count     = "${var.tectonic_aws_az_count}"
   cidr_block   = "${var.tectonic_aws_vpc_cidr_block}"
   cluster_name = "${var.tectonic_cluster_name}"
 
   external_vpc_id         = "${var.tectonic_aws_external_vpc_id}"
-  external_master_subnets = []
-  external_worker_subnets = []
+  external_master_subnets = ["${compact(var.tectonic_aws_external_master_subnets)}"]
+  external_worker_subnets = ["${compact(var.tectonic_aws_external_worker_subnets)}"]
 }
 
 module "etcd" {

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -25,3 +25,13 @@ variable "tectonic_aws_az_count" {
 variable "tectonic_aws_external_vpc_id" {
   type = "string"
 }
+
+variable "tectonic_aws_external_master_subnets" {
+  type    = "list"
+  default = [""]
+}
+
+variable "tectonic_aws_external_worker_subnets" {
+  type    = "list"
+  default = [""]
+}

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -26,12 +26,12 @@ variable "tectonic_aws_external_vpc_id" {
   type = "string"
 }
 
-variable "tectonic_aws_external_master_subnets" {
+variable "tectonic_aws_external_master_subnet_ids" {
   type    = "list"
   default = [""]
 }
 
-variable "tectonic_aws_external_worker_subnets" {
+variable "tectonic_aws_external_worker_subnet_ids" {
   type    = "list"
   default = [""]
 }


### PR DESCRIPTION
BYO VPC slipped through the recent refactoring and wasn't properly tested.  It was not working before these changes.

With these changes clusters CAN now be built into existing VPC and will work as expected.

[The conditional operator always evaluates both branches](https://github.com/hashicorp/hil/issues/50). On one of the branches, the VPC resource may not be present when using an external VPC, because it's count is set to zero. Thus we have to wrap the potentially missing resource in a fake `join()`. Because the expression is now treated like an list of VPC resources, having an empty list is a valid state and the build works as expected.

Hashicorp is aware of the [issue](https://github.com/hashicorp/terraform/issues/11566) and intends to fix it.

This issue also affected @Quentin-M 's work on BYO external CA certs.

~~We run into a limitation of Terraform that forces us to take an unwanted side-effect.
Because [the conditional operator always evaluates both branches](https://github.com/hashicorp/hil/issues/50), we cannot skip creating a VPC resource as it would lead to one of the condition branches being invalid.
The resulting extra VPC will be empty and not actually used further on by the cluster, which will correctly build into the externally provided VPC. It doesn't incur any costs while it exists, but it will show up when listing VPCs. It also doesn't affect other resources in any way.~~

~~For the sake of providing the BYO VPC feature to users, I feel that it's worth living with this side-effect until the root issue gets addressed.~~

I would like to hear other opinions on this.

@philips @Quentin-M @s-urbaniak @bison 