### PR TITLE
Ignore AMI changing on worker launch config

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -33,6 +33,9 @@ resource "aws_instance" "etcd_node" {
   vpc_security_group_ids = ["${var.sg_ids}"]
 
   lifecycle {
+    # Ignore changes in the AMI which force recreation of the resource. This
+    # avoids accidental deletion of nodes whenever a new CoreOS Release comes
+    # out.
     ignore_changes = ["ami"]
   }
 

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -63,7 +63,11 @@ resource "aws_launch_configuration" "master_conf" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = ["image_id"]
+
+    # Ignore changes in the AMI which force recreation of the resource. This
+    # avoids accidental deletion of nodes whenever a new CoreOS Release comes
+    # out.
+    ignore_changes = ["image_id"]
   }
 
   root_block_device {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -33,6 +33,10 @@ resource "aws_launch_configuration" "worker_conf" {
 
   lifecycle {
     create_before_destroy = true
+    # Ignore changes in the AMI which force recreation of the resource. This
+    # avoids accidental deletion of nodes whenever a new CoreOS Release comes
+    # out.
+    ignore_changes        = ["image_id"]
   }
 
   root_block_device {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -33,10 +33,11 @@ resource "aws_launch_configuration" "worker_conf" {
 
   lifecycle {
     create_before_destroy = true
+
     # Ignore changes in the AMI which force recreation of the resource. This
     # avoids accidental deletion of nodes whenever a new CoreOS Release comes
     # out.
-    ignore_changes        = ["image_id"]
+    ignore_changes = ["image_id"]
   }
 
   root_block_device {


### PR DESCRIPTION
Prevents terraform from recreating the resource when a new CoreOS release
comes out.

This an extension of the same changes done to etcd and masters in #367