### PR TITLE
Document aggregated logging

### DIFF
--- a/Documentation/admin/index.md
+++ b/Documentation/admin/index.md
@@ -3,8 +3,10 @@
 - [Upgrade][admin-upgrade]
 - [User Management][admin-user-management]
 - ["assets.zip" and Component Recovery][assets-zip]
+- [Configure Aggregated Logging][logging]
 
 
 [admin-upgrade]: upgrade.md
 [admin-user-management]: user-management.md
 [assets-zip]: assets-zip.md
+[logging]: logging.md

--- a/Documentation/admin/logging-customization.md
+++ b/Documentation/admin/logging-customization.md
@@ -1,0 +1,73 @@
+# Customizing Fluentd
+
+The [fluentd-configmap.yaml][fluentd-config] provided has been designed to be easily customizable. Generally you'll want to avoid modifying anything other than the `fluentd.conf` and `output.conf` sections of the configmap.
+
+## Customizing log destination
+
+The [customizing log destination][customizing-log-destination] document explains how to configure where logs are sent.
+
+## Add custom parsing/filtering logic
+
+To add additional filters or parsers, add them to the `extra.conf` section in the [fluentd-configmap.yaml][fluentd-config]. The `extra.conf` already has a very brief example of how to add an extra field to log entries, and a more detailed example is shown below.
+
+For details on Fluentd post-processing, check out the Fluentd [fliters][fluentd-docs-filter] and [parsers][fluentd-docs-parser] documents.
+
+### Targeting a specific application's logs
+
+Fluentd routes event based on tags. Events flowing through Fluentd can be routed based on the value of the `tag` using `<match>` and `<filter>` directives. The configuration tags events using the following conventions:
+
+- systemd logs have a tag `systemd.<unit-name-here>`
+- Kubernetes container logs have a tag `kube.<namespace-name>.<container-name>`
+- Kubernetes API audit logs have a tag `kube-apiserver-audit`
+
+The existing configuration already does additional post processing based on some of these tags.
+
+For example, the host's `kubelet.service` log's are parsed by matching on the tag `systemd.kubelet`, and we do the same for parsing the Docker engine's logs using the tag `systemd.docker`. These filters set their `key_name` parameter to `MESSAGE` which is the actual field name for the log message when it originates from journald.
+
+Similarly, we parse the logs of the kube-apiserver, kube-scheduler, and other controller components by performing a wildcard match on the tag: `kube.kube-system.**`. This filter set its `key_name` parameter to `log`, which is the field for log messages originating from Docker.
+
+#### Example: Parsing the guestbook apache logs
+
+The following configuration will parse the `frontend` component's logs from the guestbook example app deployed in the ["Deploy your second app"][second-app] tutorial. To use it, copy and paste the snippet below [fluentd-configmap.yaml][fluentd-config]'s `extra.conf` section (make sure you indent to the correct level).
+
+```
+<filter kube.default.php-redis>
+  @type parser
+  # Fluentd provides a few built-in formats for popular and common formats such as "apache" and "json".
+  format apache2
+  key_name log
+  # Retain the original "log" field after parsing out the data.
+  reserve_data true
+
+  # The access logs and error logs are interleaved with each other and have
+  # different formats, so ignore parse errors, as they're expected
+  suppress_parse_error_log true
+</filter>
+
+<filter kube.default.php-redis>
+  @type parser
+  format apache_error
+  key_name log
+  reserve_data true
+
+  # The access logs and error logs are interleaved with each other and have
+  # different formats, so ignore parse errors, as they're expected
+  suppress_parse_error_log true
+</filter>
+```
+
+Once you've updated your config, you will need to delete and recreate your `fluentd` pods in order for the configuration to take effect:
+
+```
+$ kubectl delete pods --namespace logging -l app=fluentd
+```
+
+Once your pods have restarted, any new logs being parsed should be using the new configuration.
+
+[fluentd-config]: ../files/logging/fluentd-configmap.yaml
+[quay-fluentd-kubernetes]: https://quay.io/repository/coreos/fluentd-kubernetes?tab=tags
+[fluentd-match]: http://docs.fluentd.org/v0.12/articles/config-file#2-ldquomatchrdquo-tell-fluentd-what-to-do
+[fluentd-docs-filter]: http://docs.fluentd.org/v0.12/articles/filter-plugin-overview
+[fluentd-docs-parser]: http://docs.fluentd.org/v0.12/articles/parser-plugin-overview
+[second-app]: ../tutorials/second-app.md
+[customizing-log-destination]: logging-destination.md

