### PR TITLE
modules/aws/vpc: lock down security groups

### DIFF
--- a/modules/aws/vpc/sg-master.tf
+++ b/modules/aws/vpc/sg-master.tf
@@ -167,17 +167,6 @@ resource "aws_security_group_rule" "master_ingress_etcd" {
   self      = true
 }
 
-# TODO(squat): remove this once we pin etcd pods to masters
-resource "aws_security_group_rule" "master_ingress_etcd_from_worker" {
-  type                     = "ingress"
-  security_group_id        = "${aws_security_group.master.id}"
-  source_security_group_id = "${aws_security_group.worker.id}"
-
-  protocol  = "tcp"
-  from_port = 2379
-  to_port   = 2380
-}
-
 resource "aws_security_group_rule" "master_ingress_bootstrap_etcd" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"
@@ -186,17 +175,6 @@ resource "aws_security_group_rule" "master_ingress_bootstrap_etcd" {
   from_port = 12379
   to_port   = 12380
   self      = true
-}
-
-# TODO(squat): remove this once we pin etcd pods to masters
-resource "aws_security_group_rule" "master_ingress_bootstrap_etcd_from_worker" {
-  type                     = "ingress"
-  security_group_id        = "${aws_security_group.master.id}"
-  source_security_group_id = "${aws_security_group.worker.id}"
-
-  protocol  = "tcp"
-  from_port = 12379
-  to_port   = 12380
 }
 
 resource "aws_security_group_rule" "master_ingress_services" {

--- a/modules/aws/vpc/sg-worker.tf
+++ b/modules/aws/vpc/sg-worker.tf
@@ -157,28 +157,6 @@ resource "aws_security_group_rule" "worker_ingress_kubelet_secure_from_master" {
   to_port   = 10255
 }
 
-# TODO(squat): remove this once we pin etcd pods to masters
-resource "aws_security_group_rule" "worker_ingress_etcd" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.worker.id}"
-
-  protocol  = "tcp"
-  from_port = 2379
-  to_port   = 2380
-  self      = true
-}
-
-# TODO(squat): remove this once we pin etcd pods to masters
-resource "aws_security_group_rule" "worker_ingress_etcd_from_master" {
-  type                     = "ingress"
-  security_group_id        = "${aws_security_group.worker.id}"
-  source_security_group_id = "${aws_security_group.master.id}"
-
-  protocol  = "tcp"
-  from_port = 2379
-  to_port   = 2380
-}
-
 resource "aws_security_group_rule" "worker_ingress_services" {
   type              = "ingress"
   security_group_id = "${aws_security_group.worker.id}"


### PR DESCRIPTION
This commit locks down the master and worker security groups for AWS
since we know that etcd pods and control plane pods that need access to
etcd will only be scheduled on master nodes. For that reason, the etcd
ports, 2379-2380 and 12379-12380, only need to accept connections from
other master nodes.

See
https://github.com/kubernetes-incubator/bootkube/blob/master/pkg/util/etcdutil/migrate.go#L132.

cc @sym3tri @Quentin-M