### PR TITLE
[WIP] module/bootkube: support secure external etcd connections

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -98,6 +98,24 @@ variable "tectonic_etcd_servers" {
   default     = [""]
 }
 
+variable "tectonic_etcd_ca_cert_path" {
+  description = "The path to the etcd CA certificate for TLS communication with etcd (optional)."
+  type        = "string"
+  default     = ""
+}
+
+variable "tectonic_etcd_client_cert_path" {
+  description = "The path to the etcd client certificate for TLS communication with etcd (optional)."
+  type        = "string"
+  default     = ""
+}
+
+variable "tectonic_etcd_client_key_path" {
+  description = "The path to the etcd client key for TLS communication with etcd (optional)."
+  type        = "string"
+  default     = ""
+}
+
 // The base DNS domain of the cluster.
 // Example: `openstack.dev.coreos.systems`
 variable "tectonic_base_domain" {

--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -69,7 +69,7 @@ data "template_file" "etcd-member" {
 
 resource "ignition_systemd_unit" "etcd-member" {
   name   = "etcd-member.service"
-  enable = true
+  enable = "${var.etcd_gateway_enabled == 1 ? true : false}"
 
   dropin = [
     {

--- a/modules/aws/ignition/variables.tf
+++ b/modules/aws/ignition/variables.tf
@@ -33,6 +33,11 @@ variable "etcd_endpoints" {
   description = "List of etcd endpoints"
 }
 
+variable "etcd_gateway_enabled" {
+  description = "Specifies whether the etcd gateway should be enabled or not."
+  default     = true
+}
+
 variable "bootkube_service" {
   type        = "string"
   description = "The content of the bootkube systemd service unit"

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -38,3 +38,7 @@ output "ca_key" {
 output "systemd_service" {
   value = "${data.template_file.bootkube_service.rendered}"
 }
+
+output "etcd_gateway_enabled" {
+  value = "${data.null_data_source.etcd.outputs.no_certs}"
+}

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -20,6 +20,9 @@ spec:
     - --bind-address=0.0.0.0
     - --client-ca-file=/etc/kubernetes/secrets/ca.crt
     - --etcd-servers=${etcd_servers}
+    ${etcd_ca_flag}
+    ${etcd_cert_flag}
+    ${etcd_key_flag}
     - --insecure-port=8080
     - --advertise-address=${advertise_address}
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt

--- a/modules/bootkube/resources/manifests/kube-apiserver-secret.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver-secret.yaml
@@ -9,3 +9,6 @@ data:
   apiserver.crt: ${apiserver_cert}
   service-account.pub: ${serviceaccount_pub}
   ca.crt: ${ca_cert}
+  etcd-ca.crt: ${etcd_ca_cert}
+  etcd-client.crt: ${etcd_client_cert}
+  etcd-client.key: ${etcd_client_key}

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -31,6 +31,9 @@ spec:
         - --insecure-port=8080
         - --advertise-address=${advertise_address}
         - --etcd-servers=${etcd_servers}
+        ${etcd_ca_flag}
+        ${etcd_cert_flag}
+        ${etcd_key_flag}
         - --etcd-quorum-read=true
         - --storage-backend=etcd3
         - --allow-privileged=true

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -18,9 +18,21 @@ variable "kube_dns_service_ip" {
   type        = "string"
 }
 
-variable "etcd_servers" {
-  description = "List of etcd servers to connect with (scheme://ip:port)"
+variable "etcd_endpoints" {
+  description = "List of etcd endpoints to connect with (hostnames/IPs only)"
   type        = "list"
+}
+
+variable "etcd_ca_cert" {
+  type = "string"
+}
+
+variable "etcd_client_cert" {
+  type = "string"
+}
+
+variable "etcd_client_key" {
+  type = "string"
 }
 
 variable "cloud_provider" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -79,6 +79,7 @@ module "ignition-masters" {
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
   kube_dns_service_ip       = "${var.tectonic_kube_dns_service_ip}"
   etcd_endpoints            = ["${module.etcd.endpoints}"]
+  etcd_gateway_enabled      = "${module.bootkube.etcd_gateway_enabled}"
   kubeconfig_s3_location    = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
   assets_s3_location        = "${aws_s3_bucket_object.tectonic-assets.bucket}/${aws_s3_bucket_object.tectonic-assets.key}"
   container_images          = "${var.tectonic_container_images}"

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -25,7 +25,10 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_servers = ["http://127.0.0.1:2379"]
+  etcd_endpoints   = ["${module.etcd.endpoints}"]
+  etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
+  etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
+  etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
 }
 
 module "tectonic" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -25,7 +25,10 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_servers = ["http://127.0.0.1:2379"]
+  etcd_endpoints   = ["${module.etcd.ip_address}"]
+  etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
+  etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
+  etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
 }
 
 module "tectonic" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -25,7 +25,10 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_servers = ["http://127.0.0.1:2379"]
+  etcd_endpoints   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
+  etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
+  etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
+  etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
 }
 
 module "tectonic" {

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -25,7 +25,10 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_servers = ["http://127.0.0.1:2379"]
+  etcd_endpoints   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
+  etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
+  etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
+  etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
 }
 
 module "tectonic" {


### PR DESCRIPTION
This introduces the possibility to configure the etcd CA cert, client
cert, and client key to be used for secure etcd connectivity, if an external etcd is specified.

Todos:
- [x] passthru etcd ca/client certs
- [x] use direct etcd url rather than the gateway

Fixes #233
Fixes #147 