--- a/Documentation/admin/logging-destination.md
+++ b/Documentation/admin/logging-destination.md
@@ -1,0 +1,137 @@
+# Customizing log destination
+
+In order for Fluentd to send your logs to a different destination, you will need to use different Docker image with the correct Fluentd plugin for your destination. Once you have an image, you need to replace the contents of the `output.conf` section in your [fluentd-configmap.yaml][fluentd-config] with the appropriate [match directive][fluentd-match] for your output plugin.
+
+## Prebuilt images
+
+There are currently 4 prebuilt Debian based Docker images in the [quay.io/coreos/fluentd-kubernetes][quay-fluentd-Kubernetes] registry available for various logging destinations:
+
+- [quay.io/coreos/fluentd-kubernetes:v0.12-debian-cloudwatch][quay-fluentd-kubernetes]
+- [quay.io/coreos/fluentd-kubernetes:v0.12-debian-logentries][quay-fluentd-kubernetes]
+- [quay.io/coreos/fluentd-kubernetes:v0.12-debian-loggly][quay-fluentd-kubernetes]
+- [quay.io/coreos/fluentd-kubernetes:v0.12-debian-elasticsearch][quay-fluentd-kubernetes]
+
+**Note**: there are Alpine based images which are automatically published along side the Debian images, but they cannot be used in conjunction with the systemd input plugin, because Alpine has no `libsystemd` package available.
+
+To use one of these images, update the `image` field in your [fluentd-ds.yaml][fluentd-ds] manifest, and update your [fluentd-configmap.yaml][fluentd-config] `output.conf` with the correct match configuration for your configured output plugin.
+
+If you deploy Elasticsearch into your cluster, ensure the hostname and port of the service match the value in the `output.conf` section of your [fluentd-configmap.yaml][fluentd-config].
+
+### Using a different storage destination than Elasticsearch
+
+To change where your logs are sent, change the image in [fluentd-ds.yaml][fluentd-ds] to an image providing the necessary output plugin. The `output.conf` stanza in [fluentd-configmap.yaml][fluentd-config] must also be updated to match the new output plugin.
+
+#### Logentries
+
+To change to the logentries image, replace the line containing `image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-elasticsearch` with `image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-logentries`.
+
+Next, update your [fluentd-configmap.yaml][fluentd-config] `output.conf`:
+
+```
+<match **>
+  # Plugin specific settings
+  type logentries
+  config_path /etc/logentries/logentries-tokens.conf
+
+  # Buffer settings
+  buffer_chunk_limit 2M
+  buffer_queue_limit 32
+  flush_interval 10s
+  max_retry_wait 30
+  disable_retry_limit
+  num_threads 8
+</match>
+```
+
+**Note**: You will need to also modify your `fluentd-ds.yaml` to add a secret/volumeMount for your `logentries-token.conf` referenced in the config above.
+
+#### Cloudwatch
+
+To change to the cloudwatch image, replace the line containing `image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-elasticsearch` with `image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-cloudwatch`. You will also need to create an IAM user and set the `AWS_ACCESS_KEY`, `AWS_SECRET_KEY` and `AWS_REGION` environment variables in your manifest [as documented in the plugin's README](https://github.com/ryotarai/fluent-plugin-cloudwatch-logs#preparation). We recommend you use secrets [as environment variables](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) to accomplish setting the environment variables securely.
+
+Next, update your [fluentd-configmap.yaml][fluentd-config] `output.conf`:
+
+```
+<match **>
+  # Plugin specific settings
+  type cloudwatch_logs
+  log_group_name your-log-group
+  log_stream_name your-log-stream
+  auto_create_stream true
+
+  # Buffer settings
+  buffer_chunk_limit 2M
+  buffer_queue_limit 32
+  flush_interval 10s
+  max_retry_wait 30
+  disable_retry_limit
+  num_threads 8
+</match>
+```
+
+#### Loggly
+
+To change to the cloudwatch image, replace the line containing `image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-elasticsearch` with `image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-loggly`.
+
+Next, update your [fluentd-configmap.yaml][fluentd-config] `output.conf` (replace `xxx-xxxx-xxxx-xxxxx-xxxxxxxxxx` with your loggly customer token):
+
+```
+<match **>
+  # Plugin specific settings
+  type loggly_buffered
+  loggly_url https://logs-01.loggly.com/bulk/xxx-xxxx-xxxx-xxxxx-xxxxxxxxxx
+
+  # Buffer settings
+  buffer_chunk_limit 2M
+  buffer_queue_limit 32
+  flush_interval 10s
+  max_retry_wait 30
+  disable_retry_limit
+  num_threads 8
+</match>
+```
+
+### Elasticsearch Authentication
+
+If your Elasticsearch cluster is configured with x-pack or authentication methods, you will need to modify the `output.conf` section of your [fluentd-configmap.yaml][fluentd-config] to set credentials.
+
+Installing the x-pack plugin on your Elasticsearch nodes enables authentication to Elasticsearch by default. The default user is `elastic` and the default password is `changeme`. Modify the configuration to include the `user` and `password` fields like so:
+
+```
+<match **>
+  type elasticsearch
+  log_level info
+  include_tag_key true
+
+  # Connection settings
+  host elasticsearch.default.svc.cluster.local
+  port 9200
+  scheme https
+  ssl_verify true
+  user elastic
+  password changeme
+
+  logstash_format true
+  template_file /fluentd/etc/elasticsearch-template-es5x.json
+  template_name elasticsearch-template-es5x.json
+
+  # Buffer settings
+  buffer_chunk_limit 2M
+  buffer_queue_limit 32
+  flush_interval 5s
+  max_retry_wait 30
+  disable_retry_limit
+  num_threads 8
+</match>
+```
+
+### AWS Elasticsearch
+
+AWS Elasticsearch isn't officially supported at this time. AWS Elasticsearch functions differently from standard Elasticsearch making the standard Fluentd Elasticsearch plugin not work with it by default. If you are interested in using or contributing support for AWS Elasticsearch, please file an issue on [Github](https://github.com/coreos-inc/tectonic-installer/issues). Alternatively, you could look at one of the many AWS Signing proxies, which may work for your purposes, and allow you to use the default Elasticsearch configuration, pointed at the signing proxy.
+
+
+[fluentd-ds]: ../files/logging/fluentd-ds.yaml
+[fluentd-config]: ../files/logging/fluentd-configmap.yaml
+[quay-fluentd-kubernetes]: https://quay.io/repository/coreos/fluentd-kubernetes?tab=tags
+[fluentd-docs-output]: http://docs.fluentd.org/v0.12/articles/output-plugin-overview
+[fluentd-match]: http://docs.fluentd.org/v0.12/articles/config-file#2-ldquomatchrdquo-tell-fluentd-what-to-do

--- a/Documentation/admin/logging.md
+++ b/Documentation/admin/logging.md
@@ -1,0 +1,94 @@
+# Aggregated Logging in Tectonic
+
+Tectonic does not preconfigure any particular aggregated logging stack. Tectonic recommends several example logging configurations that can be customized for site requirements. The recommended logging setup uses Fluentd to retrieve logs on each node and forward them to a log storage backend. The Tectonic examples use Elasticsearch for log storage. Elasticsearch can be replaced by any destination Fluentd supports with an Output plugin. For a list of Fluentd plugins, check [http://www.fluentd.org/plugins/all](http://www.fluentd.org/plugins/all)
+
+If you want to run these examples locally, all of the files mentioned are available in the [Github repo for the Tectonic Installer][logging-config-files].
+
+## Overview
+
+### Prerequisites
+
+- Kubernetes 1.6+
+- `kubectl` configured
+  - If you need to configure `kubectl`, follow the instructions on [configuring credentials][configuring-credentials].
+- An Elasticsearch cluster, or other log storage destination
+  - See [customizing log destination][customizing-log-destination] for a list of available log destinations with pre-built images available.
+
+### Fluentd
+
+Fluentd runs as a DaemonSet on all nodes, including masters, and is configured using a ConfigMap of Fluentd config files which define how to collect the logs.
+
+The [provided configuration][fluentd-config] is setup to do the following:
+
+- Read host system logs using the Journal
+- Read Kubernetes containers logs
+- Read Kubernetes API server audit logs
+- Tag logs based on metadata such as container name
+- Enable Monitoring (exposed as Prometheus metrics)
+- Parse known log formats based on their tag
+- Send logs to Elasticsearch
+
+### Elasticsearch
+
+In this setup, we will not be configuring or setting up Elasticsearch, or Kibana. If you are looking for something to get started with, https://github.com/pires/kubernetes-elasticsearch-cluster is a good reference, and has examples of deploying an Elasticsearch cluster on Kubernetes while following best practices.
+
+If you want to customize your Elasticsearch output configuration or look at examples using different storage destinations, see the [customizing log destination][customizing-log-destination] document.
+
+## Deploying Fluentd
+
+First create the `logging` namespace for all of our resources to live in:
+
+```
+$ kubectl create ns logging
+```
+
+Then setup all the service account and roles that Fluentd needs to query Kubernetes for metadata about the containers logs it's watching:
+
+```
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/fluentd-service-account.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/fluentd-role.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/fluentd-role-binding.yaml
+```
+
+Next deploy Fluentd:
+
+```
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/fluentd-configmap.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/fluentd-svc.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/fluentd-ds.yaml
+```
+
+Finally, watch for the pods to become ready:
+
+```
+$ kubectl get pods --watch --namespace logging
+```
+
+Once all the pods are ready, everything should be functioning. To double check, use `kubectl logs` on one of the pods listed above to make sure there aren't any errors, and that Fluentd is able to send logs to where you've configured.
+
+
+### (Optional) Deploy Prometheus to monitor Fluentd
+
+Tectonic includes the [promtheus-operator][prometheus-operator] in installations by default. This operator can be used to create additional instances of Prometheus to monitor your apps.
+
+If you wish to enable Prometheus monitoring of your Fluentd pods, run the following commands:
+
+```
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/monitoring/prometheus-fluentd-role-binding.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/monitoring/prometheus-fluentd-service-account.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/monitoring/prometheus-fluentd.yaml
+$ kubectl create -f https://coreos.com/tectonic/docs/latest/files/monitoring/fluentd-prometheus-service-monitor.yaml
+```
+
+## Customization
+
+If you would like to make customizations to your logging setup, view our doc on [customizing Fluentd][customizing-fluentd].
+
+
+[fluentd-config]: ../files/logging/fluentd-configmap.yaml
+[fluentd-ds]: ../files/logging/fluentd-ds.yaml
+[configuring-credentials]: ../tutorials/first-app.md#configuring-credentials
+[logging-config-files]: https://github.com/coreos/tectonic-installer/tree/master/Documentation/files/logging
+[prometheus-operator]: https://github.com/coreos/prometheus-operator
+[customizing-fluentd]: logging-customization.md
+[customizing-log-destination]: logging-destination.md

--- a/Documentation/files/logging/fluentd-aggregator-deployment.yaml
+++ b/Documentation/files/logging/fluentd-aggregator-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: fluentd-aggregator
+  namespace: logging
+  labels:
+    app: fluentd-aggregator
+    component: log-aggregator
+spec:
+  replicas: 2
+  minReadySeconds: 5
+  progressDeadlineSeconds: 15
+  revisionHistoryLimit: 5
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: "100%"
+  template:
+    metadata:
+      labels:
+        app: fluentd-aggregator
+    spec:
+      containers:
+      - name: fluentd-aggregator
+        image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-elasticsearch
+        imagePullPolicy: Always
+        command: ["fluentd", "-c", "/fluentd/etc/fluentd.conf", "-p", "/fluentd/plugins"]
+        env:
+        - name: FLUENTD_CONFIG
+          value: fluentd-aggregator.conf
+        resources:
+          limits:
+            cpu: 2
+            memory: 1024Mi
+          requests:
+            cpu: 1
+            memory: 250Mi
+        ports:
+        - name: fwd-input
+          containerPort: 24224
+          protocol: TCP
+        - name: fwd-input-udp
+          containerPort: 24224
+          protocol: UDP
+        - name: prom-metrics
+          containerPort: 24231
+          protocol: TCP
+        - name: monitor-agent
+          containerPort: 24220
+          protocol: TCP
+        - name: http-input
+          containerPort: 9880
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: 24224
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: fluentd-config
+          mountPath: /fluentd/etc
+      volumes:
+      - name: fluentd-config
+        configMap:
+          name: "fluentd-config"
+      # Give the aggregator ample time to flush it's logs
+      terminationGracePeriodSeconds: 160
+      serviceAccountName: fluentd

--- a/Documentation/files/logging/fluentd-aggregator-svc.yaml
+++ b/Documentation/files/logging/fluentd-aggregator-svc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd-aggregator
+  namespace: logging
+  labels:
+    app: fluentd-aggregator
+spec:
+  type: ClusterIP
+  selector:
+    app: fluentd-aggregator
+  ports:
+  - name: fluentd-input
+    port: 24224
+    targetPort: fwd-input
+    protocol: TCP
+  - name: fluentd-input-udp
+    port: 24224
+    targetPort: fwd-input-udp
+    protocol: UDP
+  # Exposes Prometheus metrics
+  - name: prometheus-metrics
+    port: 24231
+    targetPort: prom-metrics
+    protocol: TCP
+  # Can be accessed using "kubectl proxy" at:
+  # http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/fluentd-aggregator:monitor-agent/api/plugins.json
+  - name: monitor-agent
+    port: 24220
+    targetPort: monitor-agent
+    protocol: TCP

--- a/Documentation/files/logging/fluentd-configmap.yaml
+++ b/Documentation/files/logging/fluentd-configmap.yaml
@@ -1,0 +1,361 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: logging
+  labels:
+    app: fluentd
+data:
+  fluentd.conf: |
+    # Use the config specified by the FLUENTD_CONFIG environment variable, or
+    # default to fluentd-standalone.conf
+    @include "#{ENV['FLUENTD_CONFIG'] || 'fluentd-standalone.conf'}"
+
+  # A config for running Fluentd as a daemon which collects, filters, parses,
+  # and sends log to storage. No extra fluentd processes required.
+  fluentd-standalone.conf: |
+    # Common config
+    @include general.conf
+    @include prometheus.conf
+
+    # Input sources
+    @include systemd-input.conf
+    @include kubernetes-input.conf
+    @include apiserver-audit-input.conf
+
+    # Parsing/Filtering
+    @include systemd-filter.conf
+    @include kubernetes-filter.conf
+    @include extra.conf
+
+    # Send to storage
+    @include output.conf
+
+  # A config for running Fluentd as a daemon which collects logs and forwards
+  # the logs using a forward_output to a Fluentd configured as an aggregator,
+  # with a forward_input.
+  fluentd-forwarder.conf: |
+    @include general.conf
+    @include prometheus.conf
+
+    @include apiserver-audit-input.conf
+    @include systemd-input.conf
+    @include kubernetes-input.conf
+
+    # Send to the aggregator
+    @include forward-output.conf
+
+  # A config for running Fluentd as HA ready deployment for receiving forwarded
+  # logs, and then applying filtering, and parsing before sending them to
+  # storage.
+  fluentd-aggregator.conf: |
+    # Receive from the forwarder
+    @include forward-input.conf
+
+    @include general.conf
+    @include prometheus.conf
+
+    @include systemd-filter.conf
+    @include kubernetes-filter.conf
+    @include extra.conf
+
+    # Send to storage
+    @include output.conf
+
+  forward-input.conf: |
+    <source>
+      @type forward
+      port 24224
+      bind 0.0.0.0
+    </source>
+
+  forward-output.conf: |
+    <match **>
+      @type forward
+      require_ack_response true
+      ack_response_timeout 30
+      recover_wait 10s
+      heartbeat_interval 1s
+      phi_threshold 16
+      send_timeout 10s
+      hard_timeout 10s
+      expire_dns_cache 15
+
+      heartbeat_type tcp
+
+      buffer_chunk_limit 2M
+      buffer_queue_limit 32
+      flush_interval 5s
+      max_retry_wait 15
+      disable_retry_limit
+      num_threads 8
+
+      <server>
+        name fluentd-aggregator
+        host fluentd-aggregator.logging.svc.cluster.local
+        weight 60
+      </server>
+    </match>
+
+  general.conf: |
+    # Prevent fluentd from handling records containing its own logs. Otherwise
+    # it can lead to an infinite loop, when error in sending one message generates
+    # another message which also fails to be sent and so on.
+    <match fluent.**>
+      type null
+    </match>
+
+    # Used for health checking
+    <source>
+      @type http
+      port 9880
+      bind 0.0.0.0
+    </source>
+
+    # Emits internal metrics to every minute, and also exposes them on port
+    # 24220. Useful for determining if an output plugin is retryring/erroring,
+    # or determining the buffer queue length.
+    <source>
+      @type monitor_agent
+      bind 0.0.0.0
+      port 24220
+      tag fluentd.monitor.metrics
+    </source>
+
+
+  prometheus.conf: |
+    # input plugin that is required to expose metrics by other prometheus
+    # plugins, such as the prometheus_monitor input below.
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port 24231
+      metrics_path /metrics
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent and exposes them
+    # as prometheus metrics
+    <source>
+      @type prometheus_monitor
+      # update the metrics every 5 seconds
+      interval 5
+    </source>
+
+    <source>
+      @type prometheus_output_monitor
+      interval 5
+    </source>
+
+    <source>
+      @type prometheus_tail_monitor
+      interval 5
+    </source>
+
+  systemd.conf: |
+    @include systemd-input.conf
+    @include systemd-filter.conf
+
+  systemd-input.conf: |
+    <source>
+      @type systemd
+      pos_file /var/log/fluentd-journald-systemd.pos
+      read_from_head true
+      strip_underscores true
+      tag systemd
+    </source>
+
+  systemd-filter.conf: |
+    <match systemd>
+      @type rewrite_tag_filter
+      rewriterule1 SYSTEMD_UNIT   ^(.+).service$  systemd.$1
+      rewriterule2 SYSTEMD_UNIT   !^(.+).service$ systemd.unmatched
+    </match>
+
+    <filter systemd.kubelet>
+      type parser
+      format kubernetes
+      reserve_data true
+      key_name MESSAGE
+      suppress_parse_error_log true
+    </filter>
+
+    <filter systemd.docker>
+      type parser
+      format /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+      reserve_data true
+      key_name MESSAGE
+      suppress_parse_error_log true
+    </filter>
+
+    # Filter filter ssh logs since it's mostly bots trying to login
+    <filter systemd.**>
+      @type grep
+      exclude1 SYSTEMD_UNIT (sshd@.*\.service)
+    </filter>
+
+  kubernetes.conf: |
+    @include kubernetes-input.conf
+    @include kubernetes-filter.conf
+
+  kubernetes-input.conf: |
+    # Capture Kubernetes pod logs
+    # The kubelet creates symlinks that capture the pod name, namespace,
+    # container name & Docker container ID to the docker logs for pods in the
+    # /var/log/containers directory on the host.
+    <source>
+      type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      time_format %Y-%m-%dT%H:%M:%S.%NZ
+      tag kubernetes.*
+      format json
+      read_from_head true
+    </source>
+
+  kubernetes-filter.conf: |
+    # Query the API for extra metadata.
+    <filter kubernetes.**>
+      type kubernetes_metadata
+      # If the logs begin with '{' and end with '}' then it's JSON so merge
+      # the JSON log field into the log event
+      merge_json_log true
+      preserve_json_log true
+    </filter>
+
+    # rewrite_tag_filter does not support nested fields like
+    # kubernetes.container_name, so this exists to flatten the fields
+    # so we can use them in our rewrite_tag_filter
+    <filter kubernetes.**>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        kubernetes_namespace_container_name ${record["kubernetes"]["namespace_name"]}.${record["kubernetes"]["container_name"]}
+      </record>
+    </filter>
+
+    # retag based on the container name of the log message
+    <match kubernetes.**>
+      @type rewrite_tag_filter
+      rewriterule1 kubernetes_namespace_container_name  ^(.+)$ kube.$1
+    </match>
+
+    # Remove the unnecessary field as the information is already available on
+    # other fields.
+    <filter kube.**>
+      @type record_transformer
+      remove_keys kubernetes_namespace_container_name
+    </filter>
+
+    <filter kube.kube-system.**>
+      type parser
+      format kubernetes
+      reserve_data true
+      key_name log
+      suppress_parse_error_log true
+    </filter>
+
+  apiserver-audit-input.conf: |
+    # Example:
+    # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+    # 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+    <source>
+      type tail
+      format multiline
+      multiline_flush_interval 5s
+      format_firstline /^\S+\s+AUDIT:/
+      # Fields must be explicitly captured by name to be parsed into the record.
+      # Fields may not always be present, and order may change, so this just looks
+      # for a list of key="\"quoted\" value" pairs separated by spaces.
+      # Unknown fields are ignored.
+      # Note: We can't separate query/response lines as format1/format2 because
+      #       they don't always come one after the other for a given query.
+      format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+      time_format %FT%T.%L%Z
+      path /var/log/kubernetes/kube-apiserver-audit.log
+      pos_file /var/log/kube-apiserver-audit.log.pos
+      tag kube-apiserver-audit
+    </source>
+
+  output.conf: |
+    <match **>
+      type elasticsearch
+      log_level info
+      include_tag_key true
+      # Replace with the host/port to your Elasticsearch cluster.
+      # This assumes a service `elasticsearch` exists in the default namespace
+      host elasticsearch.elasticsearch.svc.cluster.local
+      port 9200
+      scheme http
+      ssl_verify false
+
+      logstash_format true
+      template_file /fluentd/etc/elasticsearch-template-es5x.json
+      template_name elasticsearch-template-es5x.json
+
+      buffer_chunk_limit 2M
+      buffer_queue_limit 32
+      flush_interval 10s
+      max_retry_wait 30
+      disable_retry_limit
+      num_threads 8
+
+    </match>
+
+  elasticsearch-template-es5x.json: |
+    {
+      "template" : "logstash-*",
+      "version" : 50001,
+      "settings" : {
+        "index.refresh_interval" : "5s",
+        "number_of_shards": 1
+      },
+      "mappings" : {
+        "_default_" : {
+          "_all" : {"enabled" : true, "norms" : false},
+          "dynamic_templates" : [ {
+            "message_field" : {
+              "path_match" : "message",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text",
+                "norms" : false
+              }
+            }
+          }, {
+            "string_fields" : {
+              "match" : "*",
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "text", "norms" : false,
+                "fields" : {
+                  "keyword" : { "type": "keyword" }
+                }
+              }
+            }
+          } ],
+          "properties" : {
+            "@timestamp": { "type": "date", "include_in_all": false },
+            "@version": { "type": "keyword", "include_in_all": false },
+            "geoip"  : {
+              "dynamic": true,
+              "properties" : {
+                "ip": { "type": "ip" },
+                "location" : { "type" : "geo_point" },
+                "latitude" : { "type" : "half_float" },
+                "longitude" : { "type" : "half_float" }
+              }
+            }
+          }
+        }
+      }
+    }
+  extra.conf: |
+    # Example filter that adds an extra field "cluster_name" to all log
+    # messages:
+    # <filter **>
+    #   @type record_transformer
+    #   <record>
+    #     cluster_name "your_cluster_name"
+    #   </record>
+    # </filter>
+

