### PR TITLE
aws: deploy vanilla k8s cluster

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -146,17 +146,22 @@ variable "tectonic_admin_password_hash" {
 variable "tectonic_ca_cert" {
   type        = "string"
   description = "PEM-encoded CA certificate, used to generate Tectonic Console's server certificate. Optional, if left blank, a CA certificate will be automatically generated."
-  default = ""
+  default     = ""
 }
 
 variable "tectonic_ca_key" {
   type        = "string"
   description = "PEM-encoded CA key, used to generate Tectonic Console's server certificate. Optional if tectonic_ca_cert is left blank"
-  default = ""
+  default     = ""
 }
 
 variable "tectonic_ca_key_alg" {
   type        = "string"
   description = "Algorithm used to generate tectonic_ca_key. Optional if tectonic_ca_cert is left blank."
   default     = "RSA"
+}
+
+variable "tectonic_vanilla_k8s" {
+  description = "If set to true, a vanilla Kubernetes cluster will be deployed, omitting the tectonic assets."
+  default     = false
 }

--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -123,5 +123,6 @@ resource "ignition_systemd_unit" "bootkube" {
 
 resource "ignition_systemd_unit" "tectonic" {
   name    = "tectonic.service"
+  enable  = "${var.tectonic_service_disabled == 0 ? true : false}"
   content = "${var.tectonic_service}"
 }

--- a/modules/aws/ignition/variables.tf
+++ b/modules/aws/ignition/variables.tf
@@ -35,5 +35,10 @@ variable "bootkube_service" {
 
 variable "tectonic_service" {
   type        = "string"
-  description = "The content of the tectonic systemd service unit"
+  description = "The content of the tectonic installer systemd service unit"
+}
+
+variable "tectonic_service_disabled" {
+  description = "Specifies whether the tectonic installer systemd unit will be disabled. If true, no tectonic assets will be deployed"
+  default     = false
 }

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -36,14 +36,15 @@ module "etcd" {
 module "ignition-masters" {
   source = "../../modules/aws/ignition"
 
-  kubelet_node_label     = "master=true"
-  kube_dns_service_ip    = "${var.tectonic_kube_dns_service_ip}"
-  etcd_endpoints         = ["${module.etcd.endpoints}"]
-  kubeconfig_s3_location = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
-  assets_s3_location     = "${aws_s3_bucket_object.tectonic-assets.bucket}/${aws_s3_bucket_object.tectonic-assets.key}"
-  container_images       = "${var.tectonic_container_images}"
-  bootkube_service       = "${module.bootkube.systemd_service}"
-  tectonic_service       = "${module.tectonic.systemd_service}"
+  kubelet_node_label        = "master=true"
+  kube_dns_service_ip       = "${var.tectonic_kube_dns_service_ip}"
+  etcd_endpoints            = ["${module.etcd.endpoints}"]
+  kubeconfig_s3_location    = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
+  assets_s3_location        = "${aws_s3_bucket_object.tectonic-assets.bucket}/${aws_s3_bucket_object.tectonic-assets.key}"
+  container_images          = "${var.tectonic_container_images}"
+  bootkube_service          = "${module.bootkube.systemd_service}"
+  tectonic_service          = "${module.tectonic.systemd_service}"
+  tectonic_service_disabled = "${var.tectonic_vanilla_k8s}"
 }
 
 module "masters" {


### PR DESCRIPTION
This introduces a new variable "tectonic_vanilla_k8s" which omits deploying tectonic assets if set to true.

/cc @mxinden @alexsomesan