### PR TITLE
Set default iops for master, etcd, worker root volumes to 100

### DIFF
--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -60,6 +60,7 @@ variable "root_volume_size" {
 
 variable "root_volume_iops" {
   type        = "string"
+  default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
 

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -92,5 +92,6 @@ variable "root_volume_size" {
 
 variable "root_volume_iops" {
   type        = "string"
+  default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -60,5 +60,6 @@ variable "root_volume_size" {
 
 variable "root_volume_iops" {
   type        = "string"
+  default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }


### PR DESCRIPTION
Much like #261, these values default should be set to the minimum value
AWS allows rather than leaving it empty, as refreshes detect the
implicit zero value of zero changing to "100" when querying AWS for the
current value.