### PR TITLE
platforms/aws: by default create the VPC for the user

### DIFF
--- a/platforms/aws/terraform.tfvars.example
+++ b/platforms/aws/terraform.tfvars.example
@@ -23,11 +23,12 @@ tectonic_aws_worker_ec2_type = "t2.medium"
 tectonic_aws_etcd_ec2_type = "t2.medium"
 
 # VPC Details
-# specify an existing VPC to use, or leave blank to create a new one
-tectonic_aws_az_count = 3 # some AWS regions only have 2!
-tectonic_aws_external_vpc_id = "vpc-123456"
-tectonic_aws_external_master_subnet_ids = ["subnet-111111", "subnet-222222", "subnet-333333"] # must match AZ count 
-tectonic_aws_external_worker_subnet_ids = ["subnet-111111", "subnet-222222", "subnet-333333"] # must match AZ count 
+# Uncomment to use an existing VPC to use, or leave as is to create a new one
+# 
+# tectonic_aws_az_count = 3 # some AWS regions only have 2!
+# tectonic_aws_external_vpc_id = "vpc-123456"
+# tectonic_aws_external_master_subnet_ids = ["subnet-111111", "subnet-222222", "subnet-333333"] # must match AZ count 
+# tectonic_aws_external_worker_subnet_ids = ["subnet-111111", "subnet-222222", "subnet-333333"] # must match AZ count 
 
 # Update Details
 # leave blank for default values


### PR DESCRIPTION
If you follow the AWS getting started guide, you'll likely hit the
following error because terraform tries to refer to non-existent
VPC resources by default:

    $ terraform apply -var-file=build/${CLUSTER}/terraform.tfvars platforms/aws
    # ...
    Error refreshing state: 8 error(s) occurred:

    * data.aws_subnet.external_master.2: InvalidSubnetID.NotFound: The subnet ID 'subnet-333333' does not exist
    	status code: 400, request id: 5bf3c607-4f50-41a0-82f7-38cd0ce162e3
    * data.aws_subnet.external_master.0: InvalidSubnetID.NotFound: The subnet ID 'subnet-111111' does not exist
	status code: 400, request id: 16c136e8-1492-4607-b935-71c32f35d0eb
    * data.aws_subnet.external_master.1: InvalidSubnetID.NotFound: The subnet ID 'subnet-222222' does not exist
	status code: 400, request id: 7fa2fbd4-fa13-48e5-938a-6b0046b6bfcf
    # ...

Consider just creating the VPC instead. Users who want to use an
existing one can uncomment the variables.