### PR TITLE
platforms/azure: fix the usage of an existing DNS zone resource group

### DIFF
--- a/Documentation/variables/azure.md
+++ b/Documentation/variables/azure.md
@@ -7,7 +7,6 @@ This document gives an overview of the variables used in the different platforms
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
 | tectonic_azure_config_version | (internal) This declares the version of the Azure configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
-| tectonic_azure_create_dns_zone | If set to true, create an Azure DNS zone | string | `true` |
 | tectonic_azure_dns_resource_group |  | string | `tectonic-dns-group` |
 | tectonic_azure_etcd_vm_size | Instance size for the etcd node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |
 | tectonic_azure_external_rsg_name | Pre-existing resource group to use as parent for cluster resources. | string | `` |
@@ -17,6 +16,7 @@ This document gives an overview of the variables used in the different platforms
 | tectonic_azure_location |  | string | - |
 | tectonic_azure_master_vm_size | Instance size for the master node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |
 | tectonic_azure_ssh_key | Name of an Azure ssh key to use joe-sfo | string | - |
+| tectonic_azure_use_custom_fqdn | If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure. | string | `true` |
 | tectonic_azure_vnet_cidr_block | Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute. | string | `10.0.0.0/16` |
 | tectonic_azure_worker_vm_size | Instance size for the worker node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |
 | tectonic_ssh_key |  | string | `` |

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -5,9 +5,6 @@ tectonic_admin_email = ""
 // bcrypt hash of admin password to use with Tectonic Console
 tectonic_admin_password_hash = ""
 
-// If set to true, create an Azure DNS zone
-tectonic_azure_create_dns_zone = "true"
-
 // 
 tectonic_azure_dns_resource_group = "tectonic-dns-group"
 
@@ -34,6 +31,9 @@ tectonic_azure_master_vm_size = "Standard_DS2_v2"
 
 // 
 tectonic_azure_ssh_key = ""
+
+// If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure.
+tectonic_azure_use_custom_fqdn = "true"
 
 // Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute.
 tectonic_azure_vnet_cidr_block = "10.0.0.0/16"

--- a/modules/azure/dns/etcd.tf
+++ b/modules/azure/dns/etcd.tf
@@ -6,5 +6,5 @@ resource "azurerm_dns_a_record" "etcd" {
   ttl     = "60"
   records = ["${var.etcd_ip_addresses}"]
 
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
 }

--- a/modules/azure/dns/main.tf
+++ b/modules/azure/dns/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_dns_zone" "tectonic_azure_dns_zone" {
   name                = "${var.base_domain}"
   resource_group_name = "${var.resource_group_name}"
-  count               = "${var.create_dns_zone == "true" ? 1 : 0}"
+  count               = "${var.use_custom_fqdn == "true" ? 1 : 0}"
 }

