### PR TITLE
Update external links on the last success screen

### DIFF
--- a/installer/frontend/components/success.jsx
+++ b/installer/frontend/components/success.jsx
@@ -48,7 +48,7 @@ export const Success = connect(stateToProps)(
       <p>
         You can interact with nodes and deploy your Kubernetes-aware applications with kubectl. See the <a href="https://kubernetes.io/docs/tasks/kubectl/install/" target="_blank">upstream kubectl documentation</a> for more details.
       </p>
-      <a href="https://kubernetes.io/docs/tasks/kubectl/install/" target="_blank"><button className="btn btn-default" style={{marginTop: 20}}>Configure kubectl&nbsp;&nbsp;<i className="fa fa-external-link"></i></button></a>
+      <a href="https://coreos.com/tectonic/docs/latest/tutorials/first-app.html#configuring-credentials" target="_blank"><button className="btn btn-default" style={{marginTop: 20}}>Configure kubectl&nbsp;&nbsp;<i className="fa fa-external-link"></i></button></a>
     </div>
   </div>
   <hr className="spacer" />
@@ -59,7 +59,7 @@ export const Success = connect(stateToProps)(
       <p>
         Once you have kubectl set up, learn how to deploy your first app!
       </p>
-      <a href="https://coreos.com/tectonic/docs/latest/usage/first-app.html" target="_blank"><button className="btn btn-default" style={{marginTop: 20}}>Deploy Application&nbsp;&nbsp;<i className="fa fa-external-link"></i></button></a>
+      <a href="https://coreos.com/tectonic/docs/latest/tutorials/first-app.html#deploying-a-simple-application" target="_blank"><button className="btn btn-default" style={{marginTop: 20}}>Deploy Application&nbsp;&nbsp;<i className="fa fa-external-link"></i></button></a>
     </div>
   </div>
   <hr className="spacer" />


### PR DESCRIPTION
* Update "kubectl link" to "Configuring credentials" on CoreOS tutorial / doc site for specific steps to download kubectl / kubectl-config in Tectonic Console.
https://coreos.com/tectonic/docs/latest/tutorials/first-app.html#configuring-credentials

* Update "deploy your app" link to "Deploying a simple application" on CoreOS tutorial / doc site
https://coreos.com/tectonic/docs/latest/tutorials/first-app.html#deploying-a-simple-application

<img width="1225" alt="external_links _installation_complete_screen__0428_2017" src="https://cloud.githubusercontent.com/assets/5903705/25549340/1d4868e2-2c26-11e7-9f7c-916036d6686e.png">
