### PR TITLE
switch : to = to correct syntax

### DIFF
--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -33,19 +33,19 @@ variable "tectonic_azure_ssh_key" {
 
 variable "tectonic_azure_master_vm_size" {
   type = "string"
-  description: "Instance size for the master node(s). Example: Standard_DS2."
+  description =  "Instance size for the master node(s). Example: Standard_DS2."
   default = "Standard_DS2"
 }
 
 variable "tectonic_azure_worker_vm_size" {
   type = "string"
-  description: "Instance size for the worker node(s). Example: Standard_DS2."
+  description =  "Instance size for the worker node(s). Example: Standard_DS2."
   default = "Standard_DS2"
 }
 
 variable "tectonic_azure_etcd_vm_size" {
   type = "string"
-  description: "Instance size for the etcd node(s). Example: Standard_DS2."
+  description =  "Instance size for the etcd node(s). Example: Standard_DS2."
   default = "Standard_DS2"
 }
 


### PR DESCRIPTION
Terraform get was failing due to incorrect syntax:

terraform get platforms/azure
Error loading Terraform: Error loading config: Error parsing platforms/azure/variables.tf: At 36:14: illegal char

Verified with terraform validate:

terraform validate platforms/azure/
Error loading files Error parsing platforms/azure/variables.tf: At 36:14: illegal char