### PR TITLE
aws/init-assets: fix systemd dependency

### DIFF
--- a/modules/aws/ignition/resources/services/init-assets.service
+++ b/modules/aws/ignition/resources/services/init-assets.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Download Tectonic Assets
 ConditionPathExists=!/opt/tectonic/init_assets.done
-RequiredBy=bootkube.service
 Before=bootkube.service
 
 [Service]
@@ -17,3 +16,4 @@ ExecStartPost=/bin/touch /opt/tectonic/init_assets.done
 
 [Install]
 WantedBy=multi-user.target
+RequiredBy=bootkube.service


### PR DESCRIPTION
WantedBy/Before needs to be in the [Install] section rather than in the
[Unit] section of the systemd unit.

This fixes it.