### PR TITLE
tectonic: replace curl with kubectl in the install script

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -76,6 +76,20 @@ resource "localfile_file" "tectonic" {
   destination = "${path.cwd}/generated/tectonic.sh"
 }
 
+# tectonic.sh (resources/generated/tectonic-rkt.sh)
+data "template_file" "tectonic-rkt" {
+  template = "${file("${path.module}/resources/tectonic-rkt.sh")}"
+
+  vars {
+    hyperkube_image = "${var.container_images["hyperkube"]}"
+  }
+}
+
+resource "localfile_file" "tectonic-rkt" {
+  content     = "${data.template_file.tectonic-rkt.rendered}"
+  destination = "${path.cwd}/generated/tectonic-rkt.sh"
+}
+
 # tectonic.service (available as output variable)
 data "template_file" "tectonic_service" {
   template = "${file("${path.module}/resources/tectonic.service")}"

--- a/modules/tectonic/resources/manifests/console/service.yaml
+++ b/modules/tectonic/resources/manifests/console/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: tectonic-console
+  namespace: tectonic-system
   labels:
     app: tectonic-console
     component: ui

--- a/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: tectonic-custom-error
+  namespace: tectonic-system
 data:
   custom-http-errors: "400,401,403,404,500,503,504"

--- a/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: default-http-backend
+  namespace: tectonic-system
 spec:
   replicas: 1
   template:

--- a/modules/tectonic/resources/manifests/ingress/default-backend/service.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: default-http-backend
+  namespace: tectonic-system
   labels:
    app: default-http-backend
 spec:

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: tectonic-ingress-controller
+  namespace: tectonic-system
   labels:
     app: tectonic-lb
     component: ingress-controller

--- a/modules/tectonic/resources/tectonic-rkt.sh
+++ b/modules/tectonic/resources/tectonic-rkt.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+/usr/bin/rkt run \
+  --trust-keys-from-https \
+  --volume assets,kind=host,source=$(pwd) \
+  --mount volume=assets,target=/assets \
+  ${hyperkube_image} \
+  --net=host \
+  --dns=host \
+  --working-dir=/assets/tectonic \
+  --exec=/bin/bash -- /assets/tectonic.sh /assets/kubeconfig /assets

--- a/modules/tectonic/resources/tectonic.service
+++ b/modules/tectonic/resources/tectonic.service
@@ -12,7 +12,7 @@ WorkingDirectory=/opt/tectonic
 User=root
 Group=root
 
-ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic
+ExecStart=/usr/bin/bash /opt/tectonic/tectonic-rkt.sh
 ExecStartPost=/bin/touch /opt/tectonic/init_tectonic.done
 
 [Install]


### PR DESCRIPTION
This replaces the curl based logic in tectonic.sh with kubectl.
It launches a rkt container using the hyperkube image and applies the
configuration.

It also fixes implicit namespace creation for services which were
created previously in the tectonic-system namespace implicitely.

Fixes #86

/cc @alexsomesan