### PR TITLE
installer/scripts/release/make_release_tarball: Revert breaking review

### DIFF
--- a/installer/scripts/release/make_release_tarball.sh
+++ b/installer/scripts/release/make_release_tarball.sh
@@ -16,7 +16,7 @@ echo "Retrieving Tectonic Installer binaries"
 "$DIR/get_installer_bins.sh"
 
 echo "Adding TerraForm sources"
-cp -r "$TERRAFORM_SOURCES" "$TECTONIC_RELEASE_TOP_DIR"
+cp -r $TERRAFORM_SOURCES "$TECTONIC_RELEASE_TOP_DIR"
 
 echo "Building release tarball"
 tar -cvzf "$ROOT/$TECTONIC_RELEASE_TARBALL_FILE" -C "$TECTONIC_RELEASE_DIR" .


### PR DESCRIPTION
https://github.com/coreos/tectonic-installer/pull/283#discussion_r113019124 actually broke the release script because the variable contains multiple paths to copy, on purpose. Using quotes makes the script think it should copy one path containing spaces.