### PR TITLE
Extend timeout for terraform apply test

### DIFF
--- a/installer/server/terraform/executor_test.go
+++ b/installer/server/terraform/executor_test.go
@@ -80,7 +80,7 @@ func TestExecutorSimple(t *testing.T) {
 	// Wait for its termination.
 	select {
 	case <-done:
-	case <-time.After(1 * time.Second):
+	case <-time.After(10 * time.Second):
 		assert.FailNow(t, "TerraForm apply timed out")
 	}
 


### PR DESCRIPTION
The test `TestExecutorSimple` was frequently timing out when the Jenkins executors are overloaded. Extending the timeout to ensure this passes.

/cc @Quentin-M 