### PR TITLE
WIP: Fixes existing resource group and existing dns zone.

### DIFF
--- a/modules/azure/dns/etcd.tf
+++ b/modules/azure/dns/etcd.tf
@@ -5,6 +5,4 @@ resource "azurerm_dns_a_record" "etcd" {
   name    = "${var.cluster_name}-etcd"
   ttl     = "60"
   records = ["${var.etcd_ip_addresses}"]
-
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
 }

--- a/modules/azure/dns/main.tf
+++ b/modules/azure/dns/main.tf
@@ -1,5 +1,4 @@
 resource "azurerm_dns_zone" "tectonic_azure_dns_zone" {
   name                = "${var.base_domain}"
   resource_group_name = "${var.resource_group_name}"
-  count               = "${var.create_dns_zone == "true" ? 1 : 0}"
 }

--- a/modules/azure/dns/master.tf
+++ b/modules/azure/dns/master.tf
@@ -5,8 +5,6 @@ resource "azurerm_dns_a_record" "tectonic-api" {
   name    = "${var.cluster_name}-k8s"
   ttl     = "60"
   records = ["${var.master_ip_addresses}"]
-
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "tectonic-console" {
@@ -16,8 +14,6 @@ resource "azurerm_dns_a_record" "tectonic-console" {
   name    = "${var.cluster_name}"
   ttl     = "60"
   records = ["${var.console_ip_address}"]
-
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "master_nodes" {
@@ -27,6 +23,4 @@ resource "azurerm_dns_a_record" "master_nodes" {
   name    = "${var.cluster_name}-master"
   ttl     = "59"
   records = ["${var.master_ip_addresses}"]
-
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
 }

--- a/modules/azure/dns/variables.tf
+++ b/modules/azure/dns/variables.tf
@@ -30,7 +30,3 @@ variable "etcd_ip_addresses" {
   type = "list"
 }
 
-variable "create_dns_zone" {
-  type    = "string"
-  default = "false"
-}

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -97,8 +97,6 @@ module "dns" {
   location            = "${var.tectonic_azure_location}"
   resource_group_name = "${var.tectonic_azure_dns_resource_group}"
 
-  create_dns_zone = "${var.tectonic_azure_create_dns_zone}"
-
   // TODO etcd list
   // TODO worker list
 }

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -2,8 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = ""
 
-  kube_apiserver_url = "${var.tectonic_azure_create_dns_zone == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
-  oidc_issuer_url    = "${var.tectonic_azure_create_dns_zone == "true" ? "https://${var.tectonic_cluster_name}.${var.tectonic_base_domain}/identity" : "https://${module.masters.ingress_internal_fqdn}/identity"}"
+  kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
+  oidc_issuer_url    = "https://${var.tectonic_cluster_name}.${var.tectonic_base_domain}/identity"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -35,8 +35,8 @@ module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "azure"
 
-  base_address       = "${var.tectonic_azure_create_dns_zone == "true" ? "${var.tectonic_cluster_name}.${var.tectonic_base_domain}" : module.masters.ingress_internal_fqdn}"
-  kube_apiserver_url = "${var.tectonic_azure_create_dns_zone == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
+  base_address       = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}"
+  kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -67,11 +67,11 @@ resource "null_resource" "tectonic" {
   depends_on = ["module.tectonic", "module.masters"]
 
   triggers {
-    api-endpoint = "${var.tectonic_azure_create_dns_zone == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
+    api-endpoint = "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}"
   }
 
   connection {
-    host  = "${var.tectonic_azure_create_dns_zone == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
+    host  = "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}"
     user  = "core"
     agent = true
   }


### PR DESCRIPTION
- In testing we found that setting `tectonic_azure_dns_resource_group`
had no effect.
- In this existing code `tectonic_base_domain` is used as the zone name
when associating host records with the zone. This was also broken.
- It seems that when things are set here dns would be resolved the last
item in the zone list from `az resource resource list -g tectonic-dns-group
--resource-type Microsoft.Network/dnszones --query [].name`
After this change it works as expected.

- TODO: introduce logic to set lifecycle to prevent deletion if the dns
zone already exists. Not sure how to test for that without a data
source.
https://www.terraform.io/docs/configuration/resources.html#prevent_destroy