### PR TITLE
Only create minimum number of NAT gateways needed

### DIFF
--- a/modules/aws/vpc/vpc-private.tf
+++ b/modules/aws/vpc/vpc-private.tf
@@ -12,7 +12,7 @@ resource "aws_route" "to_nat_gw" {
   count                  = "${var.external_vpc_id == "" ? var.worker_az_count : 0}"
   route_table_id         = "${aws_route_table.private_routes.*.id[count.index]}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${aws_nat_gateway.nat_gw.*.id[count.index]}"
+  nat_gateway_id         = "${element(aws_nat_gateway.nat_gw.*.id, count.index)}"
   depends_on             = ["aws_route_table.private_routes"]
 }
 

--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -53,12 +53,12 @@ resource "aws_route_table_association" "route_net" {
 }
 
 resource "aws_eip" "nat_eip" {
-  count = "${var.external_vpc_id == "" ? var.master_az_count : 0}"
+  count = "${var.external_vpc_id == "" ? min(var.master_az_count, var.worker_az_count) : 0}"
   vpc   = true
 }
 
 resource "aws_nat_gateway" "nat_gw" {
-  count         = "${var.external_vpc_id == "" ? var.master_az_count : 0}"
+  count         = "${var.external_vpc_id == "" ? min(var.master_az_count, var.worker_az_count) : 0}"
   allocation_id = "${aws_eip.nat_eip.*.id[count.index]}"
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
 }


### PR DESCRIPTION
This fixes an issue @sym3tri noticed. Before this change, the number of NAT gateways created was based on the number of master subnets. This doesn't make sense if the number of worker subnets is lower, since not all NAT gateways will be attached to worker subnets in that case.

With this change, we create as little NAT gateways as needed to support the number of worker subnets attached or to fit in the number of master subnets available (hence the min(..) expression).

@sym3tri @Quentin-M @s-urbaniak 