### PR TITLE
platforms/aws: respect tectonic_etcd_count variable

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -85,8 +85,8 @@ variable "tectonic_worker_count" {
 // Example: `1`
 variable "tectonic_etcd_count" {
   type        = "string"
-  default     = "1"
-  description = "The number of etcd nodes to be created."
+  default     = "-1"
+  description = "The number of etcd nodes to be created. If not set, the count of etcd nodes will be determined automatically (currently only supported on AWS)."
 }
 
 variable "tectonic_etcd_servers" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -16,7 +16,7 @@ module "vpc" {
 module "etcd" {
   source = "../../modules/aws/etcd"
 
-  instance_count = "${var.tectonic_aws_az_count == 5 ? 5 : 3}"
+  instance_count = "${var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : var.tectonic_aws_az_count == 5 ? 5 : 3}"
   az_count       = "${var.tectonic_aws_az_count}"
   ec2_type       = "${var.tectonic_aws_etcd_ec2_type}"
 


### PR DESCRIPTION
If tectonic_etcd_count is set, use it. If unset retain the current
behavior to imply the amount of etcd nodes based on the count of
availability zones.

Fixes #213