### PR TITLE
Fix FQDNs for console ingress

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -36,7 +36,7 @@ resource "template_folder" "tectonic" {
     admin_email         = "${var.admin_email}"
     admin_password_hash = "${var.admin_password_hash}"
 
-    console_base_address = "https://${var.base_address}"
+    console_base_address = "${var.base_address}"
     console_client_id    = "${var.console_client_id}"
     console_secret       = "${random_id.console_secret.b64}"
     console_callback     = "https://${var.base_address}/auth/callback"

--- a/modules/tectonic/resources/manifests/config.yaml
+++ b/modules/tectonic/resources/manifests/config.yaml
@@ -8,6 +8,6 @@ data:
   installerPlatform: "${platform}"
   certificatesStrategy: "${certificates_strategy}"
   tectonicUpdaterEnabled: "true"
-  consoleBaseAddress: "${console_base_address}"
+  consoleBaseAddress: "https://${console_base_address}"
   kubeAPIServerURL: "${kube_apiserver_url}"
   tectonicVersion: "${tectonic_version}"


### PR DESCRIPTION
The ingress manifests are templated to inject the FQDN for the console.
Somehow, the variable carrying the FQDN value was also including `https://` before the actual name.
This is incompatible with Ingress manifest syntax and was causing the ingress creation to fail.

This change removes the `https://` prefix from the variable value. Instead, we set it in-line wherever the variable interpolation needs to include it.

@s-urbaniak @squat 