### PR TITLE
Add syntax formatting make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,13 @@ docs: Documentation/variables/config.md Documentation/variables/platform-aws.md 
 clean: destroy
 	rm -rf $(BUILD_DIR)
 
-.PHONY: make clean terraform terraform-dev
+# This target is used by the GitHub PR checker to validate canonical syntax on all files.
+#
+structure-check:
+	terraform fmt -list -write=false . | tee $TMPDIR/tf_fmt_files
+	exit $(wc -l <$TMPDIR/tf_fmt_files)
+
+canonical-syntax:
+	terraform fmt -list .
+
+.PHONY: make clean terraform terraform-dev structure-check canonical-syntax


### PR DESCRIPTION
Terraform comes with a convenient syntax checking and formatting tool which can be used to ensure templates follow canonical syntax rules.

This change introduces two new make targets:
* `structure-check` will be used by the upcoming PR checker to validate canonical syntax
* `canonical-syntax` can be used at any time to align the complete repository to canonical syntax.