### PR TITLE
Ignore generated .terraformrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pull-secret.json
 tectonic-license.txt
 generated/
 bin/
+.terraformrc


### PR DESCRIPTION
The `.terraformrc` is generated automatically and user specific.
It should not amount to SCM changes.

@Quentin-M  @s-urbaniak 