### PR TITLE
installer/scripts: add TerraForm binary/templates to release tarball

### DIFF
--- a/installer/scripts/release/common.env.sh
+++ b/installer/scripts/release/common.env.sh
@@ -2,6 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT="$DIR/../.."
+REPOSITORY_ROOT="$ROOT/.."
 WORKSPACE_DIR="$ROOT/.workspace"
 TMP_DIR="$WORKSPACE_DIR/tmpdir"
 
@@ -20,3 +21,8 @@ MATCHBOX_RELEASE_VERSION=v0.5.0
 MATCHBOX_RELEASE_URL="https://github.com/coreos/matchbox/releases/download/${MATCHBOX_RELEASE_VERSION}/matchbox-${MATCHBOX_RELEASE_VERSION}-linux-amd64.tar.gz"
 MATCHBOX_ARCHIVE_TOP_DIR="matchbox-${MATCHBOX_RELEASE_VERSION}-linux-amd64"
 
+TERRAFORM_BIN_TMP_DIR="$TMP_DIR/terraform-bin"
+TERRAFORM_BIN_VERSION=0.8.8
+TERRAFORM_BIN_URL='https://releases.hashicorp.com/terraform/${TERRAFORM_BIN_VERSION}/terraform_${TERRAFORM_BIN_VERSION}_${os}_amd64.zip'
+
+TERRAFORM_SOURCES="${REPOSITORY_ROOT}/modules ${REPOSITORY_ROOT}/platforms ${REPOSITORY_ROOT}/config.tf"

--- a/installer/scripts/release/get_terraform_bins.sh
+++ b/installer/scripts/release/get_terraform_bins.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "$DIR/common.env.sh"
+
+mkdir -p "${TMP_DIR}" "${TERRAFORM_BIN_TMP_DIR}"
+
+set -x
+
+for os in "linux" "darwin" "windows"; do
+    curl -L $(eval echo ${TERRAFORM_BIN_URL}) -o ${TERRAFORM_BIN_TMP_DIR}/terraform_${os}.zip
+    mkdir -p ${INSTALLER_RELEASE_DIR}/${os}/
+    unzip -o ${TERRAFORM_BIN_TMP_DIR}/terraform_${os}.zip -d ${INSTALLER_RELEASE_DIR}/${os}/
+    chmod +x ${INSTALLER_RELEASE_DIR}/${os}/terraform*
+done

--- a/installer/scripts/release/make_release_tarball.sh
+++ b/installer/scripts/release/make_release_tarball.sh
@@ -9,9 +9,16 @@ check_aws_creds
 echo "Retrieving matchbox release"
 "$DIR/get_matchbox_release.sh"
 
+echo "Retrieving TerraForm resources"
+"$DIR/get_terraform_bins.sh"
+
 echo "Retrieving Tectonic Installer binaries"
 "$DIR/get_installer_bins.sh"
 
+echo "Adding TerraForm sources"
+cp -r "$TERRAFORM_SOURCES" "$TECTONIC_RELEASE_TOP_DIR"
+
+echo "Building release tarball"
 tar -cvzf "$ROOT/$TECTONIC_RELEASE_TARBALL_FILE" -C "$TECTONIC_RELEASE_DIR" .
 
 echo "Release tarball is available at $ROOT/$TECTONIC_RELEASE_TARBALL_FILE"

--- a/installer/server/terraform/sources.go
+++ b/installer/server/terraform/sources.go
@@ -12,6 +12,13 @@ import (
 )
 
 // sources lists the files/directories that compose the TerraForm sources.
+//
+// The separator enables us to make the distinction between finding a directory
+// and a file.
+//
+// NOTE: Any changes to this list must be reflected in the release script.
+// TODO: Ideally, we would have only one source of truth. We could maybe use
+// a LDFLAG to fill this for example.
 var sources = []string{
 	"modules" + string(filepath.Separator),
 	"platforms" + string(filepath.Separator),

--- a/release.groovy
+++ b/release.groovy
@@ -15,7 +15,7 @@ pipeline {
     stage('Release') {
       agent none
       environment {
-        GO_PROJECT = '/go/src/github.com/coreos-inc/tectonic'
+        GO_PROJECT = '/go/src/github.com/coreos/tectonic-installer'
       }
       steps {
         script {
@@ -44,7 +44,7 @@ pipeline {
                   variable: 'GITHUB_CREDENTIALS'
                 ]]) {
                   container('webapp-agent') {
-                    checkout([$class: 'GitSCM', branches: [[name: "refs/tags/${params.releaseTag}"]], userRemoteConfigs: [[credentialsId: 'github-coreosbot', url: 'https://github.com/coreos-inc/tectonic.git']]])
+                    checkout([$class: 'GitSCM', branches: [[name: "refs/tags/${params.releaseTag}"]], userRemoteConfigs: [[credentialsId: 'github-coreosbot', url: 'https://github.com/coreos/tectonic-installer.git']]])
                     sh "mkdir -p \$(dirname $GO_PROJECT) && ln -sf $WORKSPACE $GO_PROJECT"
                     sh "go get github.com/golang/lint/golint"
                     sh """#!/bin/bash -ex
@@ -67,4 +67,3 @@ pipeline {
     }
   }
 }
-


### PR DESCRIPTION
This PR adds the TerraForm binary, as well as the TerraForm templates to the release binary.

Note that users of the release won't necessarily have to have TerraForm installed on their machine (even though they could), the executor will automatically pick-up the one that is shipped in the release.

```
├── matchbox
│   ├── ...
├── tectonic-installer
│   ├── darwin
│   │   ├── installer
│   │   └── terraform* (upstream)
│   ├── linux
│   │   ├── installer
│   │   └── terraform* (upstream)
│   └── windows
│       ├── installer
│       └── terraform* (upstream)
├── platforms*
│   ├── ...
├── modules*
│    ├── ...
└── config.tf*

*: new
```