### PR TITLE
Use same conditional format as in rest of module

### DIFF
--- a/modules/aws/etcd/outputs.tf
+++ b/modules/aws/etcd/outputs.tf
@@ -1,4 +1,4 @@
 # We have to do this join() & split() 'trick' because the ternary operator can't output lists.
 output "endpoints" {
-  value = ["${split(",", length(var.external_endpoints) == 0 ? join(",", aws_route53_record.etc_a_nodes.*.fqdn) :  join(",", var.external_endpoints))}"]
+  value = ["${split(",", length(var.external_endpoints) == 0 ? join(",", aws_route53_record.etc_a_nodes.*.fqdn) : join(",", var.external_endpoints))}"]
 }

--- a/modules/aws/etcd/outputs.tf
+++ b/modules/aws/etcd/outputs.tf
@@ -1,4 +1,4 @@
 # We have to do this join() & split() 'trick' because the ternary operator can't output lists.
 output "endpoints" {
-  value = ["${split(",", join(",", var.external_endpoints) == "" ? join(",", aws_route53_record.etc_a_nodes.*.fqdn) :  join(",", var.external_endpoints))}"]
+  value = ["${split(",", length(var.external_endpoints) == 0 ? join(",", aws_route53_record.etc_a_nodes.*.fqdn) :  join(",", var.external_endpoints))}"]
 }


### PR DESCRIPTION
`var.external_endpoints` is a list, so calling `length()` on it will return the number of elements.
No need to `join()` convert it to a string to check emptiness.

@Quentin-M @s-urbaniak 