### PR TITLE
Clean up git-version script.

### DIFF
--- a/git-version
+++ b/git-version
@@ -1,7 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 # pull the current git commit hash
-COMMIT=`git rev-parse HEAD`
+COMMIT=$(git rev-parse HEAD)
 
 # check if the current commit has a matching tag
 TAG=$(git describe --exact-match --abbrev=0 --tags ${COMMIT} 2> /dev/null || true)
@@ -18,4 +20,4 @@ if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
 	VERSION="${VERSION}_dirty"
 fi
 
-echo $VERSION
+echo "$VERSION"


### PR DESCRIPTION
- bash doesn't always exist in /bin
- Use $() instead of backticks
- Wrap string in double-quotes to prevent globbing/splitting. (see https://github.com/koalaman/shellcheck/wiki/SC2086)

I doubt anyone cares, but this change makes it possible to build & use the tectonic installer on freebsd. (Yes I actually tested this.)