### PR TITLE
installer: Bump to Kubernetes 1.5.7

### DIFF
--- a/installer/assets/candidate/app-version-kubernetes.json
+++ b/installer/assets/candidate/app-version-kubernetes.json
@@ -9,11 +9,11 @@
     }
   },
   "spec": {
-    "desiredVersion": "1.5.6+tectonic.1",
+    "desiredVersion": "1.5.7+tectonic.1",
     "paused": false
   },
   "status": {
-    "currentVersion": "1.5.6+tectonic.1",
+    "currentVersion": "1.5.7+tectonic.1",
     "paused": false
   }
 }

--- a/installer/assets/candidate/app-version-tectonic-cluster.json
+++ b/installer/assets/candidate/app-version-tectonic-cluster.json
@@ -9,11 +9,11 @@
     }
   },
   "spec": {
-    "desiredVersion": "1.5.6-tectonic.1",
+    "desiredVersion": "1.5.7-tectonic.1",
     "paused": false
   },
   "status": {
-    "currentVersion": "1.5.6-tectonic.1",
+    "currentVersion": "1.5.7-tectonic.1",
     "paused": false
   }
 }

--- a/installer/assets/provisioning/tectonic-aws-controller.yaml.tmpl
+++ b/installer/assets/provisioning/tectonic-aws-controller.yaml.tmpl
@@ -96,7 +96,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.5.7_coreos.0
     - path: /opt/bin/decrypt-tls-assets
       filesystem: root
       mode: 0700

--- a/installer/assets/provisioning/tectonic-aws-worker.yaml.tmpl
+++ b/installer/assets/provisioning/tectonic-aws-worker.yaml.tmpl
@@ -83,7 +83,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.5.7_coreos.0
     - path: /opt/bin/decrypt-tls-assets
       filesystem: root
       mode: 0700

--- a/installer/assets/provisioning/tectonic-metal-controller.yaml.tmpl
+++ b/installer/assets/provisioning/tectonic-metal-controller.yaml.tmpl
@@ -124,7 +124,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.5.7_coreos.0
     - path: /etc/kubernetes/kubeconfig
       filesystem: root
       mode: 0644

--- a/installer/assets/provisioning/tectonic-metal-worker.yaml.tmpl
+++ b/installer/assets/provisioning/tectonic-metal-worker.yaml.tmpl
@@ -99,7 +99,7 @@ storage:
       contents:
         inline: |
           KUBELET_ACI=quay.io/coreos/hyperkube
-          KUBELET_VERSION=v1.5.6_coreos.0
+          KUBELET_VERSION=v1.5.7_coreos.0
     - path: /etc/kubernetes/kubeconfig
       filesystem: root
       mode: 0644

--- a/installer/assets/self-hosted/kube-apiserver.yaml.tmpl
+++ b/installer/assets/self-hosted/kube-apiserver.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-apiserver
-        image: quay.io/coreos/hyperkube:v1.5.6_coreos.0
+        image: quay.io/coreos/hyperkube:v1.5.7_coreos.0
         command:
         - /usr/bin/flock
         - --exclusive

--- a/installer/scripts/update-payload/payload.json
+++ b/installer/scripts/update-payload/payload.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.6-tectonic.1",
+  "version": "1.5.7-tectonic.1",
   "deployments": [
     {
       "apiVersion": "extensions/v1beta1",
@@ -112,7 +112,7 @@
   "desiredVersions": [
     {
       "name": "kubernetes",
-      "version": "1.5.6+tectonic.1"
+      "version": "1.5.7+tectonic.1"
     }
   ]
 }

--- a/installer/server/tectonic.go
+++ b/installer/server/tectonic.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	tectonicVersion              = "1.5.6-tectonic.1"
+	tectonicVersion              = "1.5.7-tectonic.1"
 	tectonicNamespace            = "tectonic-system"
 	tectonicCASecretName         = "tectonic-ca-cert-secret"
 	tectonicTLSSecret            = "tectonic-tls-secret"

--- a/installer/tests/scripts/bare-metal/get-kubectl.sh
+++ b/installer/tests/scripts/bare-metal/get-kubectl.sh
@@ -4,7 +4,7 @@
 set -eu
 
 DEST=${1:-"bin"}
-VERSION="v1.5.6"
+VERSION="v1.5.7"
 
 URL="https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/kubectl"
 

--- a/installer/vendor/github.com/kubernetes-incubator/bootkube/pkg/asset/internal/templates.go
+++ b/installer/vendor/github.com/kubernetes-incubator/bootkube/pkg/asset/internal/templates.go
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: kubelet
-        image: quay.io/coreos/hyperkube:v1.5.6_coreos.0
+        image: quay.io/coreos/hyperkube:v1.5.7_coreos.0
         command:
         - ./hyperkube
         - kubelet
@@ -147,7 +147,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-apiserver
-        image: quay.io/coreos/hyperkube:v1.5.6_coreos.0
+        image: quay.io/coreos/hyperkube:v1.5.7_coreos.0
         command:
         - /usr/bin/flock
         - --exclusive
@@ -291,7 +291,7 @@ spec:
         master: "true"
       containers:
       - name: kube-controller-manager
-        image: quay.io/coreos/hyperkube:v1.5.6_coreos.0
+        image: quay.io/coreos/hyperkube:v1.5.7_coreos.0
         command:
         - ./hyperkube
         - controller-manager
@@ -347,7 +347,7 @@ spec:
         master: "true"
       containers:
       - name: kube-scheduler
-        image: quay.io/coreos/hyperkube:v1.5.6_coreos.0
+        image: quay.io/coreos/hyperkube:v1.5.7_coreos.0
         command:
         - ./hyperkube
         - scheduler
@@ -380,7 +380,7 @@ spec:
       hostNetwork: true
       containers:
       - name: kube-proxy
-        image: quay.io/coreos/hyperkube:v1.5.6_coreos.0
+        image: quay.io/coreos/hyperkube:v1.5.7_coreos.0
         command:
         - /hyperkube
         - proxy


### PR DESCRIPTION
* kube-apiserver now drops unneeded path information if an older version of Windows kubectl sends it. ([#44585](https://github.com/kubernetes/kubernetes/pull/44585), [@mml](https://github.com/mml))
* Fix for kube-proxy healthcheck handling an update that simultaneously removes one port and adds another. ([#44365](https://github.com/kubernetes/kubernetes/pull/44365), [@MrHohn](https://github.com/MrHohn))
* Fix [broken service accounts when using dedicated service account key](https://github.com/kubernetes/kubernetes/issues/44285). ([#44169](https://github.com/kubernetes/kubernetes/pull/44169), [@mikedanese](https://github.com/mikedanese))
* Update to fluentd-gcp:1.28.3, rebased on ubuntu-slim:0.8 ([#43928](https://github.com/kubernetes/kubernetes/pull/43928), [@ixdy](https://github.com/ixdy))
* Fix polarity of NodePort logic to avoid leaked ports ([#43259](https://github.com/kubernetes/kubernetes/pull/43259), [@thockin](https://github.com/thockin))
* Upgrade golang versions to 1.7.5 ([#41771](https://github.com/kubernetes/kubernetes/pull/41771), [@cblecker](https://github.com/cblecker))