### PR TITLE
Migrate more manifests to k8s 1,6

### DIFF
--- a/installer/assets/heapster-deployment.yaml
+++ b/installer/assets/heapster-deployment.yaml
@@ -20,7 +20,6 @@ spec:
         version: v1.3.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
         - name: heapster
@@ -64,3 +63,6 @@ spec:
             requests:
               cpu: 50m
               memory: 90Mi
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists

--- a/installer/assets/ingress/hostport/nginx-ingress-daemonset.yaml
+++ b/installer/assets/ingress/hostport/nginx-ingress-daemonset.yaml
@@ -13,25 +13,14 @@ spec:
         app: tectonic-lb
         component: ingress-controller
         type: nginx
-      annotations:
-          scheduler.alpha.kubernetes.io/affinity: >
-            {
-              "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "nodeSelectorTerms": [
-                    {
-                      "matchExpressions": [
-                        {
-                          "key": "master",
-                          "operator": "DoesNotExist"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
       containers:
         - name: nginx-ingress-lb
           image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.3

--- a/modules/tectonic/resources/manifests/heapster/deployment.yaml
+++ b/modules/tectonic/resources/manifests/heapster/deployment.yaml
@@ -17,7 +17,6 @@ spec:
         k8s-app: heapster
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
         - name: heapster
@@ -61,3 +60,6 @@ spec:
             requests:
               cpu: 50m
               memory: 90Mi
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists

--- a/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
+++ b/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
@@ -14,25 +14,14 @@ spec:
         app: tectonic-lb
         component: ingress-controller
         type: nginx
-      annotations:
-          scheduler.alpha.kubernetes.io/affinity: >
-            {
-              "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                  "nodeSelectorTerms": [
-                    {
-                      "matchExpressions": [
-                        {
-                          "key": "master",
-                          "operator": "DoesNotExist"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            }
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
       containers:
         - name: nginx-ingress-lb
           image: ${ingress_controller_image}


### PR DESCRIPTION
This finishes migrating several tolerations and affinity definitions from annotations to properties in the pod spec.

cc @Quentin-M @aaronlevy 