### PR TITLE
Makefile: Add '${BUILD_DIR}/.terraform' to the dependency of 'make destroy'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ plan: installer-env $(BUILD_DIR)/.terraform
 apply: installer-env $(BUILD_DIR)/.terraform
 	cd $(BUILD_DIR) && $(TF_CMD) apply $(TOP_DIR)/platforms/$(PLATFORM)
 
-destroy: installer-env
+destroy: installer-env ${BUILD_DIR}/.terraform
 	cd $(BUILD_DIR) && $(TF_CMD) destroy -force $(TOP_DIR)/platforms/$(PLATFORM)
 
 terraform-check:


### PR DESCRIPTION
This makes sure that `make destroy` works even we haven't run `make apply`
before.

This is useful when running the `make destroy` directly within a container.