### PR TITLE
tectonic: stop capturing 400x errors in default ingress backend

### DIFF
--- a/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/configmap.yaml
@@ -4,6 +4,6 @@ metadata:
   name: tectonic-custom-error
   namespace: tectonic-system
 data:
-  custom-http-errors: "400,401,403,404,500,503,504"
+  custom-http-errors: "404,500,503,504"
   server-name-hash-bucket-size: "1024"
   use-http2: "false"


### PR DESCRIPTION
This was causing a number of bugs in console.

- 400 errors messages were getting captured and un-viewable
- I suspect 401/403 errors were breaking the "you need to login" logic.

/cc @rithujohn191 