### PR TITLE
apiserver: add --apiserver-count

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -12,7 +12,8 @@ resource "template_folder" "bootkube" {
     exechealthz_image     = "${var.container_images["exechealthz"]}"
     flannel_image         = "${var.container_images["flannel"]}"
 
-    etcd_servers = "${join(",", var.etcd_servers)}"
+    master_count   = "${var.master_count}"
+    etcd_servers   = "${join(",", var.etcd_servers)}"
     cloud_provider = "${var.cloud_provider}"
 
     cluster_cidr = "${var.cluster_cidr}"

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -1,35 +1,35 @@
 # Self-hosted manifests (resources/generated/manifests/)
 resource "template_folder" "bootkube" {
-  input_path = "${path.module}/resources/manifests"
+  input_path  = "${path.module}/resources/manifests"
   output_path = "${path.cwd}/generated/manifests"
 
   vars {
-    hyperkube_image = "${var.container_images["hyperkube"]}"
+    hyperkube_image        = "${var.container_images["hyperkube"]}"
     pod_checkpointer_image = "${var.container_images["pod_checkpointer"]}"
-    kubedns_image         = "${var.container_images["kubedns"]}"
-    kubednsmasq_image     = "${var.container_images["kubednsmasq"]}"
-    dnsmasq_metrics_image = "${var.container_images["dnsmasq_metrics"]}"
-    exechealthz_image     = "${var.container_images["exechealthz"]}"
-    flannel_image         = "${var.container_images["flannel"]}"
+    kubedns_image          = "${var.container_images["kubedns"]}"
+    kubednsmasq_image      = "${var.container_images["kubednsmasq"]}"
+    dnsmasq_metrics_image  = "${var.container_images["dnsmasq_metrics"]}"
+    exechealthz_image      = "${var.container_images["exechealthz"]}"
+    flannel_image          = "${var.container_images["flannel"]}"
 
     master_count   = "${var.master_count}"
     etcd_servers   = "${join(",", var.etcd_servers)}"
     cloud_provider = "${var.cloud_provider}"
 
-    cluster_cidr = "${var.cluster_cidr}"
-    service_cidr = "${var.service_cidr}"
+    cluster_cidr        = "${var.cluster_cidr}"
+    service_cidr        = "${var.service_cidr}"
     kube_dns_service_ip = "${var.kube_dns_service_ip}"
-    advertise_address = "${var.advertise_address}"
+    advertise_address   = "${var.advertise_address}"
 
-    anonymous_auth = "${var.anonymous_auth}"
-    oidc_issuer_url = "${var.oidc_issuer_url}"
-    oidc_client_id = "${var.oidc_client_id}"
+    anonymous_auth      = "${var.anonymous_auth}"
+    oidc_issuer_url     = "${var.oidc_issuer_url}"
+    oidc_client_id      = "${var.oidc_client_id}"
     oidc_username_claim = "${var.oidc_username_claim}"
-    oidc_groups_claim = "${var.oidc_groups_claim}"
+    oidc_groups_claim   = "${var.oidc_groups_claim}"
 
-    ca_cert = "${base64encode(var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert)}"
-    apiserver_key = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
-    apiserver_cert = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
+    ca_cert            = "${base64encode(var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert)}"
+    apiserver_key      = "${base64encode(tls_private_key.apiserver.private_key_pem)}"
+    apiserver_cert     = "${base64encode(tls_locally_signed_cert.apiserver.cert_pem)}"
     serviceaccount_pub = "${base64encode(tls_private_key.service-account.public_key_pem)}"
     serviceaccount_key = "${base64encode(tls_private_key.service-account.private_key_pem)}"
   }
@@ -40,15 +40,15 @@ data "template_file" "kubeconfig" {
   template = "${file("${path.module}/resources/kubeconfig")}"
 
   vars {
-    ca_cert = "${base64encode(var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert)}"
+    ca_cert      = "${base64encode(var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert)}"
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
-    kubelet_key = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
-    server = "${var.kube_apiserver_url}"
+    kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
+    server       = "${var.kube_apiserver_url}"
   }
 }
 
 resource "localfile_file" "kubeconfig" {
-  content = "${data.template_file.kubeconfig.rendered}"
+  content     = "${data.template_file.kubeconfig.rendered}"
   destination = "${path.cwd}/generated/kubeconfig"
 }
 
@@ -58,11 +58,11 @@ data "template_file" "bootkube" {
 
   vars {
     bootkube_image = "${var.container_images["bootkube"]}"
-    etcd_server = "${element(var.etcd_servers, 0)}"
+    etcd_server    = "${element(var.etcd_servers, 0)}"
   }
 }
 
 resource "localfile_file" "bootkube" {
-  content = "${data.template_file.bootkube.rendered}"
+  content     = "${data.template_file.bootkube.rendered}"
   destination = "${path.cwd}/generated/bootkube.sh"
 }

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -52,6 +52,7 @@ spec:
         - --oidc-groups-claim=${oidc_groups_claim}
         - --oidc-ca-file=/etc/kubernetes/secrets/ca.crt
         - --cloud-provider=${cloud_provider}
+        - --apiserver-count=${master_count}
         env:
         - name: POD_IP
           valueFrom:

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -1,84 +1,88 @@
 variable "container_images" {
-    description = "Container images to use"
-    type = "map"
+  description = "Container images to use"
+  type        = "map"
 }
 
 variable "kube_apiserver_url" {
-    description = "URL used to reach kube-apiserver"
-    type        = "string"
+  description = "URL used to reach kube-apiserver"
+  type        = "string"
 }
 
 variable "kube_apiserver_service_ip" {
-    description = "Service IP used to reach kube-apiserver inside the cluster"
-    type        = "string"
+  description = "Service IP used to reach kube-apiserver inside the cluster"
+  type        = "string"
 }
 
 variable "kube_dns_service_ip" {
-    description = "Service IP used to reach kube-dns"
-    type        = "string"
+  description = "Service IP used to reach kube-dns"
+  type        = "string"
+}
+
+variable "master_count" {
+  type = "string"
 }
 
 variable "etcd_servers" {
-    description = "List of etcd servers to connect with (scheme://ip:port)"
-    type        = "list"
+  description = "List of etcd servers to connect with (scheme://ip:port)"
+  type        = "list"
 }
 
 variable "cloud_provider" {
-    description = "The provider for cloud services (empty string for no provider)"
-    type        = "string"
+  description = "The provider for cloud services (empty string for no provider)"
+  type        = "string"
 }
 
 variable "service_cidr" {
-    description = "A CIDR notation IP range from which to assign service cluster IPs"
-    type        = "string"
+  description = "A CIDR notation IP range from which to assign service cluster IPs"
+  type        = "string"
 }
 
 variable "cluster_cidr" {
-    description = "A CIDR notation IP range from which to assign pod IPs"
-    type        = "string"
+  description = "A CIDR notation IP range from which to assign pod IPs"
+  type        = "string"
 }
 
 variable "advertise_address" {
-    description = "The IP address on which to advertise the apiserver to members of the cluster"
-    type        = "string"
+  description = "The IP address on which to advertise the apiserver to members of the cluster"
+  type        = "string"
 }
 
 variable "ca_cert" {
-    description = "PEM-encoded CA certificate (generated if blank)"
-    type        = "string"
+  description = "PEM-encoded CA certificate (generated if blank)"
+  type        = "string"
 }
 
 variable "ca_key_alg" {
-    description = "Algorithm used to generate ca_key (required if ca_cert is specified)"
-    type        = "string"
+  description = "Algorithm used to generate ca_key (required if ca_cert is specified)"
+  type        = "string"
 }
 
 variable "ca_key" {
-    description = "PEM-encoded CA key (required if ca_cert is specified)"
-    type        = "string"
+  description = "PEM-encoded CA key (required if ca_cert is specified)"
+  type        = "string"
 }
 
 variable "anonymous_auth" {
-    description = "Enables anonymous requests to the secure port of the API server"
-    type        = "string"
+  description = "Enables anonymous requests to the secure port of the API server"
+  type        = "string"
 }
 
 variable "oidc_issuer_url" {
-    description = "The URL of the OpenID issuer, only HTTPS scheme will be accepted"
-    type        = "string"
+  description = "The URL of the OpenID issuer, only HTTPS scheme will be accepted"
+  type        = "string"
 }
 
 variable "oidc_client_id" {
-    description = "The client ID for the OpenID Connect client"
-    type        = "string"
+  description = "The client ID for the OpenID Connect client"
+  type        = "string"
 }
 
 variable "oidc_username_claim" {
-    description = "The OpenID claim to use as the user name"
-    type        = "string"
+  description = "The OpenID claim to use as the user name"
+  type        = "string"
 }
 
 variable "oidc_groups_claim" {
-    description = "The OpenID claim to use for specifying user groups (string or array of strings)"
-    type        = "string"
+  description = "The OpenID claim to use for specifying user groups (string or array of strings)"
+  type        = "string"
 }

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -61,8 +61,8 @@ module "tectonic" {
 }
 
 data "archive_file" "assets" {
-  type        = "zip"
-  source_dir  = "${path.cwd}/generated/"
+  type       = "zip"
+  source_dir = "${path.cwd}/generated/"
 
   # Because the archive_file provider is a data source, depends_on can't be
   # used to guarantee that the tectonic/bootkube modules have generated

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -26,6 +26,7 @@ module "bootkube" {
   oidc_client_id      = "tectonic-kubectl"
 
   etcd_servers = ["http://127.0.0.1:2379"]
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -26,6 +26,7 @@ module "bootkube" {
   oidc_client_id      = "tectonic-kubectl"
 
   etcd_servers = ["http://127.0.0.1:2379"]
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -26,6 +26,7 @@ module "bootkube" {
   oidc_client_id      = "tectonic-kubectl"
 
   etcd_servers = ["http://127.0.0.1:2379"]
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -26,6 +26,7 @@ module "bootkube" {
   oidc_client_id      = "tectonic-kubectl"
 
   etcd_servers = ["http://127.0.0.1:2379"]
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {


### PR DESCRIPTION
Currently we don't set apiserver-count leading to the situation that an
arbitrary api server gets an endpoint assigned in the cluster.

I.e. in a three master setup only one endpoint is created:
```
$ kubectl get endpoints --all-namespaces NAMESPACE     NAME
     ENDPOINTS                 AGE default       kubernetes
10.0.33.61:443            2m
```

During a bootstrap scenario this even flips arbitrarily when apiserver daemonset pods are being created:

```
$ kubectl get pods --all-namespaces
...
kube-system   kube-apiserver-c2vb3                                         1/1       Running             0          3m
kube-system   kube-apiserver-rwvx4                                         0/1       ContainerCreating   0          1m
kube-system   kube-apiserver-t6x59                                         1/1       Running             0          1m
...

$ kubectl --namespace=default get endpoints
NAMESPACE     NAME                      ENDPOINTS                 AGE
default       kubernetes                10.0.27.223:443           3m
```

This fixes it by specifying `--apiserver-count` leading to the following
endpoint list in case three masters are deployed:

```
$ kubectl --namespace=default get endpoints NAME         ENDPOINTS
                              AGE kubernetes
10.0.10.222:443,10.0.17.80:443,10.0.33.159:443   4m
```

/cc @aaronlevy I found https://github.com/coreos/coreos-kubernetes/pull/730 and I am unsure if this really applies. Kubelets use DNS and LBs to resolve api servers, but the internal kubernetes service gets only one endpoints assigned if we leave out this parameter. Hence if the apiserver pod goes down, the other apiservers are never talked to at all (at least for internal services).

As discussed with @alexsomesan I will also check if DaemonSets support health endpoints such that endpoints could be removed in case an API endpoint is not healthy.