### PR TITLE
config.tf - Update Tectonic Update Server Variable

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -154,7 +154,7 @@ EOF
 
 variable "tectonic_update_server" {
   type        = "string"
-  default     = "https://public.update.core-os.net"
+  default     = "https://tectonic.update.core-os.net"
   description = "The URL of the Tectonic Omaha update server"
 }
 


### PR DESCRIPTION
Replace CoreOS Container Linux Update server default variable `https://public.update.core-os.net` with Tectonic Update server default variable `https://tectonic.update.core-os.net`. This fixes with the issue where updates were not available in Tectonic Console