### PR TITLE
*: Update kubelet-wrapper env vars and node-agent

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -10,7 +10,7 @@ variable "tectonic_container_images" {
     identity                  = "quay.io/coreos/dex:v2.2.4"
     kube_version_operator     = "quay.io/coreos/kube-version-operator:7da46d189c36092f43d07ca381a61897402fa13c"
     tectonic_channel_operator = "quay.io/coreos/tectonic-channel-operator:15c001bd7c008a04394390d08ac71046e723ac48"
-    node_agent                = "quay.io/coreos/node-agent:96db3df24c2ddf0b82c38111c71179c5b10de0c9"
+    node_agent                = "quay.io/coreos/node-agent:53f6c8dcc7657b49d1468f7e24933d3897ae8ea7"
     prometheus_operator       = "quay.io/coreos/prometheus-operator:v0.6.0"
     node_exporter             = "quay.io/prometheus/node-exporter:v0.13.0"
     config_reload             = "quay.io/coreos/configmap-reload:v0.0.1"

--- a/modules/aws/ignition/resources/services/kubelet.service
+++ b/modules/aws/ignition/resources/services/kubelet.service
@@ -2,9 +2,9 @@
 Description=Kubelet via Hyperkube ACI
 
 [Service]
-Environment=KUBELET_ACI=${aci}
-Environment=KUBELET_VERSION=${version}
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment=KUBELET_IMAGE_URL=${aci}
+Environment=KUBELET_IMAGE_TAG=${version}
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume=resolv,kind=host,source=/etc/resolv.conf \
   --mount volume=resolv,target=/etc/resolv.conf \
   --volume var-lib-cni,kind=host,source=/var/lib/cni \

--- a/modules/azure/master/ignition-master.tf
+++ b/modules/azure/master/ignition-master.tf
@@ -95,8 +95,8 @@ resource "ignition_file" "kubelet-env" {
 
   content {
     content = <<EOF
-KUBELET_ACI="${var.kube_image_url}"
-KUBELET_VERSION="${var.kube_image_tag}"
+KUBELET_IMAGE_URL="${var.kube_image_url}"
+KUBELET_IMAGE_TAG="${var.kube_image_tag}"
 EOF
   }
 }

--- a/modules/azure/master/resources/master-kubelet.service
+++ b/modules/azure/master/resources/master-kubelet.service
@@ -2,7 +2,7 @@
 Description=Kubelet via Hyperkube ACI
 
 [Service]
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume=resolv,kind=host,source=/etc/resolv.conf \
   --mount volume=resolv,target=/etc/resolv.conf \
   --volume var-lib-cni,kind=host,source=/var/lib/cni \

--- a/modules/azure/worker/ignition-worker.tf
+++ b/modules/azure/worker/ignition-worker.tf
@@ -86,8 +86,8 @@ resource "ignition_file" "kubelet-env" {
 
   content {
     content = <<EOF
-KUBELET_ACI="${var.kube_image_url}"
-KUBELET_VERSION="${var.kube_image_tag}"
+KUBELET_IMAGE_URL="${var.kube_image_url}"
+KUBELET_IMAGE_TAG="${var.kube_image_tag}"
 EOF
   }
 }

--- a/modules/azure/worker/resources/worker-kubelet.service
+++ b/modules/azure/worker/resources/worker-kubelet.service
@@ -2,7 +2,7 @@
 Description=Kubelet via Hyperkube ACI
 
 [Service]
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume=resolv,kind=host,source=/etc/resolv.conf \
   --mount volume=resolv,target=/etc/resolv.conf \
   --volume var-lib-cni,kind=host,source=/var/lib/cni \

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -120,8 +120,8 @@ resource "ignition_file" "kubelet-env" {
 
   content {
     content = <<EOF
-KUBELET_ACI=${var.kube_image_url}
-KUBELET_VERSION="${var.kube_image_tag}"
+KUBELET_IMAGE_URL=${var.kube_image_url}
+KUBELET_IMAGE_TAG="${var.kube_image_tag}"
 EOF
   }
 }

--- a/modules/openstack/nodes/resources/kubelet.service
+++ b/modules/openstack/nodes/resources/kubelet.service
@@ -2,7 +2,7 @@
 Description=Kubelet via Hyperkube ACI
 
 [Service]
-Environment="RKT_OPTS=--uuid-file-save=/var/run/kubelet-pod.uuid \
+Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
   --volume=resolv,kind=host,source=/etc/resolv.conf \
   --mount volume=resolv,target=/etc/resolv.conf \
   --volume var-lib-cni,kind=host,source=/var/lib/cni \


### PR DESCRIPTION
Update the kubelet-wrapper env vars and update node-agent to support new
env vars.

The following environment variables used by kubelet-wrapper have been
deprecated:

KUBELET_VERSION has been replaced with KUBELET_IMAGE_TAG
KUBELET_ACI has replaced with KUBELET_IMAGE_URL
RKT_OPTS has been replaces with RKT_RUN_ARGS
See https://github.com/coreos/coreos-overlay/blob/build-1220/app-admin/kubelet-wrapper/files/kubelet-wrapper#L29-L39.