### PR TITLE
Ignore AMI updates on etcd/master nodes to prevent destroying nodes accidently

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -32,6 +32,10 @@ resource "aws_instance" "etcd_node" {
   user_data              = "${ignition_config.etcd.*.rendered[count.index]}"
   vpc_security_group_ids = ["${var.sg_ids}"]
 
+  lifecycle {
+    ignore_changes = ["ami"]
+  }
+
   tags = "${merge(map(
       "Name", "${var.cluster_name}-etcd-${count.index}",
       "KubernetesCluster", "${var.cluster_name}"

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -63,6 +63,7 @@ resource "aws_launch_configuration" "master_conf" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = ["image_id"]
   }
 
   root_block_device {


### PR DESCRIPTION
Currently if a new version of CoreOS comes out on a user's configured
channel after they've already deployed, and they re-run terraform apply,
Terraform will detect the new AMI, and when reconciling desired state,
it will attempt to destroy existing nodes to update the AMI.

In order to avoid this, I added a ignore_changes to both the etcd node
resource, and the master launch configuration resource, to avoid
updating masters/etcd nodes if the AMI changes.

Longer term, I would expect the Container Linux Update Operator, or a
terraform operator could resolve this, but this seems like a reasonable
change to prevent accidental destruction of a cluster.

Previously this change also set prevent_destroy, but that cannot be
parameterized with vars, so it was removed.