### PR TITLE
modules/aws/vpc: Create VPC if no external VPC is specified

### DIFF
--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -1,7 +1,7 @@
 data "aws_availability_zones" "azs" {}
 
 resource "aws_vpc" "new_vpc" {
-  count                = "${var.external_vpc_id == "" ? 0 : 1}"
+  count                = "${var.external_vpc_id == "" ? 1 : 0}"
   cidr_block           = "${var.cidr_block}"
   enable_dns_hostnames = true
   enable_dns_support   = true


### PR DESCRIPTION
We were not creating a new VPC when no external VPC ID was specified. The logic is inverted.

The issue could be seen with `data.aws_vpc.cluster_vpc` [describing all](https://github.com/hashicorp/terraform/blob/0b0a76a3d5f13812996207b0268368c694278902/builtin/providers/aws/data_source_aws_vpc.go#L74) the VPCs (`id = ""`) rather than the one we were supposed to create.

```
2017/03/30 13:40:56 [ERROR] root.masters: eval: *terraform.EvalReadDataApply, err: data.aws_vpc.cluster_vpc: multiple VPCs matched; use additional constraints to reduce matches to a single VPC
2017/03/30 13:40:56 [ERROR] root.masters: eval: *terraform.EvalSequence, err: data.aws_vpc.cluster_vpc: multiple VPCs matched; use additional constraints to reduce matches to a single VPC
2017/03/30 13:40:56 [ERROR] root.masters: eval: *terraform.EvalOpFilter, err: data.aws_vpc.cluster_vpc: multiple VPCs matched; use additional constraints to reduce matches to a single VPC
2017/03/30 13:40:56 [ERROR] root.masters: eval: *terraform.EvalSequence, err: data.aws_vpc.cluster_vpc: multiple VPCs matched; use additional constraints to reduce matches to a single VPC
2017/03/30 13:40:56 [TRACE] [walkRefresh] Exiting eval tree: data.aws_vpc.cluster_vpc
```