### PR TITLE
Update Dockerfile and fix syntax checking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,19 @@
 FROM golang:alpine
 
-ENV TERRAFORM_VERSION=0.8.8
+ENV TERRAFORM_VERSION=0.8.8-coreos
 
-RUN apk add --update git bash
+RUN apk add --update git bash make
 
-ENV TF_DEV=true
+RUN go get github.com/coreos/bcrypt-tool
 
 WORKDIR $GOPATH/src/github.com/hashicorp/terraform
-RUN git clone https://github.com/hashicorp/terraform.git ./ && \
+RUN git clone https://github.com/coreos/terraform.git ./ && \
     git checkout v${TERRAFORM_VERSION} && \
-    /bin/bash scripts/build.sh
-
-COPY ./plugins $GOPATH/src/github.com/coreos-inc/tectonic-platform-sdk/plugins
-
-RUN go build -o $GOTPAH/bin/terraform-provider-localfile \
-  github.com/coreos-inc/tectonic-platform-sdk/plugins/bins/provider-localfile
-
-RUN go build -o $GOPATH/bin/terraform-provider-template \
-  github.com/coreos-inc/tectonic-platform-sdk/plugins/bins/provider-template
+    go run scripts/generate-plugins.go && \
+    XC_ARCH=amd64 XC_OS=linux ./scripts/build.sh
 
 VOLUME /terraform
 WORKDIR /terraform
 
-ENTRYPOINT ["terraform"]
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD "bash"

--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,10 @@ clean: destroy
 
 # This target is used by the GitHub PR checker to validate canonical syntax on all files.
 #
-structure-check:
-	terraform fmt -list -write=false . | tee $(TMPDIR)/tf_fmt_files
-	exit $(shell wc -l <$(TMPDIR)/tf_fmt_files)
+structure-check: 
+	$(eval FMT_ERR := $(shell terraform fmt -list -write=false .))
+	@echo "wrong files:" $(FMT_ERR)
+	@test "$(FMT_ERR)" == ""
 
 canonical-syntax:
 	terraform fmt -list .


### PR DESCRIPTION
This change updates the Dockerfile to:
* build terraform from our coreos/terraform fork, to include the custom plugins we use.
* install make and bcrypt-tool in the container image to provide a self-sufficient installer environment.

On top of that, there is a fix for the syntax checking make target to make it work reliably.

These changes allow us to start putting together the Jenkins testing tasks.

@s-urbaniak @Quentin-M 