--- a/Documentation/files/logging/fluentd-ds.yaml
+++ b/Documentation/files/logging/fluentd-ds.yaml
@@ -1,0 +1,77 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    app: fluentd
+    component: logging-agent
+spec:
+  minReadySeconds: 10
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: fluentd
+    spec:
+      containers:
+      - name: fluentd
+        image: quay.io/coreos/fluentd-kubernetes:v0.12-debian-elasticsearch
+        imagePullPolicy: Always
+        command: ["fluentd", "-c", "/fluentd/etc/fluentd.conf", "-p", "/fluentd/plugins"]
+        env:
+        - name: FLUENTD_CONFIG
+          value: fluentd-standalone.conf
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 500m
+            memory: 200Mi
+        ports:
+        - name: prom-metrics
+          containerPort: 24231
+          protocol: TCP
+        - name: monitor-agent
+          containerPort: 24220
+          protocol: TCP
+        - name: http-input
+          containerPort: 9880
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            # Use percent encoding for query param.
+            # The value is {"log": "health check"}.
+            # the endpoint itself results in a new fluentd
+            # tag 'fluentd.pod-healthcheck'
+            path: /fluentd.pod.healthcheck?json=%7B%22log%22%3A+%22health+check%22%7D
+            port: 9880
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluentd-config
+          mountPath: /fluentd/etc
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluentd-config
+        configMap:
+          name: "fluentd-config"
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/Documentation/files/logging/fluentd-namespace.yaml
+++ b/Documentation/files/logging/fluentd-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fluentd

