### PR TITLE
modules/tectonic: stop templating console

### DIFF
--- a/modules/tectonic/resources/manifests/config.yaml
+++ b/modules/tectonic/resources/manifests/config.yaml
@@ -8,3 +8,6 @@ data:
   installerPlatform: "${platform}"
   certificatesStrategy: "${certificates_strategy}"
   tectonicUpdaterEnabled: "true"
+  consoleBaseAddress: "${console_base_address}"
+  kubeAPIServerURL: "${kube_apiserver_url}"
+  tectonicVersion: "${tectonic_version}"

--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -34,11 +34,17 @@ spec:
         - name: BRIDGE_K8S_AUTH
           value: oidc
         - name: BRIDGE_K8S_PUBLIC_ENDPOINT
-          value: ${kube_apiserver_url}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-config
+              key: kubeAPIServerURL
         - name: BRIDGE_LISTEN
           value: http://0.0.0.0:80
         - name: BRIDGE_BASE_ADDRESS
-          value: ${console_base_address}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-config
+              key: consoleBaseAddress
         - name: BRIDGE_BASE_PATH
           value: /
         - name: BRIDGE_PUBLIC_DIR
@@ -46,17 +52,35 @@ spec:
         - name: BRIDGE_USER_AUTH
           value: oidc
         - name: BRIDGE_USER_AUTH_OIDC_ISSUER_URL
-          value: ${oidc_issuer_url}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-identity
+              key: issuer
         - name: BRIDGE_USER_AUTH_OIDC_CLIENT_ID
-          value: ${console_client_id}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-identity
+              key: consoleClientID
         - name: BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET
-          value: ${console_secret}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-identity
+              key: consoleSecret
         - name: BRIDGE_KUBECTL_CLIENT_ID
-          value: ${kubectl_client_id }
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-identity
+              key: kubectlClientID
         - name: BRIDGE_KUBECTL_CLIENT_SECRET
-          value: ${kubectl_secret}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-identity
+              key: kubectlSecret
         - name: BRIDGE_TECTONIC_VERSION
-          value: ${tectonic_version}
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-config
+              key: tectonicVersion
         - name: BRIDGE_CA_FILE
           value: /etc/tectonic-ca-cert-secret/ca-cert
         - name: BRIDGE_LICENSE_FILE

--- a/modules/tectonic/resources/manifests/identity/configmap.yaml
+++ b/modules/tectonic/resources/manifests/identity/configmap.yaml
@@ -4,6 +4,11 @@ metadata:
   name: tectonic-identity
   namespace: tectonic-system
 data:
+  issuer: ${oidc_issuer_url}
+  consoleClientID: ${console_client_id}
+  consoleSecret: ${console_secret}
+  kubectlClientID: ${kubectl_client_id}
+  kubectlSecret: ${kubectl_secret}
   config.yaml: |
     issuer: ${oidc_issuer_url}
     storage:


### PR DESCRIPTION
This commit removes templated variables from the console deployment. This
allows us to manage the console deployment manifest with operators.