### PR TITLE
installer/.gitignore: clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ pull-secret.json
 tectonic-license.txt
 generated/
 bin/
+installer/*.aci
+installer/assets/frontend/scripts/
+installer/binassets/assets.go
+installer/frontend/node_modules/
+installer/matchbox
+installer/tests/scripts/aws/output/

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,7 +1,0 @@
-*.aci
-/assets/frontend/scripts/
-/bin/
-/binassets/assets.go
-/frontend/node_modules/
-/matchbox
-/tests/scripts/aws/output/


### PR DESCRIPTION
cleans up the nested `installer/.gitignore` after #273.