### PR TITLE
Update default IOPS for AWS gp2 volumes to 100

### DIFF
--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -88,7 +88,7 @@ variable "tectonic_aws_etcd_root_volume_size" {
 
 variable "tectonic_aws_etcd_root_volume_iops" {
   type        = "string"
-  default     = "0"
+  default     = "100"
   description = "The amount of provisioned IOPS for the root block device of etcd nodes."
 }
 
@@ -106,7 +106,7 @@ variable "tectonic_aws_master_root_volume_size" {
 
 variable "tectonic_aws_master_root_volume_iops" {
   type        = "string"
-  default     = "0"
+  default     = "100"
   description = "The amount of provisioned IOPS for the root block device of master nodes."
 }
 
@@ -124,6 +124,6 @@ variable "tectonic_aws_worker_root_volume_size" {
 
 variable "tectonic_aws_worker_root_volume_iops" {
   type        = "string"
-  default     = "0"
+  default     = "100"
   description = "The amount of provisioned IOPS for the root block device of worker nodes."
 }


### PR DESCRIPTION
The minimum value for gp2 IOPS is 100, this updates the default to
reflect this.

Without this, if a user runs terraform plan or apply, it would inform
the user that the volume needs to be recreated due to IOPs changing from
"100" => "0" after the refresh gathers AWS' default value of "100" from
the API.