### PR TITLE
modules/tectonic: fix identity_api_service

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -61,6 +61,7 @@ resource "template_folder" "tectonic" {
     cluster_id            = "${uuid()}"
     platform              = "${var.platform}"
     certificates_strategy = "${var.ca_generated == "true" ? "installerGeneratedCA" : "userProvidedCA"}"
+    identity_api_service  = "${var.identity_api_service}"
   }
 }
 


### PR DESCRIPTION
PR #231 introduced identity_api_service in
modules/tectonic/resources/manifests/config.yaml but does not propagate
the variable in assets.tf

This fixes it.