### PR TITLE
Docs: clarify audiences and use-cases

### DIFF
--- a/Documentation/dev/audiences.md
+++ b/Documentation/dev/audiences.md
@@ -1,0 +1,17 @@
+# Audiences and tools
+
+The Tectonic installer has two main use-cases and audiences – end-users that want to deploy clusters, and developers that want to extend, improve or modify the codebase. The user experience is important but different for these audiences, and is explained in detail below.
+
+## End-user experience
+
+The primary audience of this installer is end-users that want to deploy one or more clusters on supported platforms. The ideal UX is to download a release of the installer that requires minimal configuration of the user's machine, including dependencies.
+
+Freeing these users from installing many dependencies can isolate them from differences between platforms (Windows, macOS, Linux). This also reduces the documentation burden.
+
+We should strive to _never require_ end-users to use or install `make`, `npm`, etc to install a cluster.
+
+## Developer experience
+
+The developer workflow is reflective of how often clusters will be created and destroyed. This project makes heavy use of `make` to make these repetitive actions easier.
+
+It is expected that developers have a working knowledge of Terraform, including how to configure/use a `.terraformrc` and things of that nature.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Checkout the [ROADMAP](ROADMAP.md) for details on where the project is headed.
 
 ## Getting Started
 
-To use the installer you can either use an official release (starting March 29, 2017), or hack on the scripts in this repo.
+**To use a tested release** on an supported platform, follow the links below.
+
+**To hack or modify** the templates or add a new platform, use the scripts in this repo to boot and tear down clusters.
 
 ### Official releases
 


### PR DESCRIPTION
Expanding some thoughts from https://github.com/coreos/tectonic-installer/pull/372 on how we use tools like `make`. They are helpful for developers/contributors but complicate the usage for regular end-users.