### PR TITLE
Docs: change title to match standard format

### DIFF
--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting known issues and workarounds
+# Troubleshooting Tectonic Installer
 
 ## Re-applying over a partially failed run
 


### PR DESCRIPTION
I'm cleaning up the FAQs and Troubleshooting guides for this release. The only thing I'm going to do to this file before we bring the old Installer files over to this repo is change the title. Just to keep my head straight.