--- a/Documentation/files/logging/fluentd-role-binding.yaml
+++ b/Documentation/files/logging/fluentd-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd-read
+  namespace: logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd-read
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: logging

--- a/Documentation/files/logging/fluentd-role.yaml
+++ b/Documentation/files/logging/fluentd-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd-read
+  namespace: logging
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]

--- a/Documentation/files/logging/fluentd-service-account.yaml
+++ b/Documentation/files/logging/fluentd-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: logging

--- a/Documentation/files/logging/fluentd-svc.yaml
+++ b/Documentation/files/logging/fluentd-svc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    app: fluentd
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: fluentd
+  ports:
+  # Exposes Prometheus metrics
+  - name: prometheus-metrics
+    port: 24231
+    targetPort: prom-metrics
+    protocol: TCP
+  # Can be accessed using "kubectl proxy" at:
+  # http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/fluentd:monitor-agent/api/plugins.json
+  - name: monitor-agent
+    port: 24220
+    targetPort: monitor-agent
+    protocol: TCP

--- a/Documentation/files/logging/monitoring/fluentd-prometheus-service-monitor.yaml
+++ b/Documentation/files/logging/monitoring/fluentd-prometheus-service-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ServiceMonitor
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    app: fluentd
+spec:
+  jobLabel: app
+  selector:
+    matchExpressions:
+    - {key: app, operator: In, values: [fluentd, fluentd-aggregator]}
+  namespaceSelector:
+    any: false
+    matchNames:
+    - logging
+  endpoints:
+  - port: prometheus-metrics
+    interval: 15s

