### PR TITLE
aws: allow custom tags for AWS resources

### DIFF
--- a/modules/aws/etcd/network.tf
+++ b/modules/aws/etcd/network.tf
@@ -2,10 +2,10 @@ resource "aws_security_group" "etcd_sec_group" {
   vpc_id = "${var.vpc_id}"
   count  = "${length(var.external_endpoints) == 0 ? 1 : 0}"
 
-  tags {
-    Name              = "${var.cluster_name}_etcd_sg"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}_etcd_sg",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 
   ingress {
     protocol  = -1

--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -32,8 +32,8 @@ resource "aws_instance" "etcd_node" {
   user_data              = "${ignition_config.etcd.*.rendered[count.index]}"
   vpc_security_group_ids = ["${aws_security_group.etcd_sec_group.id}"]
 
-  tags {
-    Name              = "${var.cluster_name}-etcd-${count.index}"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}-etcd-${count.index}",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }

--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -45,3 +45,9 @@ variable "container_image" {
 variable "ec2_type" {
   type = "string"
 }
+
+variable "extra_tags" {
+  description = "Extra AWS tags to be applied to created resources."
+  type        = "map"
+  default     = {}
+}

--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -26,10 +26,10 @@ resource "aws_elb" "api-internal" {
     interval            = 5
   }
 
-  tags {
-    Name              = "${var.cluster_name}-api-internal"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}-api-internal",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 resource "aws_route53_record" "api-internal" {
@@ -73,10 +73,10 @@ resource "aws_elb" "api-external" {
     interval            = 5
   }
 
-  tags {
-    Name              = "${var.cluster_name}-api-external"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}-api-external",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 resource "aws_route53_record" "api-external" {
@@ -120,10 +120,10 @@ resource "aws_elb" "console" {
     interval            = 5
   }
 
-  tags {
-    Name              = "${var.cluster_name}-console"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}-console",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 resource "aws_route53_record" "ingress-public" {

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -48,6 +48,8 @@ resource "aws_autoscaling_group" "masters" {
     propagate_at_launch = true
   }
 
+  tags = ["${var.autoscaling_group_extra_tags}"]
+
   lifecycle {
     create_before_destroy = true
   }
@@ -71,10 +73,10 @@ resource "aws_launch_configuration" "master_conf" {
 resource "aws_security_group" "master_sec_group" {
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name              = "${var.cluster_name}_master_sg"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}_master_sg",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 
   ingress {
     protocol  = -1

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -54,3 +54,15 @@ variable "public_vpc" {
   description = "If set to true, public facing ingress resource are created."
   default     = true
 }
+
+variable "extra_tags" {
+  description = "Extra AWS tags to be applied to created resources."
+  type        = "map"
+  default     = {}
+}
+
+variable "autoscaling_group_extra_tags" {
+  description = "Extra AWS tags to be applied to created autoscaling group resources."
+  type        = "list"
+  default     = []
+}

--- a/modules/aws/vpc/security-groups.tf
+++ b/modules/aws/vpc/security-groups.tf
@@ -15,4 +15,9 @@ resource "aws_security_group" "cluster_default" {
     self        = true
     cidr_blocks = ["0.0.0.0/0"]
   }
+
+  tags = "${merge(map(
+    "Name","${var.cluster_name}-sg-cluster_default",
+    "KubernetesCluster", "${var.cluster_name}"
+  ), var.extra_tags)}"
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -21,3 +21,9 @@ variable "external_master_subnets" {
 variable "external_worker_subnets" {
   type = "list"
 }
+
+variable "extra_tags" {
+  description = "Extra AWS tags to be applied to created resources."
+  type        = "map"
+  default     = {}
+}

--- a/modules/aws/vpc/vpc-private.tf
+++ b/modules/aws/vpc/vpc-private.tf
@@ -2,10 +2,10 @@ resource "aws_route_table" "private_routes" {
   count  = "${var.external_vpc_id == "" ? var.az_count : 0}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name              = "private-${data.aws_availability_zones.azs.names[count.index]}"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "private-${data.aws_availability_zones.azs.names[count.index]}",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 resource "aws_route" "to_nat_gw" {
@@ -22,11 +22,11 @@ resource "aws_subnet" "worker_subnet" {
   vpc_id            = "${data.aws_vpc.cluster_vpc.id}"
   availability_zone = "${data.aws_availability_zones.azs.names[count.index]}"
 
-  tags {
-    Name                              = "worker-${data.aws_availability_zones.azs.names[count.index]}"
-    KubernetesCluster                 = "${var.cluster_name}"
-    "kubernetes.io/role/internal-elb" = ""
-  }
+  tags = "${merge(map(
+      "Name", "worker-${data.aws_availability_zones.azs.names[count.index]}",
+      "KubernetesCluster", "${var.cluster_name}",
+      "kubernetes.io/role/internal-elb", ""
+    ), var.extra_tags)}"
 }
 
 resource "aws_route_table_association" "worker_routing" {

--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -7,10 +7,10 @@ resource "aws_route_table" "default" {
   count  = "${var.external_vpc_id == "" ? 1 : 0}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  tags {
-    Name              = "public"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "public",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 resource "aws_main_route_table_association" "main_vpc_routes" {
@@ -32,11 +32,10 @@ resource "aws_subnet" "master_subnet" {
   vpc_id            = "${data.aws_vpc.cluster_vpc.id}"
   availability_zone = "${data.aws_availability_zones.azs.names[count.index]}"
 
-  tags {
-    Name                     = "master-${data.aws_availability_zones.azs.names[count.index]}"
-    KubernetesCluster        = "${var.cluster_name}"
-    "kubernetes.io/role/elb" = ""
-  }
+  tags = "${merge(map(
+      "Name", "master-${data.aws_availability_zones.azs.names[count.index]}",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 resource "aws_route_table_association" "route_net" {

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -6,10 +6,10 @@ resource "aws_vpc" "new_vpc" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  tags {
-    Name              = "${var.cluster_name}"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 }
 
 data "aws_vpc" "cluster_vpc" {

--- a/modules/aws/worker-asg/security-groups.tf
+++ b/modules/aws/worker-asg/security-groups.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "worker_sec_group" {
   vpc_id = "${var.vpc_id}"
 
-  tags {
-    Name              = "${var.cluster_name}_worker_sg"
-    KubernetesCluster = "${var.cluster_name}"
-  }
+  tags = "${merge(map(
+      "Name", "${var.cluster_name}_worker_sg",
+      "KubernetesCluster", "${var.cluster_name}"
+    ), var.extra_tags)}"
 
   ingress {
     protocol  = -1

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -34,3 +34,15 @@ variable "user_data" {
   type        = "string"
   description = "User-data content used to boot the instances"
 }
+
+variable "extra_tags" {
+  description = "Extra AWS tags to be applied to created resources."
+  type        = "map"
+  default     = {}
+}
+
+variable "autoscaling_group_extra_tags" {
+  description = "Extra AWS tags to be applied to created autoscaling group resources."
+  type        = "list"
+  default     = []
+}

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -56,6 +56,8 @@ resource "aws_autoscaling_group" "workers" {
     propagate_at_launch = true
   }
 
+  tags = ["${var.autoscaling_group_extra_tags}"]
+
   lifecycle {
     create_before_destroy = true
   }

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -10,6 +10,7 @@ module "vpc" {
   external_vpc_id         = "${var.tectonic_aws_external_vpc_id}"
   external_master_subnets = ["${compact(var.tectonic_aws_external_master_subnet_ids)}"]
   external_worker_subnets = ["${compact(var.tectonic_aws_external_worker_subnet_ids)}"]
+  extra_tags              = "${var.tectonic_aws_extra_tags}"
 }
 
 module "etcd" {
@@ -31,6 +32,7 @@ module "etcd" {
   cluster_name = "${var.tectonic_cluster_name}"
 
   external_endpoints = ["${compact(var.tectonic_etcd_servers)}"]
+  extra_tags         = "${var.tectonic_aws_extra_tags}"
 }
 
 module "ignition-masters" {
@@ -62,10 +64,12 @@ module "masters" {
   cl_channel = "${var.tectonic_cl_channel}"
   user_data  = "${module.ignition-masters.ignition}"
 
-  internal_zone_id = "${aws_route53_zone.tectonic-int.zone_id}"
-  external_zone_id = "${join("", data.aws_route53_zone.tectonic-ext.*.zone_id)}"
-  base_domain      = "${var.tectonic_base_domain}"
-  public_vpc       = "${var.tectonic_aws_external_vpc_public}"
+  internal_zone_id             = "${aws_route53_zone.tectonic-int.zone_id}"
+  external_zone_id             = "${join("", data.aws_route53_zone.tectonic-ext.*.zone_id)}"
+  base_domain                  = "${var.tectonic_base_domain}"
+  public_vpc                   = "${var.tectonic_aws_external_vpc_public}"
+  extra_tags                   = "${var.tectonic_aws_extra_tags}"
+  autoscaling_group_extra_tags = "${var.tectonic_autoscaling_group_extra_tags}"
 }
 
 module "ignition-workers" {
@@ -92,7 +96,9 @@ module "workers" {
   subnet_ids   = ["${module.vpc.worker_subnet_ids}"]
   extra_sg_ids = ["${module.vpc.cluster_default_sg}"]
 
-  ssh_key    = "${var.tectonic_aws_ssh_key}"
-  cl_channel = "${var.tectonic_cl_channel}"
-  user_data  = "${module.ignition-workers.ignition}"
+  ssh_key                      = "${var.tectonic_aws_ssh_key}"
+  cl_channel                   = "${var.tectonic_cl_channel}"
+  user_data                    = "${module.ignition-workers.ignition}"
+  extra_tags                   = "${var.tectonic_aws_extra_tags}"
+  autoscaling_group_extra_tags = "${var.tectonic_autoscaling_group_extra_tags}"
 }

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -54,3 +54,15 @@ variable "tectonic_aws_external_worker_subnet_ids" {
   description = "List of subnet IDs within an existing VPC to deploy worker nodes into. Required to use an existing VPC and the list must match the AZ count. Example: [\"subnet-111111\", \"subnet-222222\", \"subnet-333333\"]"
   default     = [""]
 }
+
+variable "tectonic_aws_extra_tags" {
+  description = "Extra AWS tags to be applied to created resources."
+  type        = "map"
+  default     = {}
+}
+
+variable "tectonic_autoscaling_group_extra_tags" {
+  description = "Extra AWS tags to be applied to created autoscaling group resources."
+  type        = "list"
+  default     = []
+}

--- a/terraform.mk
+++ b/terraform.mk
@@ -1,8 +1,8 @@
 TOP_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
 TERRAFORM_REPOSITORY=https://github.com/coreos/terraform.git
-TERRAFORM_BRANCH=v0.8.8-coreos
-TERRAFORM_RELEASE_TARBALL_URL=https://github.com/coreos/terraform/releases/download/v0.8.8-coreos/terraform.zip
+TERRAFORM_BRANCH=v0.8.8-coreos.1
+TERRAFORM_RELEASE_TARBALL_URL=https://github.com/coreos/terraform/releases/download/v0.8.8-coreos.1/terraform.zip
 TERRAFORM_BUILD_DIR=$(TOP_DIR)/build/terraform
 TERRAFORM_BINS_DIR=$(TOP_DIR)/bin/terraform
 TERRAFORM_GO_IMAGE=golang:1.8


### PR DESCRIPTION
With the exception of autoscaling groups this allows for custom tags on AWS resources.

The autoscaling group resource is tricky, because it is not a map type, but rather a map of strings to objects which prevents us from using interpolation syntax in the templates.

We are figuring out ways to implement this feature, but it will probably mean introducing a new field to the autoscaling group resource object in terraform.

Fixes #204