### PR TITLE
ingress config: Disable http2.

### DIFF
--- a/installer/assets/ingress/default-backend-configmap.yaml
+++ b/installer/assets/ingress/default-backend-configmap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: tectonic-custom-error
 data:
   custom-http-errors: "400,401,403,404,500,503,504"
+  use-http2: "false"

--- a/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   custom-http-errors: "400,401,403,404,500,503,504"
   server-name-hash-bucket-size: "1024"
+  use-http2: "false"


### PR DESCRIPTION
nginx sends "transfer-encoding: chunked" header, which is blacklisted in http2.
This causes spdy errors in Chrome.