### PR TITLE
Make node role labels consistent with other probjects

### DIFF
--- a/Documentation/generic-platform.md
+++ b/Documentation/generic-platform.md
@@ -33,8 +33,8 @@ Master nodes run most, if not all, control plane components including the API se
   - MUST have any necessary API access for k8s cloud plugin functionality (i.e. AWS node IAM Role) 
 
 - **Cloud-init/Ignition:**
-  - MUST run the kubelet with label node-role.kubernetes.io/master=true 
-  - MAY run the kubelet with label with label node-role.kubernetes.io/node=true 
+  - MUST run the kubelet with label node-role.kubernetes.io/master 
+  - MAY run the kubelet with label with label node-role.kubernetes.io/node 
 
 
 ### Infra Nodes (Optional) or Load Balancers

--- a/modules/azure/master/ignition-master.tf
+++ b/modules/azure/master/ignition-master.tf
@@ -46,6 +46,7 @@ data "template_file" "kubelet-master" {
   template = "${file("${path.module}/resources/master-kubelet.service")}"
 
   vars {
+    node_label     = "${var.kubelet_node_label}"
     cloud_provider = "${var.cloud_provider}"
     cluster_dns    = "${var.tectonic_kube_dns_service_ip}"
   }

--- a/modules/azure/master/resources/master-kubelet.service
+++ b/modules/azure/master/resources/master-kubelet.service
@@ -26,7 +26,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --exit-on-lock-contention \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --allow-privileged \
-  --node-labels=master=true \
+  --node-labels=${node_label} \
   --minimum-container-ttl-duration=6m0s \
   --cluster_dns=${cluster_dns} \
   --cluster_domain=cluster.local \

--- a/modules/azure/master/variables.tf
+++ b/modules/azure/master/variables.tf
@@ -73,3 +73,7 @@ variable "cloud_provider" {
   type    = "string"
   default = "azure"
 }
+
+variable "kubelet_node_label" {
+  type = "string"
+}

--- a/modules/azure/worker/ignition-worker.tf
+++ b/modules/azure/worker/ignition-worker.tf
@@ -37,6 +37,7 @@ data "template_file" "kubelet-worker" {
   template = "${file("${path.module}/resources/worker-kubelet.service")}"
 
   vars {
+    node_label     = "${var.kubelet_node_label}"
     cloud_provider = "${var.cloud_provider}"
     cluster_dns    = "${var.tectonic_kube_dns_service_ip}"
   }

--- a/modules/azure/worker/resources/worker-kubelet.service
+++ b/modules/azure/worker/resources/worker-kubelet.service
@@ -26,7 +26,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --exit-on-lock-contention \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --allow-privileged \
-  --node-labels=node=true \
+  --node-labels=${node_label} \
   --minimum-container-ttl-duration=6m0s \
   --cluster_dns=${cluster_dns} \
   --cluster_domain=cluster.local \

--- a/modules/azure/worker/variables.tf
+++ b/modules/azure/worker/variables.tf
@@ -74,3 +74,7 @@ variable "cloud_provider" {
   type    = "string"
   default = "azure"
 }
+
+variable "kubelet_node_label" {
+  type = "string"
+}

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -14,7 +14,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       hostNetwork: true
       containers:
       - name: kube-apiserver

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -13,7 +13,7 @@ spec:
         k8s-app: kube-controller-manager
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       containers:
       - name: kube-controller-manager
         image: ${hyperkube_image}

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -13,7 +13,7 @@ spec:
         k8s-app: kube-scheduler
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       containers:
       - name: kube-scheduler
         image: ${hyperkube_image}

--- a/modules/bootkube/resources/manifests/pod-checkpoint-installer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpoint-installer.yaml
@@ -12,7 +12,7 @@ spec:
         k8s-app: pod-checkpoint-installer
     spec:
       nodeSelector:
-        master: "true"
+        node-role.kubernetes.io/master: ""
       hostNetwork: true
       containers:
       - name: checkpoint-installer

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -36,7 +36,7 @@ module "etcd" {
 module "ignition-masters" {
   source = "../../modules/aws/ignition"
 
-  kubelet_node_label        = "master=true"
+  kubelet_node_label        = "node-role.kubernetes.io/master"
   kube_dns_service_ip       = "${var.tectonic_kube_dns_service_ip}"
   etcd_endpoints            = ["${module.etcd.endpoints}"]
   kubeconfig_s3_location    = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
@@ -70,7 +70,7 @@ module "masters" {
 module "ignition-workers" {
   source = "../../modules/aws/ignition"
 
-  kubelet_node_label     = ""
+  kubelet_node_label     = "node-role.kubernetes.io/node"
   kube_dns_service_ip    = "${var.tectonic_kube_dns_service_ip}"
   etcd_endpoints         = ["${module.etcd.endpoints}"]
   kubeconfig_s3_location = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -49,6 +49,7 @@ module "masters" {
   tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   cloud_provider               = ""
+  kubelet_node_label           = "node-role.kubernetes.io/master"
 }
 
 module "workers" {
@@ -72,6 +73,7 @@ module "workers" {
   tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   cloud_provider               = ""
+  kubelet_node_label           = "node-role.kubernetes.io/node"
 }
 
 module "dns" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -102,7 +102,7 @@ EOF
   bootkube_service             = "${module.bootkube.systemd_service}"
   tectonic_service             = "${module.tectonic.systemd_service}"
   hostname_infix               = "master"
-  node_labels                  = "master=true"
+  node_labels                  = "node-role.kubernetes.io/master"
 }
 
 module "worker_nodes" {
@@ -126,7 +126,7 @@ EOF
   bootkube_service             = ""
   tectonic_service             = ""
   hostname_infix               = "worker"
-  node_labels                  = "worker=true"
+  node_labels                  = "node-role.kubernetes.io/node"
 }
 
 module "secrets" {

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -102,7 +102,7 @@ EOF
   bootkube_service             = "${module.bootkube.systemd_service}"
   tectonic_service             = "${module.tectonic.systemd_service}"
   hostname_infix               = "master"
-  node_labels                  = "master=true"
+  node_labels                  = "node-role.kubernetes.io/master"
 }
 
 module "worker_nodes" {
@@ -126,7 +126,7 @@ EOF
   bootkube_service             = ""
   tectonic_service             = ""
   hostname_infix               = "worker"
-  node_labels                  = "worker=true"
+  node_labels                  = "node-role.kubernetes.io/node"
 }
 
 module "secrets" {


### PR DESCRIPTION
To be consistent with other tools in community:

https://github.com/kubernetes/kubeadm/issues/150#issuecomment-280986966
https://github.com/kubernetes/kubernetes/pull/41835

Original discussion: https://github.com/kubernetes/kubernetes/pull/39112

Originally a value of `true` was proposed, but looks like it might be extraneous and other tools (kubeadm, for example) are not populating the value.

/cc @alexsomesan @Quentin-M @aaronlevy