### PR TITLE
platforms/aws: use local IP as api server advertise address

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -39,7 +39,6 @@ resource "template_dir" "bootkube" {
     cluster_cidr        = "${var.cluster_cidr}"
     service_cidr        = "${var.service_cidr}"
     kube_dns_service_ip = "${var.kube_dns_service_ip}"
-    advertise_address   = "${var.advertise_address}"
 
     anonymous_auth      = "${var.anonymous_auth}"
     oidc_issuer_url     = "${var.oidc_issuer_url}"
@@ -73,10 +72,9 @@ resource "template_dir" "bootkube-bootstrap" {
     etcd_cert_flag = "${data.null_data_source.etcd.outputs.cert_flag}"
     etcd_key_flag  = "${data.null_data_source.etcd.outputs.key_flag}"
 
-    advertise_address = "${var.advertise_address}"
-    cloud_provider    = "${var.cloud_provider}"
-    cluster_cidr      = "${var.cluster_cidr}"
-    service_cidr      = "${var.service_cidr}"
+    cloud_provider = "${var.cloud_provider}"
+    cluster_cidr   = "${var.cluster_cidr}"
+    service_cidr   = "${var.service_cidr}"
   }
 }
 
@@ -170,7 +168,8 @@ data "template_file" "bootkube" {
   template = "${file("${path.module}/resources/bootkube.sh")}"
 
   vars {
-    bootkube_image = "${var.container_images["bootkube"]}"
+    advertise_address = "${var.advertise_address}"
+    bootkube_image    = "${var.container_images["bootkube"]}"
   }
 }
 

--- a/modules/bootkube/resources/bootkube.service
+++ b/modules/bootkube/resources/bootkube.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=Bootstrap a Kubernetes cluster
 ConditionPathExists=!/opt/tectonic/init_bootkube.done
+Requires=coreos-metadata.service
+After=coreos-metadata.service
 
 [Service]
+EnvironmentFile=/run/metadata/coreos
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/opt/tectonic

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -6,6 +6,10 @@
 # be missing for now, making bootkube crash.
 mkdir -p /etc/kubernetes/manifests/
 
+for f in bootstrap-manifests/bootstrap-apiserver.yaml manifests/kube-apiserver.yaml; do
+    sed -i s/\$$ADVERTISE_ADDRESS/${advertise_address}/ "$f"
+done
+
 /usr/bin/rkt run \
   --trust-keys-from-https \
   --volume assets,kind=host,source=$(pwd) \

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -25,7 +25,7 @@ spec:
     ${etcd_cert_flag}
     ${etcd_key_flag}
     - --insecure-port=0
-    - --advertise-address=${advertise_address}
+    - --advertise-address=$$ADVERTISE_ADDRESS
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
     - --secure-port=443

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -29,7 +29,7 @@ spec:
         - --bind-address=0.0.0.0
         - --secure-port=443
         - --insecure-port=0
-        - --advertise-address=${advertise_address}
+        - --advertise-address=$$ADVERTISE_ADDRESS
         - --etcd-servers=${etcd_servers}
         ${etcd_ca_flag}
         ${etcd_cert_flag}

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -18,7 +18,7 @@ module "bootkube" {
   kube_apiserver_service_ip = "${var.tectonic_kube_apiserver_service_ip}"
   kube_dns_service_ip       = "${var.tectonic_kube_dns_service_ip}"
 
-  advertise_address = "0.0.0.0"
+  advertise_address = "$$COREOS_EC2_IPV4_LOCAL"
   anonymous_auth    = "false"
 
   oidc_username_claim = "email"


### PR DESCRIPTION
While not being an optimal solution, this prevents flipping the API server
endpoint and thus kube-proxy rewriting iptables rules constantly which has
performance impacts.

This fixes it by setting the API server advertise address to the local IP
address of the launched node.

Fixes #384