### PR TITLE
Platform/Azure: Add server-name-hash-bucket-size to ingress configmap

### DIFF
--- a/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: tectonic-system
 data:
   custom-http-errors: "400,401,403,404,500,503,504"
+  server-name-hash-bucket-size: "1024"


### PR DESCRIPTION
Fix for #165 that broke Azure provided FQDN since host name is too long for nginx ingress controller