### PR TITLE
frontend: Add reset button on bootup page. 

### DIFF
--- a/installer/frontend/components/aws-tf-poweron.jsx
+++ b/installer/frontend/components/aws-tf-poweron.jsx
@@ -6,6 +6,7 @@ import { saveAs } from 'file-saver';
 import { Alert } from './alert';
 import { WaitingLi } from './ui';
 import { AWS_DomainValidation } from './aws-domain-validation';
+import { ResetButton } from './reset-button';
 import { CLUSTER_NAME } from '../cluster-config';
 import { TFDestroy } from '../aws-actions';
 import { observeClusterStatus } from '../server';
@@ -160,6 +161,7 @@ class AWS_TF_PowerOn extends React.Component {
               <i className="fa fa-download"></i>&nbsp;&nbsp;Download assets
             </button>
           </a>
+          <ResetButton />
         </div>
       </div>
       }

--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -7,6 +7,7 @@ import { savable } from '../reducer';
 import * as trail from '../trail';
 
 import { Loader } from './loader';
+import { ResetButton } from './reset-button';
 import { restoreModal } from './restore';
 import { WithTooltip } from './tooltip';
 import { PLATFORM_TYPE } from '../cluster-config';
@@ -63,13 +64,7 @@ const Pager = ({showPrev, showNext, disableNext, loadingNext, navigatePrevious, 
                 >Previous Step</button>
       }
       { resetBtn && <div className="wiz-form__actions__prev">
-
-        <button onClick={() => {
-          // eslint-disable-next-line no-alert
-          (window.config.devMode || window.confirm('Do you really want to start over?')) && window.reset();
-        }} className="btn btn-link">
-           Start Over
-        </button>
+        <ResetButton />
       </div>
       }
       {

--- a/installer/frontend/components/reset-button.jsx
+++ b/installer/frontend/components/reset-button.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export const ResetButton = () => <button onClick={() => {
+  // eslint-disable-next-line no-alert
+  (window.config.devMode || window.confirm('Do you really want to start over?')) && window.reset();
+}} className="btn btn-link">
+   Start Over
+</button>;


### PR DESCRIPTION
Only show it if terraform isn't running.

This prevents users from getting stuck on the bootup page if terraform apply fails.