### PR TITLE
Make target to import cluster from UI generated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@
 config.tfvars
 id_rsa*
 pull-secret.json
-ssh-key.pem
 tectonic-*.tar.gz
 tectonic-license.txt
 terraform.tfstate*
 terraform.tfvars
+build/**

--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,32 @@ INSTALLER_BIN = $(TOP_DIR)/installer/bin/$(shell uname | tr '[:upper:]' '[:lower
 TF_DOCS := $(shell which terraform-docs 2> /dev/null)
 TF_CMD = TERRAFORM_CONFIG=$(TOP_DIR)/.terraformrc terraform
 
-$(info Using build directory [${BUILD_DIR}])
-
 all: apply
 
 $(INSTALLER_BIN):
 	make build -C $(TOP_DIR)/installer
 
-installer-env: $(INSTALLER_BIN) terraformrc.example	
-	sed "s|<PATH_TO_INSTALLER>|$(INSTALLER_BIN)|g" terraformrc.example > .terraformrc
+installer-env: $(INSTALLER_BIN) terraformrc.example
+	$(info Using build directory [${BUILD_DIR}])
+	@sed "s|<PATH_TO_INSTALLER>|$(INSTALLER_BIN)|g" terraformrc.example > .terraformrc
 
-localconfig:
+init:
+ifdef FROM_ASSETS
+	$(eval CLUSTER = $(shell unzip -Z1 $(FROM_ASSETS) | grep -Eo '^[^/\\]+' | sort -u))
+	$(eval BUILD_DIR = $(TOP_DIR)/build/$(CLUSTER))
+	@unzip -d $(TOP_DIR)/build $(FROM_ASSETS)
+	@echo 
+	@echo Done!
+	@echo Your assets for cluster $(CLUSTER) are imported.
+	@echo Now just use the cluster name variable and you are good to go.
+	@echo 
+	@echo CLUSTER=$(CLUSTER) make plan / apply / destroy
+	@echo 
+	@echo Happy applying!
+else
 	mkdir -p $(BUILD_DIR)
 	touch $(BUILD_DIR)/terraform.tfvars
+endif
 
 $(BUILD_DIR)/.terraform:
 	cd $(BUILD_DIR) && $(TF_CMD) get $(TOP_DIR)/platforms/$(PLATFORM)


### PR DESCRIPTION
This enables the CLI build system to consume assets produced by the UI installer.

Users will be able to boot a cluster using the UI installer, then download the assets.zip and continue to manage their cluster using the CLI flows (make apply / make destroy).

Among other things, this allows for an easy way to destroy clusters created with the UI after the installer has been shut down.

To import assets created by the UI, a user would use the following command:
```
make init FROM_ASSETS=~/Downloads/assets-test.zip
```
Which then outputs the necessary environment for CLI operations:
```
...
  inflating: /Users/alex/go/src/github.com/coreos/tectonic-installer/build/tectonic212910865/pull_secret.json
  inflating: /Users/alex/go/src/github.com/coreos/tectonic-installer/build/tectonic212910865/terraform.tfstate
  inflating: /Users/alex/go/src/github.com/coreos/tectonic-installer/build/tectonic212910865/terraform.tfvars
...

Done!
Your assets for cluster tectonic212910865 are imported.
Now just use the cluster name variable and you are good to go.

CLUSTER=tectonic212910865 make plan / apply / destroy

Happy applying!
```

I will follow up with a document describing in more details the interaction flows a user would take through the UI and then CLI for the most common cluster lifecycle operation.

NOTE: the new `init` target replaces the old `localconfig` target, but can still create a empty build location if not passed an assets bundle.

/cc: @sym3tri @Quentin-M @s-urbaniak 