### PR TITLE
server/terraform: create the executor next to the installer

### DIFF
--- a/installer/server/terraform/executor.go
+++ b/installer/server/terraform/executor.go
@@ -80,32 +80,13 @@ type Executor struct {
 }
 
 // NewExecutor initializes a new Executor.
-func NewExecutor() (*Executor, error) {
-	// Create a temporary folder in which the new Executor can run.
-	executionPath, err := ioutil.TempDir(os.TempDir(), "tectonic")
-	if err != nil {
-		return nil, err
-	}
-
-	// Create an executor in that path.
-	ex, err := NewExecutorFromPath(executionPath)
-	if err != nil {
-		os.RemoveAll(executionPath)
-		return nil, err
-	}
-
-	return ex, err
-}
-
-// NewExecutorFromPath creates an Executor from an existing path.
-func NewExecutorFromPath(executionPath string) (*Executor, error) {
-	var err error
-
+func NewExecutor(executionPath string) (*Executor, error) {
 	ex := new(Executor)
 	ex.executionPath = executionPath
 
-	// Create the folder in which the logs will be stored, if not existing.
-	os.Mkdir(filepath.Join(ex.executionPath, logsFolderName), 0770)
+	// Create the folder in which the executor, and its logs will be stored,
+	// if not existing.
+	os.MkdirAll(filepath.Join(ex.executionPath, logsFolderName), 0770)
 
 	// Create a Executor CLI configuration file, that contains the list of
 	// vendored providers/provisioners.

--- a/installer/server/terraform/executor_test.go
+++ b/installer/server/terraform/executor_test.go
@@ -52,8 +52,14 @@ func TestMain(m *testing.M) {
 // worked (State/Status), and then create a new executor at the path of the
 // existing one and verify the state is shared.
 func TestExecutorSimple(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "tectonic")
+	if err != nil {
+		t.Logf("Failed to create temporary directory: %s", err)
+		t.FailNow()
+	}
+
 	// Create an executor.
-	ex, err := NewExecutor()
+	ex, err := NewExecutor(tmpDir)
 	if err == ErrBinaryNotFound {
 		t.Skip("TerraForm not found, skipping")
 		return
@@ -98,7 +104,7 @@ func TestExecutorSimple(t *testing.T) {
 	assert.NotZero(t, len(outputBytes))
 
 	// Creates a new executor at the same existing one.
-	ex2, err := NewExecutorFromPath(ex.WorkingDirectory())
+	ex2, err := NewExecutor(ex.WorkingDirectory())
 	assert.Nil(t, err)
 	assert.NotNil(t, ex2)
 
@@ -111,8 +117,14 @@ func TestExecutorSimple(t *testing.T) {
 // TestExecutorMissingVar executes TerraForm apply with missing variables and
 // ensures it failed.
 func TestExecutorMissingVar(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "tectonic")
+	if err != nil {
+		t.Logf("Failed to create temporary directory: %s", err)
+		t.FailNow()
+	}
+
 	// Create an executor.
-	ex, err := NewExecutor()
+	ex, err := NewExecutor(tmpDir)
 	if err == ErrBinaryNotFound {
 		t.Skip("TerraForm not found, skipping")
 		return
@@ -135,7 +147,7 @@ func TestExecutorMissingVar(t *testing.T) {
 	// Wait for its termination.
 	select {
 	case <-done:
-	case <-time.After(1 * time.Second):
+	case <-time.After(10 * time.Second):
 		assert.FailNow(t, "TerraForm apply timed out")
 	}
 


### PR DESCRIPTION
Rather than tmp, so users always have the assets somewhere,
regardless of whether they download them or not, and
regardless of potential system reboots.

We should probably have a flag / env variable that controls that,
but we have little time right now. Must switch to doing self-hosted etcd
cleanup for the release now.

Fixes #446 