### PR TITLE
Configure audit logging for kube-apiserver

### DIFF
--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -54,6 +54,10 @@ spec:
         - --oidc-groups-claim=${oidc_groups_claim}
         - --oidc-ca-file=/etc/kubernetes/secrets/ca.crt
         - --cloud-provider=${cloud_provider}
+        - --audit-log-path=/var/log/kube-apiserver-audit.log
+        - --audit-log-maxage=30
+        - --audit-log-maxbackup=3
+        - --audit-log-maxsize=100
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
@@ -63,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /var/lock
           name: var-lock
+          readOnly: false
+        - mountPath: /var/log
+          name: var-log
           readOnly: false
       hostNetwork: true
       tolerations:
@@ -83,3 +90,6 @@ spec:
       - name: var-lock
         hostPath:
           path: /var/lock
+      - name: var-log
+        hostPath:
+          path: /var/log


### PR DESCRIPTION
Adds audit related flags to the API server manifests for logging to a file in a host volume. I did not update the bootstrap API manifest because it seems unnecessary.

It is expected you would configure fluentd to tail this log file. 

An alternative approach is to make the API server container use `/dev/stdout` as the path to the logfile. This makes it harder and less efficient to configure capturing logs, since the streams will become interleaved, and the API server logs and the audit logs have different formats. This is the simplest approach currently.

If we wish to not use a host mount and not use `/dev/stdout`, then we could avoid it by running a sidecar pod which tails and prints the log file from an empty volume, but then pod restarts will cause some logs to get lost, and isn't really much better than a host mount. This is my least favorite of the options.