### PR TITLE
Remove etcd gateway

### DIFF
--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -6,7 +6,6 @@ data "ignition_config" "main" {
   ]
 
   systemd = [
-    "${data.ignition_systemd_unit.etcd-member.id}",
     "${data.ignition_systemd_unit.docker.id}",
     "${data.ignition_systemd_unit.locksmithd.id}",
     "${data.ignition_systemd_unit.kubelet.id}",
@@ -66,27 +65,6 @@ data "ignition_systemd_unit" "kubelet-env" {
   name    = "kubelet-env.service"
   enable  = true
   content = "${data.template_file.kubelet-env.rendered}"
-}
-
-data "template_file" "etcd-member" {
-  template = "${file("${path.module}/resources/services/etcd-member.service")}"
-
-  vars {
-    image     = "${var.container_images["etcd"]}"
-    endpoints = "${join(",", formatlist("%s:2379", var.etcd_endpoints))}"
-  }
-}
-
-data "ignition_systemd_unit" "etcd-member" {
-  name   = "etcd-member.service"
-  enable = "${var.etcd_gateway_enabled}"
-
-  dropin = [
-    {
-      name    = "40-etcd-gateway.conf"
-      content = "${data.template_file.etcd-member.rendered}"
-    },
-  ]
 }
 
 data "ignition_file" "max-user-watches" {

--- a/modules/aws/ignition/resources/services/etcd-member.service
+++ b/modules/aws/ignition/resources/services/etcd-member.service
@@ -1,6 +1,0 @@
-[Service]
-Environment="ETCD_IMAGE=${image}"
-ExecStart=
-ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
-    --listen-addr=127.0.0.1:2379 \
-    --endpoints=${endpoints}

--- a/modules/aws/ignition/variables.tf
+++ b/modules/aws/ignition/variables.tf
@@ -28,16 +28,6 @@ variable "kubelet_node_taints" {
   description = "Taints that Kubelet will apply on the node"
 }
 
-variable "etcd_endpoints" {
-  type        = "list"
-  description = "List of etcd endpoints"
-}
-
-variable "etcd_gateway_enabled" {
-  description = "Specifies whether the etcd gateway should be enabled or not."
-  default     = true
-}
-
 variable "bootkube_service" {
   type        = "string"
   description = "The content of the bootkube systemd service unit"
@@ -50,10 +40,5 @@ variable "tectonic_service" {
 
 variable "tectonic_service_disabled" {
   description = "Specifies whether the tectonic installer systemd unit will be disabled. If true, no tectonic assets will be deployed"
-  default     = false
-}
-
-variable "locksmithd_disabled" {
-  description = "Specifies whether locksmith will be disabled or not"
   default     = false
 }

--- a/modules/azure/master/ignition-master.tf
+++ b/modules/azure/master/ignition-master.tf
@@ -6,7 +6,6 @@ data "ignition_config" "master" {
   ]
 
   systemd = [
-    "${data.ignition_systemd_unit.etcd-member.id}",
     "${data.ignition_systemd_unit.docker.id}",
     "${data.ignition_systemd_unit.locksmithd.id}",
     "${data.ignition_systemd_unit.kubelet-master.id}",
@@ -59,27 +58,6 @@ data "ignition_systemd_unit" "kubelet-master" {
   name    = "kubelet.service"
   enable  = true
   content = "${data.template_file.kubelet-master.rendered}"
-}
-
-data "template_file" "etcd-member" {
-  template = "${file("${path.module}/resources/etcd-member.service")}"
-
-  vars {
-    version   = "${var.tectonic_versions["etcd"]}"
-    endpoints = "${join(",",formatlist("%s:2379",var.etcd_endpoints))}"
-  }
-}
-
-data "ignition_systemd_unit" "etcd-member" {
-  name   = "etcd-member.service"
-  enable = true
-
-  dropin = [
-    {
-      name    = "40-etcd-gateway.conf"
-      content = "${data.template_file.etcd-member.rendered}"
-    },
-  ]
 }
 
 data "ignition_file" "kubeconfig" {

--- a/modules/azure/master/resources/etcd-member.service
+++ b/modules/azure/master/resources/etcd-member.service
@@ -1,6 +1,0 @@
-[Service]
-Environment="ETCD_IMAGE_TAG=${version}"
-ExecStart=
-ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
-    --listen-addr=127.0.0.1:2379 \
-    --endpoints=${endpoints}

--- a/modules/azure/master/variables.tf
+++ b/modules/azure/master/variables.tf
@@ -57,14 +57,6 @@ variable "master_count" {
   type = "string"
 }
 
-variable "etcd_endpoints" {
-  type = "list"
-}
-
-variable "tectonic_versions" {
-  type = "map"
-}
-
 variable "tectonic_kube_dns_service_ip" {
   type = "string"
 }

--- a/modules/azure/worker/ignition-worker.tf
+++ b/modules/azure/worker/ignition-worker.tf
@@ -6,7 +6,6 @@ data "ignition_config" "worker" {
   ]
 
   systemd = [
-    "${data.ignition_systemd_unit.etcd-member.id}",
     "${data.ignition_systemd_unit.docker.id}",
     "${data.ignition_systemd_unit.locksmithd.id}",
     "${data.ignition_systemd_unit.kubelet-worker.id}",
@@ -48,27 +47,6 @@ data "ignition_systemd_unit" "kubelet-worker" {
   name    = "kubelet.service"
   enable  = true
   content = "${data.template_file.kubelet-worker.rendered}"
-}
-
-data "template_file" "etcd-member" {
-  template = "${file("${path.module}/resources/etcd-member.service")}"
-
-  vars {
-    version   = "${var.tectonic_versions["etcd"]}"
-    endpoints = "${join(",",formatlist("%s:2379",var.etcd_endpoints))}"
-  }
-}
-
-data "ignition_systemd_unit" "etcd-member" {
-  name   = "etcd-member.service"
-  enable = true
-
-  dropin = [
-    {
-      name    = "40-etcd-gateway.conf"
-      content = "${data.template_file.etcd-member.rendered}"
-    },
-  ]
 }
 
 data "ignition_file" "kubeconfig" {

--- a/modules/azure/worker/resources/etcd-member.service
+++ b/modules/azure/worker/resources/etcd-member.service
@@ -1,6 +1,0 @@
-[Service]
-Environment="ETCD_IMAGE_TAG=${version}"
-ExecStart=
-ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
-    --listen-addr=127.0.0.1:2379 \
-    --endpoints=${endpoints}

--- a/modules/azure/worker/variables.tf
+++ b/modules/azure/worker/variables.tf
@@ -58,14 +58,6 @@ variable "kubeconfig_content" {
   default = ""
 }
 
-variable "tectonic_versions" {
-  type = "map"
-}
-
-variable "etcd_endpoints" {
-  type = "list"
-}
-
 variable "tectonic_kube_dns_service_ip" {
   type = "string"
 }

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -39,10 +39,6 @@ output "systemd_service" {
   value = "${data.template_file.bootkube_service.rendered}"
 }
 
-output "etcd_gateway_enabled" {
-  value = "${!var.experimental_enabled && data.null_data_source.etcd.outputs.no_certs}"
-}
-
 output "content_hash" {
   value = "${sha1("${template_dir.bootkube-bootstrap.id} ${template_dir.bootkube.id} ${join(" ",local_file.etcd-operator.*.id,local_file.etcd-service.*.id,local_file.bootstrap-etcd.*.id)}")}"
 

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -14,7 +14,6 @@ data "ignition_config" "node" {
   ]
 
   systemd = [
-    "${data.ignition_systemd_unit.etcd-member.id}",
     "${data.ignition_systemd_unit.docker.id}",
     "${data.ignition_systemd_unit.locksmithd.id}",
     "${data.ignition_systemd_unit.kubelet.id}",
@@ -82,27 +81,6 @@ data "ignition_systemd_unit" "kubelet" {
   name    = "kubelet.service"
   enable  = true
   content = "${data.template_file.kubelet.rendered}"
-}
-
-data "template_file" "etcd-member" {
-  template = "${file("${path.module}/resources/etcd-member.service")}"
-
-  vars {
-    version   = "${var.tectonic_versions["etcd"]}"
-    endpoints = "${join(",", formatlist("%s:2379", var.etcd_fqdns))}"
-  }
-}
-
-data "ignition_systemd_unit" "etcd-member" {
-  name   = "etcd-member.service"
-  enable = true
-
-  dropin = [
-    {
-      name    = "40-etcd-gateway.conf"
-      content = "${data.template_file.etcd-member.rendered}"
-    },
-  ]
 }
 
 data "ignition_file" "kubeconfig" {

--- a/modules/openstack/nodes/variables.tf
+++ b/modules/openstack/nodes/variables.tf
@@ -18,11 +18,6 @@ variable resolv_conf_content {
   type = "string"
 }
 
-// The fqdns of the etcd endpoints.
-variable etcd_fqdns {
-  type = "list"
-}
-
 // The amount of nodes to be created.
 // Example: `3`
 variable "instance_count" {
@@ -37,10 +32,6 @@ variable "core_public_keys" {
 // The master hostnames will be prefixed with this.
 variable "cluster_name" {
   type = "string"
-}
-
-variable "tectonic_versions" {
-  type = "map"
 }
 
 variable "tectonic_kube_dns_service_ip" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -80,15 +80,12 @@ module "ignition-masters" {
   kubelet_node_label        = "node-role.kubernetes.io/master"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
   kube_dns_service_ip       = "${var.tectonic_kube_dns_service_ip}"
-  etcd_endpoints            = ["${module.etcd.endpoints}"]
-  etcd_gateway_enabled      = "${module.bootkube.etcd_gateway_enabled}"
   kubeconfig_s3_location    = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
   assets_s3_location        = "${aws_s3_bucket_object.tectonic-assets.bucket}/${aws_s3_bucket_object.tectonic-assets.key}"
   container_images          = "${var.tectonic_container_images}"
   bootkube_service          = "${module.bootkube.systemd_service}"
   tectonic_service          = "${module.tectonic.systemd_service}"
   tectonic_service_disabled = "${var.tectonic_vanilla_k8s}"
-  locksmithd_disabled       = "${var.tectonic_experimental}"
 }
 
 module "masters" {
@@ -127,13 +124,11 @@ module "ignition-workers" {
   kubelet_node_label     = "node-role.kubernetes.io/node"
   kubelet_node_taints    = ""
   kube_dns_service_ip    = "${var.tectonic_kube_dns_service_ip}"
-  etcd_endpoints         = ["${module.etcd.endpoints}"]
   kubeconfig_s3_location = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
   assets_s3_location     = ""
   container_images       = "${var.tectonic_container_images}"
   bootkube_service       = ""
   tectonic_service       = ""
-  locksmithd_disabled    = "${var.tectonic_experimental}"
 }
 
 module "workers" {

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -48,9 +48,7 @@ module "masters" {
   subnet                       = "${module.vnet.master_subnet}"
   kube_image_url               = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
   kube_image_tag               = "${element(split(":", var.tectonic_container_images["hyperkube"]), 1)}"
-  etcd_endpoints               = ["${module.etcd.ip_address}"]
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
-  tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   cloud_provider               = ""
   kubelet_node_label           = "node-role.kubernetes.io/master"
@@ -76,9 +74,7 @@ module "workers" {
   subnet                       = "${module.vnet.worker_subnet}"
   kube_image_url               = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
   kube_image_tag               = "${element(split(":", var.tectonic_container_images["hyperkube"]), 1)}"
-  etcd_endpoints               = ["${module.etcd.ip_address}"]
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
-  tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   cloud_provider               = ""
   kubelet_node_label           = "node-role.kubernetes.io/node"

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -1,17 +1,6 @@
 ---
 systemd:
   units:
-    - name: etcd-member.service
-      enable: true
-      dropins:
-        - name: 40-etcd-cluster.conf
-          contents: |
-            [Service]
-            Environment="ETCD_IMAGE_TAG={{.etcd_image_tag}}"
-            ExecStart=
-            ExecStart=/usr/lib/coreos/etcd-wrapper gateway start \
-              --listen-addr=127.0.0.1:2379 \
-              --endpoints={{.etcd_endpoints}}
     - name: docker.service
       enable: true
     - name: locksmithd.service

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -55,13 +55,11 @@ resource "matchbox_group" "worker" {
 
   metadata {
     domain_name        = "${element(var.tectonic_metal_worker_domains, count.index)}"
-    etcd_endpoints     = "${join(",", formatlist("%s:2379", var.tectonic_metal_controller_domains))}"
     k8s_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
     ssh_authorized_key = "${var.tectonic_ssh_authorized_key}"
 
     # extra data
-    etcd_image_tag     = "${var.tectonic_versions["etcd"]}"
-    kubelet_image_url  = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
-    kube_version_image = "${var.tectonic_container_images["kube_version"]}"
+    kubelet_image_url = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
+    kubelet_image_tag = "${element(split(":", var.tectonic_container_images["hyperkube"]), 1)}"
   }
 }

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -95,12 +95,10 @@ nameserver 8.8.4.4
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
-  etcd_fqdns                   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
   cluster_name                 = "${var.tectonic_cluster_name}"
   instance_count               = "${var.tectonic_master_count}"
   kube_image_url               = "${data.null_data_source.local.outputs.kube_image_url}"
   kube_image_tag               = "${data.null_data_source.local.outputs.kube_image_tag}"
-  tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   core_public_keys             = ["${module.secrets.core_public_key_openssh}"]
   bootkube_service             = "${module.bootkube.systemd_service}"
@@ -120,12 +118,10 @@ nameserver 8.8.4.4
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
-  etcd_fqdns                   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
   cluster_name                 = "${var.tectonic_cluster_name}"
   instance_count               = "${var.tectonic_worker_count}"
   kube_image_url               = "${data.null_data_source.local.outputs.kube_image_url}"
   kube_image_tag               = "${data.null_data_source.local.outputs.kube_image_tag}"
-  tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   core_public_keys             = ["${module.secrets.core_public_key_openssh}"]
   bootkube_service             = ""

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -95,12 +95,10 @@ nameserver 8.8.4.4
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
-  etcd_fqdns                   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
   cluster_name                 = "${var.tectonic_cluster_name}"
   instance_count               = "${var.tectonic_master_count}"
   kube_image_url               = "${data.null_data_source.local.outputs.kube_image_url}"
   kube_image_tag               = "${data.null_data_source.local.outputs.kube_image_tag}"
-  tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   core_public_keys             = ["${module.secrets.core_public_key_openssh}"]
   bootkube_service             = "${module.bootkube.systemd_service}"
@@ -119,12 +117,10 @@ nameserver 8.8.4.4
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
-  etcd_fqdns                   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
   cluster_name                 = "${var.tectonic_cluster_name}"
   instance_count               = "${var.tectonic_worker_count}"
   kube_image_url               = "${data.null_data_source.local.outputs.kube_image_url}"
   kube_image_tag               = "${data.null_data_source.local.outputs.kube_image_tag}"
-  tectonic_versions            = "${var.tectonic_versions}"
   tectonic_kube_dns_service_ip = "${var.tectonic_kube_dns_service_ip}"
   core_public_keys             = ["${module.secrets.core_public_key_openssh}"]
   bootkube_service             = ""


### PR DESCRIPTION
Hey.

@s-urbaniak could you take a look at the second commit and tell me why this line was the way it was? It seems like you introduced the `127.0.0.1:2379` endpoint in there.

@s-urbaniak @squat From looking on what gets created on AWS, it looks like the security groups regarding to etcd are not too bad? Is there something we need to remove there?