### PR TITLE
scripts: Don't require S3 to make a tarball.

### DIFF
--- a/installer/scripts/release/common.env.sh
+++ b/installer/scripts/release/common.env.sh
@@ -23,6 +23,4 @@ MATCHBOX_ARCHIVE_TOP_DIR="matchbox-${MATCHBOX_RELEASE_VERSION}-linux-amd64"
 
 TERRAFORM_BIN_TMP_DIR="$TMP_DIR/terraform-bin"
 TERRAFORM_BIN_VERSION=0.8.8
-TERRAFORM_BIN_URL='https://releases.hashicorp.com/terraform/${TERRAFORM_BIN_VERSION}/terraform_${TERRAFORM_BIN_VERSION}_${os}_amd64.zip'
-
-TERRAFORM_SOURCES="${REPOSITORY_ROOT}/modules ${REPOSITORY_ROOT}/platforms ${REPOSITORY_ROOT}/config.tf"
+TERRAFORM_BIN_BASE_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_BIN_VERSION}/terraform_${TERRAFORM_BIN_VERSION}"

--- a/installer/scripts/release/get_terraform_bins.sh
+++ b/installer/scripts/release/get_terraform_bins.sh
@@ -8,8 +8,8 @@ mkdir -p "${TMP_DIR}" "${TERRAFORM_BIN_TMP_DIR}"
 set -x
 
 for os in "linux" "darwin" "windows"; do
-    curl -L $(eval echo ${TERRAFORM_BIN_URL}) -o ${TERRAFORM_BIN_TMP_DIR}/terraform_${os}.zip
-    mkdir -p ${INSTALLER_RELEASE_DIR}/${os}/
-    unzip -o ${TERRAFORM_BIN_TMP_DIR}/terraform_${os}.zip -d ${INSTALLER_RELEASE_DIR}/${os}/
+    curl -L "${TERRAFORM_BIN_BASE_URL}_${os}_amd64.zip" -o "${TERRAFORM_BIN_TMP_DIR}/terraform_${os}.zip"
+    mkdir -p "${INSTALLER_RELEASE_DIR}/${os}/"
+    unzip -o "${TERRAFORM_BIN_TMP_DIR}/terraform_${os}.zip" -d "${INSTALLER_RELEASE_DIR}/${os}/"
     chmod +x ${INSTALLER_RELEASE_DIR}/${os}/terraform*
 done

--- a/installer/scripts/release/make_release_tarball.sh
+++ b/installer/scripts/release/make_release_tarball.sh
@@ -2,9 +2,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$DIR/common.env.sh"
-source "$DIR/../awsutil.sh"
-
-check_aws_creds
+TERRAFORM_SOURCES="${REPOSITORY_ROOT}/modules ${REPOSITORY_ROOT}/platforms ${REPOSITORY_ROOT}/config.tf"
 
 echo "Retrieving matchbox release"
 "$DIR/get_matchbox_release.sh"
@@ -12,8 +10,10 @@ echo "Retrieving matchbox release"
 echo "Retrieving TerraForm resources"
 "$DIR/get_terraform_bins.sh"
 
-echo "Retrieving Tectonic Installer binaries"
-"$DIR/get_installer_bins.sh"
+echo "Copying Tectonic Installer binaries"
+cp "$ROOT/bin/windows/installer.exe" "$INSTALLER_RELEASE_DIR/windows/installer.exe"
+cp "$ROOT/bin/darwin/installer"      "$INSTALLER_RELEASE_DIR/darwin/installer"
+cp "$ROOT/bin/linux/installer"       "$INSTALLER_RELEASE_DIR/linux/installer"
 
 echo "Adding TerraForm sources"
 cp -r $TERRAFORM_SOURCES "$TECTONIC_RELEASE_TOP_DIR"


### PR DESCRIPTION
- Don't check AWS creds at the start of make_release_tarball.sh.
- Copy local installer binaries to release dir instead of grabbing them from s3.
- Move terraform-specific env vars to get_terraform_bins.sh. They're only used in this one place.
- Use straightforward string interpolation instead of eval() to construct terraform binary URLs.