### PR TITLE
update ingress to enable use by others.

### DIFF
--- a/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
+++ b/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
           - --configmap=$(POD_NAMESPACE)/tectonic-custom-error
           - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
           - --default-ssl-certificate=tectonic-system/tectonic-ingress-tls-secret
-          - --watch-namespace=tectonic-system
+          - --ingress-class=tectonic
           # use downward API
           env:
             - name: POD_NAME

--- a/modules/tectonic/resources/manifests/ingress/ingress.yaml
+++ b/modules/tectonic/resources/manifests/ingress/ingress.yaml
@@ -6,11 +6,15 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     ingress.kubernetes.io/use-port-in-redirects: "true"
+    kubernetes.io/ingress.class: "tectonic"
 spec:
   tls:
-    - secretName: tectonic-ingress-tls-secret
+  - hosts:
+    - ${console_base_address}
+    secretName: tectonic-ingress-tls-secret
   rules:
-  - http:
+  - host: ${console_base_address}
+    http:
       paths:
       - path: /
         backend:

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           - --configmap=$(POD_NAMESPACE)/tectonic-custom-error
           - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
           - --default-ssl-certificate=tectonic-system/tectonic-ingress-tls-secret
-          - --watch-namespace=tectonic-system
+          - --ingress-class=tectonic
           # use downward API
           env:
             - name: POD_NAME


### PR DESCRIPTION
- addresses: https://github.com/coreos-inc/tectonic-issues/issues/219.
- Updates ingress controllers to remove default ssl cert.
  the cert is satisfied at the ingress resource.
- Adds vhost to ingress resource. Sets ingress class correctly.