--- a/Documentation/files/logging/monitoring/prometheus-fluentd-role-binding.yaml
+++ b/Documentation/files/logging/monitoring/prometheus-fluentd-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-fluentd
+  namespace: logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-fluentd
+  namespace: logging

--- a/Documentation/files/logging/monitoring/prometheus-fluentd-service-account.yaml
+++ b/Documentation/files/logging/monitoring/prometheus-fluentd-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-fluentd
+  namespace: logging

--- a/Documentation/files/logging/monitoring/prometheus-fluentd.yaml
+++ b/Documentation/files/logging/monitoring/prometheus-fluentd.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: Prometheus
+metadata:
+  name: fluentd
+  namespace: logging
+  labels:
+    prometheus: fluentd
+    component: monitoring
+spec:
+  replicas: 1
+  serviceAccountName: prometheus-fluentd
+  serviceMonitorSelector:
+    matchLabels:
+      app: fluentd
+  resources:
+    requests:
+      memory: 250Mi


### PR DESCRIPTION
Adds manifests for deploying a fluentd based logging stack, along with manifests for enabling prometheus to collect metrics from fluentd.

This document assumes you have somewhere to store logs, such as Elasticsearch, but does not document configuring/setting these services up. It also documents potential other storage destinations, but I haven't tested it using anything other than an Elasticsearch cluster deployed on k8s (using the setup from pires/kubernetes-elasticsearch), that said, changing the backend shouldn't be too difficult.

I haven't written an sort of conclusion section because generally that would be "view your logs in Kibana", but wasn't sure if I should include that, since I'm trying to not assume where your logs are stored too much.

One thing I'm considering is whether I should put this into the tutorials section, rather than admin. It wasn't super obvious, but it feels like a tutorial, but is primarily targeted at admins of a cluster, not users of a cluster.