### PR TITLE
Use cloudformation to manage the autoscaling groups

### DIFF
--- a/modules/aws/vpc/sg-elb.tf
+++ b/modules/aws/vpc/sg-elb.tf
@@ -20,6 +20,10 @@ resource "aws_security_group" "api" {
     from_port   = 443
     to_port     = 443
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group" "console" {

--- a/modules/aws/vpc/sg-etcd.tf
+++ b/modules/aws/vpc/sg-etcd.tf
@@ -49,4 +49,8 @@ resource "aws_security_group" "etcd" {
     to_port   = 2380
     self      = true
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/modules/aws/vpc/sg-master.tf
+++ b/modules/aws/vpc/sg-master.tf
@@ -5,6 +5,10 @@ resource "aws_security_group" "master" {
       "Name", "${var.cluster_name}_master_sg",
       "KubernetesCluster", "${var.cluster_name}"
     ), var.extra_tags)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_egress" {
@@ -15,6 +19,10 @@ resource "aws_security_group_rule" "master_egress" {
   to_port     = 0
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_icmp" {
@@ -25,6 +33,10 @@ resource "aws_security_group_rule" "master_ingress_icmp" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 0
   to_port     = 0
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_ssh" {
@@ -35,6 +47,10 @@ resource "aws_security_group_rule" "master_ingress_ssh" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 22
   to_port     = 22
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_http" {
@@ -45,6 +61,10 @@ resource "aws_security_group_rule" "master_ingress_http" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 80
   to_port     = 80
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_https" {
@@ -55,6 +75,10 @@ resource "aws_security_group_rule" "master_ingress_https" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 443
   to_port     = 443
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_heapster" {
@@ -65,6 +89,10 @@ resource "aws_security_group_rule" "master_ingress_heapster" {
   from_port = 4194
   to_port   = 4194
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_heapster_from_worker" {
@@ -75,6 +103,10 @@ resource "aws_security_group_rule" "master_ingress_heapster_from_worker" {
   protocol  = "tcp"
   from_port = 4194
   to_port   = 4194
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_flannel" {
@@ -85,6 +117,10 @@ resource "aws_security_group_rule" "master_ingress_flannel" {
   from_port = 4789
   to_port   = 4789
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_flannel_from_worker" {
@@ -95,6 +131,10 @@ resource "aws_security_group_rule" "master_ingress_flannel_from_worker" {
   protocol  = "udp"
   from_port = 4789
   to_port   = 4789
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_node_exporter" {
@@ -105,6 +145,10 @@ resource "aws_security_group_rule" "master_ingress_node_exporter" {
   from_port = 9100
   to_port   = 9100
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_node_exporter_from_worker" {
@@ -115,6 +159,10 @@ resource "aws_security_group_rule" "master_ingress_node_exporter_from_worker" {
   protocol  = "tcp"
   from_port = 9100
   to_port   = 9100
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_kubelet_insecure" {
@@ -125,6 +173,10 @@ resource "aws_security_group_rule" "master_ingress_kubelet_insecure" {
   from_port = 10250
   to_port   = 10250
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_kubelet_insecure_from_worker" {
@@ -135,6 +187,10 @@ resource "aws_security_group_rule" "master_ingress_kubelet_insecure_from_worker"
   protocol  = "tcp"
   from_port = 10250
   to_port   = 10250
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_kubelet_secure" {
@@ -145,6 +201,10 @@ resource "aws_security_group_rule" "master_ingress_kubelet_secure" {
   from_port = 10255
   to_port   = 10255
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_kubelet_secure_from_worker" {
@@ -155,6 +215,10 @@ resource "aws_security_group_rule" "master_ingress_kubelet_secure_from_worker" {
   protocol  = "tcp"
   from_port = 10255
   to_port   = 10255
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_etcd" {
@@ -165,6 +229,10 @@ resource "aws_security_group_rule" "master_ingress_etcd" {
   from_port = 2379
   to_port   = 2380
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_bootstrap_etcd" {
@@ -175,6 +243,10 @@ resource "aws_security_group_rule" "master_ingress_bootstrap_etcd" {
   from_port = 12379
   to_port   = 12380
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_services" {
@@ -185,6 +257,10 @@ resource "aws_security_group_rule" "master_ingress_services" {
   from_port = 32000
   to_port   = 32767
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "master_ingress_services_from_console" {
@@ -195,4 +271,8 @@ resource "aws_security_group_rule" "master_ingress_services_from_console" {
   protocol  = "tcp"
   from_port = 32000
   to_port   = 32767
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/modules/aws/vpc/sg-worker.tf
+++ b/modules/aws/vpc/sg-worker.tf
@@ -5,6 +5,10 @@ resource "aws_security_group" "worker" {
       "Name", "${var.cluster_name}_worker_sg",
       "KubernetesCluster", "${var.cluster_name}"
     ), var.extra_tags)}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_egress" {
@@ -15,6 +19,10 @@ resource "aws_security_group_rule" "worker_egress" {
   to_port     = 0
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_icmp" {
@@ -25,6 +33,10 @@ resource "aws_security_group_rule" "worker_ingress_icmp" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 0
   to_port     = 0
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_ssh" {
@@ -35,6 +47,10 @@ resource "aws_security_group_rule" "worker_ingress_ssh" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 22
   to_port     = 22
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_http" {
@@ -45,6 +61,10 @@ resource "aws_security_group_rule" "worker_ingress_http" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 80
   to_port     = 80
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_https" {
@@ -55,6 +75,10 @@ resource "aws_security_group_rule" "worker_ingress_https" {
   cidr_blocks = ["0.0.0.0/0"]
   from_port   = 443
   to_port     = 443
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_heapster" {
@@ -65,6 +89,10 @@ resource "aws_security_group_rule" "worker_ingress_heapster" {
   from_port = 4194
   to_port   = 4194
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_heapster_from_master" {
@@ -75,6 +103,10 @@ resource "aws_security_group_rule" "worker_ingress_heapster_from_master" {
   protocol  = "tcp"
   from_port = 4194
   to_port   = 4194
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_flannel" {
@@ -85,6 +117,10 @@ resource "aws_security_group_rule" "worker_ingress_flannel" {
   from_port = 4789
   to_port   = 4789
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_flannel_from_master" {
@@ -95,6 +131,10 @@ resource "aws_security_group_rule" "worker_ingress_flannel_from_master" {
   protocol  = "udp"
   from_port = 4789
   to_port   = 4789
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_node_exporter" {
@@ -105,6 +145,10 @@ resource "aws_security_group_rule" "worker_ingress_node_exporter" {
   from_port = 9100
   to_port   = 9100
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_node_exporter_from_master" {
@@ -115,6 +159,10 @@ resource "aws_security_group_rule" "worker_ingress_node_exporter_from_master" {
   protocol  = "tcp"
   from_port = 9100
   to_port   = 9100
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_kubelet_insecure" {
@@ -125,6 +173,10 @@ resource "aws_security_group_rule" "worker_ingress_kubelet_insecure" {
   from_port = 10250
   to_port   = 10250
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_kubelet_insecure_from_master" {
@@ -135,6 +187,10 @@ resource "aws_security_group_rule" "worker_ingress_kubelet_insecure_from_master"
   protocol  = "tcp"
   from_port = 10250
   to_port   = 10250
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_kubelet_secure" {
@@ -145,6 +201,10 @@ resource "aws_security_group_rule" "worker_ingress_kubelet_secure" {
   from_port = 10255
   to_port   = 10255
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_kubelet_secure_from_master" {
@@ -155,6 +215,10 @@ resource "aws_security_group_rule" "worker_ingress_kubelet_secure_from_master" {
   protocol  = "tcp"
   from_port = 10255
   to_port   = 10255
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_services" {
@@ -165,6 +229,10 @@ resource "aws_security_group_rule" "worker_ingress_services" {
   from_port = 32000
   to_port   = 32767
   self      = true
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "worker_ingress_services_from_console" {
@@ -175,4 +243,8 @@ resource "aws_security_group_rule" "worker_ingress_services_from_console" {
   protocol  = "tcp"
   from_port = 32000
   to_port   = 32767
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
The overall purpose of this PR is to enable users to modify parameters related to their ASG/LaunchConfig and have those modifications take effect.

Currently, if you change a variable on the launch_config, and re-run terraform apply, it will create a new launch_config, update the ASG to use the launch_config, destroy the old one, but the instances do not get updated.

The simplest use-case that I was testing is changing the instance_type of `worker` nodes, after realizing I didn't have enough resources to deploy my apps.

RollingUpdates of AutoScalingGroups are not a built in feature of
LaunchConfigs or ASGs, but is a feature of cloud formation. To handle
this, autoscaling group resources can be replaced with a cloudformation
resources which manages 1 thing, the autoscaling group and update policy
of that autoscaling group, as recommended by terraform upstream:
https://github.com/hashicorp/terraform/issues/1552#issuecomment-290315313

This allows preforming rolling updates, and actually makes it possible
to modify instance related parameters such as instance_type, and have
that take effect without having to manually the autoscaling groups.

This also gets us closer to a point where we can use `cfn-signal` to
indicate that a node is ready (ie: kubelet is healthy). I've also got a
WIP branch for implementing basic cfn signalling on top of this which
waits for kubelet to be healthy before proceeding with the ASG rolling
update.

## TODO

- Merge tectonic_autoscaling_group_extra_tags with the tags defined
on the ASG within the cloudformation. I was unable to get this to work. It's hard because `join` doesn't work on non-flat lists, and `encodejson` wasn't getting me what I needed. I'd love help on this @s-urbaniak or @alexsomesan.

- Currently this works fairly well overall. I can easily update my worker nodes without any trouble now. Updating masters hasn't been so successful. Without setting up `cfn-init` and `cfn-signal` to signal when a node is ready, it may be necessary to just increase the pause time on the master ASG UpdatePolicy. The new masters come up, but as far as I can tell, they're not getting all the pods they need before the other masters die off.

The lifecycle `create_before_destroy` changes are necessary because the Terraform document mentions any `create_before_destroy` resource can only depend on other `create_before_destroy` resources. Our launch_config is `create_before_destroy`, but the SGs it depends on are not. This fixes that. Without those changes, I was seeing some resources getting leaked and not cleaned up.