--- a/modules/azure/dns/master.tf
+++ b/modules/azure/dns/master.tf
@@ -6,7 +6,7 @@ resource "azurerm_dns_a_record" "tectonic-api" {
   ttl     = "60"
   records = ["${var.master_ip_addresses}"]
 
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "tectonic-console" {
@@ -17,7 +17,7 @@ resource "azurerm_dns_a_record" "tectonic-console" {
   ttl     = "60"
   records = ["${var.console_ip_address}"]
 
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "master_nodes" {
@@ -28,5 +28,5 @@ resource "azurerm_dns_a_record" "master_nodes" {
   ttl     = "59"
   records = ["${var.master_ip_addresses}"]
 
-  count = "${var.create_dns_zone == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
 }

--- a/modules/azure/dns/variables.tf
+++ b/modules/azure/dns/variables.tf
@@ -30,7 +30,7 @@ variable "etcd_ip_addresses" {
   type = "list"
 }
 
-variable "create_dns_zone" {
+variable "use_custom_fqdn" {
   type    = "string"
   default = "false"
 }

--- a/modules/azure/etcd/lb.tf
+++ b/modules/azure/etcd/lb.tf
@@ -16,7 +16,7 @@ resource "azurerm_public_ip" "etcd_publicip" {
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
   public_ip_address_allocation = "static"
-  domain_name_label            = "${var.resource_group_name}-etcd"
+  domain_name_label            = "${var.cluster_name}-etcd"
 }
 
 resource "azurerm_lb_rule" "etcd-lb" {

--- a/modules/azure/master/api-lb.tf
+++ b/modules/azure/master/api-lb.tf
@@ -3,7 +3,7 @@ resource "azurerm_public_ip" "tectonic_api_ip" {
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
   public_ip_address_allocation = "static"
-  domain_name_label            = "${var.resource_group_name}-k8s"
+  domain_name_label            = "${var.cluster_name}-k8s"
 
   tags {
     environment = "staging"

--- a/modules/azure/master/console-lb.tf
+++ b/modules/azure/master/console-lb.tf
@@ -3,7 +3,7 @@ resource "azurerm_public_ip" "tectonic_console_ip" {
   location                     = "${var.location}"
   resource_group_name          = "${var.resource_group_name}"
   public_ip_address_allocation = "static"
-  domain_name_label            = "${var.resource_group_name}"
+  domain_name_label            = "${var.cluster_name}"
 
   tags {
     environment = "staging"

--- a/modules/azure/master/output.tf
+++ b/modules/azure/master/output.tf
@@ -7,17 +7,17 @@ output "console_ip_address" {
 }
 
 output "ingress_external_fqdn" {
-  value = "${azurerm_public_ip.tectonic_console_ip.fqdn}"
+  value = "${azurerm_public_ip.tectonic_console_ip.domain_name_label}.${var.base_domain}"
 }
 
 output "ingress_internal_fqdn" {
-  value = "${azurerm_public_ip.tectonic_console_ip.fqdn}"
+  value = "${azurerm_public_ip.tectonic_console_ip.domain_name_label}.${var.base_domain}"
 }
 
 output "api_external_fqdn" {
-  value = "${azurerm_public_ip.tectonic_api_ip.fqdn}"
+  value = "${azurerm_public_ip.tectonic_api_ip.domain_name_label}.${var.base_domain}"
 }
 
 output "api_internal_fqdn" {
-  value = "${azurerm_public_ip.tectonic_api_ip.fqdn}"
+  value = "${azurerm_public_ip.tectonic_api_ip.domain_name_label}.${var.base_domain}"
 }

--- a/platforms/azure/dns-todo/worker.tf
+++ b/platforms/azure/dns-todo/worker.tf
@@ -6,5 +6,5 @@ resource "azurerm_dns_a_record" "worker_nodes" {
   name    = "${var.tectonic_cluster_name}-worker-${count.index}"
   ttl     = "59"
   records = ["${azurerm_public_ip.worker_node.ip_address[count.index]}"]
-  count   = "${var.create_dns_zone == "true" ? 1 : 0}"
+  count   = "${var.use_custom_fqdn == "true" ? 1 : 0}"
 }

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -93,7 +93,7 @@ module "dns" {
   location            = "${var.tectonic_azure_location}"
   resource_group_name = "${var.tectonic_azure_dns_resource_group}"
 
-  create_dns_zone = "${var.tectonic_azure_create_dns_zone}"
+  use_custom_fqdn = "${var.tectonic_azure_use_custom_fqdn}"
 
   // TODO etcd list
   // TODO worker list

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -29,6 +29,7 @@ module "bootkube" {
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
+  etcd_service_ip  = "${var.tectonic_kube_etcd_service_ip}"
 }
 
 module "tectonic" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -2,8 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = ""
 
-  kube_apiserver_url = "${var.tectonic_azure_create_dns_zone == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
-  oidc_issuer_url    = "${var.tectonic_azure_create_dns_zone == "true" ? "https://${var.tectonic_cluster_name}.${var.tectonic_base_domain}/identity" : "https://${module.masters.ingress_internal_fqdn}/identity"}"
+  kube_apiserver_url = "${var.tectonic_azure_use_custom_fqdn == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
+  oidc_issuer_url    = "${var.tectonic_azure_use_custom_fqdn == "true" ? "https://${var.tectonic_cluster_name}.${var.tectonic_base_domain}/identity" : "https://${module.masters.ingress_internal_fqdn}/identity"}"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -35,8 +35,8 @@ module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "azure"
 
-  base_address       = "${var.tectonic_azure_create_dns_zone == "true" ? "${var.tectonic_cluster_name}.${var.tectonic_base_domain}" : module.masters.ingress_internal_fqdn}"
-  kube_apiserver_url = "${var.tectonic_azure_create_dns_zone == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
+  base_address       = "${var.tectonic_azure_use_custom_fqdn == "true" ? "${var.tectonic_cluster_name}.${var.tectonic_base_domain}" : module.masters.ingress_internal_fqdn}"
+  kube_apiserver_url = "${var.tectonic_azure_use_custom_fqdn == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -67,11 +67,11 @@ resource "null_resource" "tectonic" {
   depends_on = ["module.tectonic", "module.masters"]
 
   triggers {
-    api-endpoint = "${var.tectonic_azure_create_dns_zone == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
+    api-endpoint = "${var.tectonic_azure_use_custom_fqdn == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
   }
 
   connection {
-    host  = "${var.tectonic_azure_create_dns_zone == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
+    host  = "${var.tectonic_azure_use_custom_fqdn == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
     user  = "core"
     agent = true
   }

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -82,7 +82,7 @@ variable "tectonic_azure_external_vnet_name" {
   description = "Pre-existing virtual network to create cluster into."
 }
 
-variable "tectonic_azure_create_dns_zone" {
-  description = "If set to true, create an Azure DNS zone"
+variable "tectonic_azure_use_custom_fqdn" {
+  description = "If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure."
   default     = "true"
 }


### PR DESCRIPTION
This PR amends https://github.com/coreos/tectonic-installer/pull/374 to:

- Cleanup the public_ips & master FQDN's from using long and incorrect FQDN's e.g. when using an existing DNS zone resource group
- Rename `tectonic_azure_create_dns_zone` to `tectonic_azure_use_custom_fqdn` to convey its functionality better around which FQDN's is used: either 1) custom FQDN that uses `tectonic_base_domain` (default) or 2) the [FQDN](https://www.terraform.io/docs/providers/azurerm/r/public_ip.html#fqdn) set up by Azure.
- Update Azure's `etcd_service_ip` in the bootkube module (similar to recent changes for AWS: https://github.com/coreos/tectonic-installer/pull/411)

This has been tested against Terraform v0.9.4 (since it's now the [default](https://github.com/coreos/tectonic-installer/pull/219) in master).

/cc @coresolve 