### PR TITLE
Default to AWS Terraform in GUI installer.

### DIFF
--- a/installer/frontend/platforms.js
+++ b/installer/frontend/platforms.js
@@ -4,26 +4,25 @@ export const AZURE = 'azure';
 export const BARE_METAL = 'bare-metal';
 export const OPENSTACK = 'openstack';
 
-export const isSupported = platform => [AWS, BARE_METAL].includes(platform) ||
-  (platform === AWS_TF && window.config.devMode);
+export const isSupported = platform => [AWS, AWS_TF, BARE_METAL].includes(platform);
 
 export const PLATFORM_NAMES = {
-  [AWS]: 'Amazon Web Services',
-  [BARE_METAL]: 'Bare Metal',
+  [AWS]: 'Amazon Web Services (CloudFormation, legacy v1.5)',
   [AWS_TF]: 'Amazon Web Services (Terraform)',
   [AZURE]: 'Microsoft Azure (Terraform)',
+  [BARE_METAL]: 'Bare Metal',
   [OPENSTACK]: 'Openstack (Terraform)',
 };
 
 export const isTerraform = p => [AWS_TF, AZURE, OPENSTACK].includes(p);
 
 export const OptGroups = [
-  ['Graphical Installer (default)', AWS, BARE_METAL],
-  ['Advanced Installer', AWS_TF, AZURE, OPENSTACK],
+  ['Graphical Installer (default)', AWS_TF, AWS, BARE_METAL],
+  ['Advanced Installer', AZURE, OPENSTACK],
 ];
 
 const platOrder = [
-  AWS, BARE_METAL, AWS_TF, AZURE, OPENSTACK,
+  AWS_TF, AWS, BARE_METAL, AZURE, OPENSTACK,
 ];
 
 export const SELECTED_PLATFORMS = (window.config ? window.config.platforms : []).sort((a, b) =>

--- a/installer/server/platforms.go
+++ b/installer/server/platforms.go
@@ -7,9 +7,9 @@ import (
 
 // KnownPlatforms is the list of supported platforms.
 var KnownPlatforms = []string{
+	"aws-tf",
 	"aws",
 	"bare-metal",
-	"aws-tf",
 	"azure",
 	"openstack",
 }


### PR DESCRIPTION
- Don't require dev mode for terraform in GUI.
- Move AWS Terraform to the top of the dropdown.
- Rename old AWS mode to AWS CloudFormation.