### PR TITLE
*: do not use paths for license/pull secret

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -26,9 +26,9 @@ This document gives an overview of variables used in all platforms of the Tecton
 | tectonic_kube_apiserver_service_ip | The Kubernetes service IP used to reach kube-apiserver inside the cluster as returned by `kubectl -n default get service kubernetes`. | string | `10.3.0.1` |
 | tectonic_kube_dns_service_ip | The Kubernetes service IP used to reach kube-dns inside the cluster as returned by `kubectl -n kube-system get service kube-dns`. | string | `10.3.0.10` |
 | tectonic_kube_etcd_service_ip | The Kubernetes service IP used to reach self-hosted etcd inside the cluster as returned by `kubectl -n kube-system get service etcd-service`. | string | `10.3.0.15` |
-| tectonic_license_path | The path to the tectonic licence file.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
+| tectonic_license | The tectonic licence.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
 | tectonic_master_count | The number of master nodes to be created. This applies only to cloud platforms. | string | `1` |
-| tectonic_pull_secret_path | The path the pull secret file in JSON format.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
+| tectonic_pull_secret | The pull secret in JSON format.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
 | tectonic_service_cidr | This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. | string | `10.3.0.0/16` |
 | tectonic_update_app_id | (internal) The Tectonic Omaha update App ID | string | `6bc7b986-4654-4a0f-94b3-84ce6feb1db4` |
 | tectonic_update_channel | (internal) The Tectonic Omaha update channel | string | `tectonic-1.6` |

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
       steps {
         parallel (
           "TerraForm: AWS": {
-            withCredentials([file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_pull_secret_path'),
-                             file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_license_path'),
+            withCredentials([file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_pull_secret'),
+                             file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_license'),
                              [
                                $class: 'UsernamePasswordMultiBinding',
                                credentialsId: 'tectonic-aws',
@@ -101,8 +101,8 @@ pipeline {
     always {
       checkout scm
 
-      withCredentials([file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_pull_secret_path'),
-                       file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_license_path'),
+      withCredentials([file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_pull_secret'),
+                       file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_license'),
                        [
                          $class: 'UsernamePasswordMultiBinding',
                          credentialsId: 'tectonic-aws',

--- a/config.tf
+++ b/config.tf
@@ -208,7 +208,7 @@ Note: This field MUST be set manually prior to creating the cluster.
 EOF
 }
 
-variable "tectonic_pull_secret_path" {
+variable "tectonic_pull_secret" {
   type = "string"
 
   description = <<EOF
@@ -218,7 +218,7 @@ Note: This field MUST be set manually prior to creating the cluster.
 EOF
 }
 
-variable "tectonic_license_path" {
+variable "tectonic_license" {
   type = "string"
 
   description = <<EOF

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -219,8 +219,6 @@ export const toAWS_TF = (cc, FORMS) => {
     clusterKind: 'tectonic-aws-tf',
     dryRun: cc[DRY_RUN],
     platform: "aws",
-    license: cc[TECTONIC_LICENSE],
-    pullSecret: cc[PULL_SECRET],
     adminPassword: window.btoa(cc[ADMIN_PASSWORD]),
     credentials: {
       AWSAccessKeyID: cc[AWS_ACCESS_KEY_ID],
@@ -228,6 +226,8 @@ export const toAWS_TF = (cc, FORMS) => {
       AWSRegion: cc[AWS_REGION],
     },
     variables: {
+      tectonic_license: cc[TECTONIC_LICENSE],
+      tectonic_pull_secret: cc[PULL_SECRET],
       tectonic_aws_region: cc[AWS_REGION],
       tectonic_admin_email: cc[ADMIN_EMAIL],
       tectonic_aws_master_ec2_type: controllers[INSTANCE_TYPE],
@@ -295,10 +295,10 @@ export const toBaremetal_TF = (cc, FORMS) => {
     clusterKind: 'tectonic-metal',
     dryRun: cc[DRY_RUN],
     platform: 'metal',
-    license: cc[TECTONIC_LICENSE],
-    pullSecret: cc[PULL_SECRET],
     adminPassword: window.btoa(cc[ADMIN_PASSWORD]),
     variables: {
+      tectonic_license: cc[TECTONIC_LICENSE],
+      tectonic_pull_secret: cc[PULL_SECRET],
       tectonic_cluster_name: cc[CLUSTER_NAME],
       tectonic_cl_channel: cc[CHANNEL_TO_USE],
       tectonic_admin_email: cc[ADMIN_EMAIL],

--- a/installer/server/terraform.go
+++ b/installer/server/terraform.go
@@ -360,18 +360,6 @@ func newExecutorFromApplyHandlerInput(input *TerraformApplyHandlerInput) (*terra
 		return nil, ctxh.NewAppError(err, fmt.Sprintf("Could not create TerraForm executor: %v", err.Error()), http.StatusInternalServerError)
 	}
 
-	// Write the License and Pull Secret to disk, and wire these files in the
-	// variables.
-	if input.License == "" {
-		return nil, ctxh.NewAppError(err, "Tectonic license not provided", http.StatusBadRequest)
-	}
-	ex.AddFile("license.txt", []byte(input.License))
-	if input.PullSecret == "" {
-		return nil, ctxh.NewAppError(err, "Tectonic pull secret not provided", http.StatusBadRequest)
-	}
-	ex.AddFile("pull_secret.json", []byte(input.PullSecret))
-	input.Variables["tectonic_license_path"] = "./license.txt"
-	input.Variables["tectonic_pull_secret_path"] = "./pull_secret.json"
 	serviceCidr := input.Variables["tectonic_service_cidr"].(string)
 
 	ip, ok := input.Variables["tectonic_kube_apiserver_service_ip"].(string)

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -34,8 +34,8 @@ resource "template_dir" "tectonic" {
 
     etcd_cluster_size = "${var.master_count > 2 ? 3 : 1}"
 
-    license     = "${base64encode(file(var.license_path))}"
-    pull_secret = "${base64encode(file(var.pull_secret_path))}"
+    license     = "${base64encode(var.license)}"
+    pull_secret = "${base64encode(var.pull_secret)}"
     ca_cert     = "${base64encode(var.ca_cert)}"
 
     update_server  = "${var.update_server}"

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -18,16 +18,14 @@ variable "ingress_kind" {
   type        = "string"
 }
 
-variable "license_path" {
-  description = "Path on disk to your Tectonic license. Obtain this from your Tectonic Account: https://account.coreos.com."
+variable "license" {
+  description = "License used to run Tectonic. Obtain this from your Tectonic Account: https://account.coreos.com."
   type        = "string"
-  default     = "/Users/coreos/Desktop/tectonic-license.txt"
 }
 
-variable "pull_secret_path" {
+variable "pull_secret" {
+  description = "Authentication secret used to pull container images. Obtain this from your Tectonic Account: https://account.coreos.com."
   type        = "string"
-  description = "Path on disk to your Tectonic pull secret. Obtain this from your Tectonic Account: https://account.coreos.com."
-  default     = "/Users/coreos/Desktop/config.json"
 }
 
 variable "ca_generated" {

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -44,8 +44,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license     = "${var.tectonic_license}"
+  pull_secret = "${var.tectonic_pull_secret}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -45,8 +45,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license     = "${var.tectonic_license}"
+  pull_secret = "${var.tectonic_pull_secret}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -42,8 +42,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license     = "${var.tectonic_license}"
+  pull_secret = "${var.tectonic_pull_secret}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -43,8 +43,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license     = "${var.tectonic_license}"
+  pull_secret = "${var.tectonic_pull_secret}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"


### PR DESCRIPTION
This actually makes using the the SDK more complicated as multiple files need to be copied over and paths (relative/absolute) must be managed.

Tested on AWS.