### PR TITLE
platforms/metal: Hack to allow a single terraform apply

### DIFF
--- a/platforms/metal/cl/coreos-install.yaml.tmpl
+++ b/platforms/metal/cl/coreos-install.yaml.tmpl
@@ -26,6 +26,11 @@ storage:
           systemctl reboot
 passwd:
   users:
-    - name: core
+    # intentionally not creating 'core' user so terraform does not SSH during install
+    - name: debug
+      create:
+        groups:
+          - sudo
+          - docker
       ssh_authorized_keys:
         - {{.ssh_authorized_key}}

--- a/platforms/metal/remote.tf
+++ b/platforms/metal/remote.tf
@@ -2,9 +2,10 @@ resource "null_resource" "kubeconfig" {
   count = "${length(var.tectonic_metal_controller_domains) + length(var.tectonic_metal_worker_domains)}"
 
   connection {
-    type = "ssh"
-    host = "${element(concat(var.tectonic_metal_controller_domains, var.tectonic_metal_worker_domains), count.index)}"
-    user = "core"
+    type    = "ssh"
+    host    = "${element(concat(var.tectonic_metal_controller_domains, var.tectonic_metal_worker_domains), count.index)}"
+    user    = "core"
+    timeout = "60m"
   }
 
   provisioner "file" {
@@ -27,9 +28,10 @@ resource "null_resource" "bootstrap" {
   depends_on = ["null_resource.kubeconfig"]
 
   connection {
-    type = "ssh"
-    host = "${element(var.tectonic_metal_controller_domains, 0)}"
-    user = "core"
+    type    = "ssh"
+    host    = "${element(var.tectonic_metal_controller_domains, 0)}"
+    user    = "core"
+    timeout = "60m"
   }
 
   provisioner "file" {


### PR DESCRIPTION
* Disallow SSH as user core during the install to disk
* Increase SSH timeout to 60 minutes to allow leeway
* This prevents terraform from SSH'ing to machines during the install phase so that a single terraform apply is needed to complete the install process.