### PR TITLE
Improve paths to license / pull secret

### DIFF
--- a/installer/server/terraform.go
+++ b/installer/server/terraform.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -348,8 +347,8 @@ func newExecutorFromApplyHandlerInput(input *TerraformApplyHandlerInput) (*terra
 	}
 	ex.AddFile("license.txt", []byte(input.License))
 	ex.AddFile("pull_secret.json", []byte(input.PullSecret))
-	input.Variables["tectonic_license_path"] = filepath.Join(ex.WorkingDirectory(), "license.txt")
-	input.Variables["tectonic_pull_secret_path"] = filepath.Join(ex.WorkingDirectory(), "pull_secret.json")
+	input.Variables["tectonic_license_path"] = "./license.txt"
+	input.Variables["tectonic_pull_secret_path"] = "./pull_secret.json"
 	serviceCidr := input.Variables["tectonic_service_cidr"].(string)
 
 	ip, ok := input.Variables["tectonic_kube_apiserver_service_ip"].(string)

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -39,8 +39,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${var.tectonic_license_path}"
-  pull_secret_path = "${var.tectonic_pull_secret_path}"
+  license_path     = "${pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -39,8 +39,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${var.tectonic_license_path}"
-  pull_secret_path = "${var.tectonic_pull_secret_path}"
+  license_path     = "${pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -39,8 +39,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${var.tectonic_license_path}"
-  pull_secret_path = "${var.tectonic_pull_secret_path}"
+  license_path     = "${pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -39,8 +39,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${var.tectonic_license_path}"
-  pull_secret_path = "${var.tectonic_pull_secret_path}"
+  license_path     = "${pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"


### PR DESCRIPTION
Because the assets are not meant to live in the executor's working directory forever, we can't use absolute path to them. Otherwise once downloaded, they will not work anymore.

Also, expand any given ~ because it is commonly used by CLI users!

Fixes https://github.com/coreos/tectonic-installer/issues/286 https://github.com/coreos/tectonic-installer/issues/289