### PR TITLE
flannel: use IANA port 4789 for vxlan

### DIFF
--- a/modules/bootkube/resources/manifests/kube-flannel.yaml
+++ b/modules/bootkube/resources/manifests/kube-flannel.yaml
@@ -19,7 +19,8 @@ data:
     {
       "Network": "${cluster_cidr}",
       "Backend": {
-        "Type": "vxlan"
+        "Type": "vxlan",
+        "Port": 4789
       }
     }
 ---

--- a/modules/openstack/nodes/secgroup.tf
+++ b/modules/openstack/nodes/secgroup.tf
@@ -22,4 +22,11 @@ resource "openstack_compute_secgroup_v2" "node" {
     ip_protocol = "icmp"
     cidr        = "0.0.0.0/0"
   }
+
+  rule {
+    from_port   = 4789
+    to_port     = 4789
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
 }


### PR DESCRIPTION
CNI doesn't set any port explicitely for vxlan, hence it defaults to the
Linux default, which is 8472, see
http://lxr.free-electrons.com/source/drivers/net/vxlan.c#L43.

Setting it to 4789 makes tools like `tcpdump -vv` happily decode encapsulated VXLAN
packets for better debugability.

Also open port 4789 explicitely in Openstack to prevent sporadic communication
problems between nodes.