### PR TITLE
modules/{bootkube,tectonic}: use the tectonic provider

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -1,5 +1,5 @@
 # Self-hosted manifests (resources/generated/manifests/)
-resource "template_folder" "bootkube" {
+resource "tectonic_template_folder" "bootkube" {
   input_path  = "${path.module}/resources/manifests"
   output_path = "${path.cwd}/generated/manifests"
 
@@ -46,7 +46,7 @@ data "template_file" "kubeconfig" {
   }
 }
 
-resource "localfile_file" "kubeconfig" {
+resource "tectonic_local_file" "kubeconfig" {
   content     = "${data.template_file.kubeconfig.rendered}"
   destination = "${path.cwd}/generated/kubeconfig"
 }
@@ -61,7 +61,7 @@ data "template_file" "bootkube" {
   }
 }
 
-resource "localfile_file" "bootkube" {
+resource "tectonic_local_file" "bootkube" {
   content     = "${data.template_file.bootkube.rendered}"
   destination = "${path.cwd}/generated/bootkube.sh"
 }

--- a/modules/bootkube/assets_tls.tf
+++ b/modules/bootkube/assets_tls.tf
@@ -39,12 +39,12 @@ resource "tls_self_signed_cert" "kube-ca" {
   ]
 }
 
-resource "localfile_file" "kube-ca-key" {
+resource "tectonic_local_file" "kube-ca-key" {
   content = "${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"
   destination = "${path.cwd}/generated/tls/ca.key"
 }
 
-resource "localfile_file" "kube-ca-crt" {
+resource "tectonic_local_file" "kube-ca-crt" {
   content = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert}"
   destination = "${path.cwd}/generated/tls/ca.crt"
 }
@@ -93,12 +93,12 @@ resource "tls_locally_signed_cert" "apiserver" {
   ]
 }
 
-resource "localfile_file" "apiserver-key" {
+resource "tectonic_local_file" "apiserver-key" {
   content = "${tls_private_key.apiserver.private_key_pem}"
   destination = "${path.cwd}/generated/tls/apiserver.key"
 }
 
-resource "localfile_file" "apiserver-crt" {
+resource "tectonic_local_file" "apiserver-crt" {
   content = "${tls_locally_signed_cert.apiserver.cert_pem}"
   destination = "${path.cwd}/generated/tls/apiserver.crt"
 }
@@ -109,12 +109,12 @@ resource "tls_private_key" "service-account" {
   rsa_bits = "2048"
 }
 
-resource "localfile_file" "service-account-key" {
+resource "tectonic_local_file" "service-account-key" {
   content = "${tls_private_key.service-account.private_key_pem}"
   destination = "${path.cwd}/generated/tls/service-account.key"
 }
 
-resource "localfile_file" "service-account-crt" {
+resource "tectonic_local_file" "service-account-crt" {
   content = "${tls_private_key.service-account.public_key_pem}"
   destination = "${path.cwd}/generated/tls/service-account.pub"
 }
@@ -151,12 +151,12 @@ resource "tls_locally_signed_cert" "kubelet" {
   ]
 }
 
-resource "localfile_file" "kubelet-key" {
+resource "tectonic_local_file" "kubelet-key" {
   content = "${tls_private_key.kubelet.private_key_pem}"
   destination = "${path.cwd}/generated/tls/kubelet.key"
 }
 
-resource "localfile_file" "kubelet-crt" {
+resource "tectonic_local_file" "kubelet-crt" {
   content = "${tls_locally_signed_cert.kubelet.cert_pem}"
   destination = "${path.cwd}/generated/tls/kubelet.crt"
 }

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -11,12 +11,12 @@
 # be used as part of the output filename, in order to enforce the creation of
 # the archive after the assets have been properly generated.
 #
-# Both localfile and template_folder providers compute their IDs by hashing
+# Both localfile and tectonic_template_folder providers compute their IDs by hashing
 # the content of the resources on disk. Because this output is computed from the
 # combination of all the resources' IDs, it can't be guessed and can only be
 # interpolated once the assets have all been created.
 output "id" {
-  value = "${sha1("${template_folder.bootkube.id} ${localfile_file.kubeconfig.id} ${localfile_file.bootkube.id}")}"
+  value = "${sha1("${tectonic_template_folder.bootkube.id} ${tectonic_local_file.kubeconfig.id} ${tectonic_local_file.bootkube.id}")}"
 }
 
 output "kubeconfig" {

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -1,6 +1,6 @@
 # Kubernetes Manifests (resources/generated/manifests/)
 ## github.com/coreos-inc/tectonic/commit/0b48144d5332201cf461a309d501b33a00a26f75
-resource "template_folder" "tectonic" {
+resource "tectonic_template_folder" "tectonic" {
   input_path  = "${path.module}/resources/manifests"
   output_path = "${path.cwd}/generated/tectonic"
 
@@ -71,7 +71,7 @@ data "template_file" "tectonic" {
   }
 }
 
-resource "localfile_file" "tectonic" {
+resource "tectonic_local_file" "tectonic" {
   content     = "${data.template_file.tectonic.rendered}"
   destination = "${path.cwd}/generated/tectonic.sh"
 }

--- a/modules/tectonic/output.tf
+++ b/modules/tectonic/output.tf
@@ -11,12 +11,12 @@
 # be used as part of the output filename, in order to enforce the creation of
 # the archive after the assets have been properly generated.
 #
-# Both localfile and template_folder providers compute their IDs by hashing
+# Both localfile and tectonic_template_folder providers compute their IDs by hashing
 # the content of the resources on disk. Because this output is computed from the
 # combination of all the resources' IDs, it can't be guessed and can only be
 # interpolated once the assets have all been created.
 output "id" {
-  value = "${sha1("${template_folder.tectonic.id} ${localfile_file.tectonic.id}")}"
+  value = "${sha1("${tectonic_template_folder.tectonic.id} ${tectonic_local_file.tectonic.id}")}"
 }
 
 output "systemd_service" {


### PR DESCRIPTION
This commit is intended to be merged at the same time as the next Tectonic release. It will enable users to use the upstream TerraForm binaries, alongside with a plugin called `tectonic`, that is the Tectonic binary. That, until the plugins are upstreamed.

It'll require a documentation update in order to explain how the `.terraformrc` file has to be modified for this to work. At the same time, we will also be able to remove:
- The Makefile targets for TerraForm,
- The TerraForm fork.