### PR TITLE
modules/azure: use provisioned tectonic and bootkube service

### DIFF
--- a/modules/azure/master/ignition-master.tf
+++ b/modules/azure/master/ignition-master.tf
@@ -11,6 +11,7 @@ resource "ignition_config" "master" {
     "${ignition_systemd_unit.locksmithd.id}",
     "${ignition_systemd_unit.kubelet-master.id}",
     "${ignition_systemd_unit.tectonic.id}",
+    "${ignition_systemd_unit.bootkube.id}",
   ]
 
   users = [
@@ -112,17 +113,13 @@ resource "ignition_file" "max-user-watches" {
   }
 }
 
-resource "ignition_systemd_unit" "tectonic" {
-  name   = "tectonic.service"
-  enable = true
+resource "ignition_systemd_unit" "bootkube" {
+  name    = "bootkube.service"
+  content = "${var.bootkube_service}"
+}
 
-  content = <<EOF
-[Unit]
-Description=Bootstrap a Tectonic cluster
-[Service]
-Type=oneshot
-WorkingDirectory=/opt/tectonic
-ExecStart=/usr/bin/bash /opt/tectonic/bootkube.sh
-ExecStart=/usr/bin/bash /opt/tectonic/tectonic.sh kubeconfig tectonic
-EOF
+resource "ignition_systemd_unit" "tectonic" {
+  name    = "tectonic.service"
+  enable  = "${var.tectonic_service_disabled == 0 ? true : false}"
+  content = "${var.tectonic_service}"
 }

--- a/modules/azure/master/variables.tf
+++ b/modules/azure/master/variables.tf
@@ -77,3 +77,18 @@ variable "cloud_provider" {
 variable "kubelet_node_label" {
   type = "string"
 }
+
+variable "bootkube_service" {
+  type        = "string"
+  description = "The content of the bootkube systemd service unit"
+}
+
+variable "tectonic_service" {
+  type        = "string"
+  description = "The content of the tectonic installer systemd service unit"
+}
+
+variable "tectonic_service_disabled" {
+  description = "Specifies whether the tectonic installer systemd unit will be disabled. If true, no tectonic assets will be deployed"
+  default     = false
+}

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -50,6 +50,9 @@ module "masters" {
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   cloud_provider               = ""
   kubelet_node_label           = "node-role.kubernetes.io/master"
+  bootkube_service             = "${module.bootkube.systemd_service}"
+  tectonic_service             = "${module.tectonic.systemd_service}"
+  tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 }
 
 module "workers" {


### PR DESCRIPTION
Currently the azure platforms directly invokes bootkube.sh and
tectonic.sh. This fixes it by using the provisioned systemd services.

Fixes #240

Tested successfully on Azure.

/cc @alexsomesan @sozercan @coresolve