### PR TITLE
modules/bootkube: disable alpha API groups

### DIFF
--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -36,7 +36,6 @@ spec:
         - --allow-privileged=true
         - --service-cluster-ip-range=${service_cidr}
         - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota
-        - --runtime-config=api/all=true
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt


### PR DESCRIPTION
This commit changes the `--runtime-config` flags on the apiserver so
that only stable API groups and the RBAC APIs are enabled. in 1.6, RBAC
graduates to beta and we can remove that line as well.