### PR TITLE
platform/metal: Add kubelet-env.service to workers

### DIFF
--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -38,11 +38,26 @@ systemd:
         ExecStart=/bin/sh -c 'while ! /usr/bin/grep '^[^#[:space:]]' /etc/resolv.conf > /dev/null; do sleep 1; done'
         [Install]
         RequiredBy=kubelet.service
+    - name: kubelet-env.service
+      enable: true
+      contents: |
+        [Unit]
+        Description=Determine the Kubelet Image Version
+        ConditionPathExists=!/etc/kubernetes/kubelet.env
+        [Service]
+        ExecStartPre=/bin/mkdir -p /etc/kubernetes
+        ExecStartPre=/usr/bin/bash -c "docker run --rm -v /etc/kubernetes/kubeconfig:/kubeconfig {{.kube_version_image}} --kubeconfig=/kubeconfig > /etc/kubernetes/kube.version"
+        ExecStart=/usr/bin/bash -c "echo KUBELET_IMAGE_URL={{.kubelet_image_url}} > /etc/kubernetes/kubelet.env; echo KUBELET_IMAGE_TAG=$(tr '+' '_' < /etc/kubernetes/kube.version) >> /etc/kubernetes/kubelet.env; rm /etc/kubernetes/kube.version"
+        Restart=on-failure
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
     - name: kubelet.service
       contents: |
         [Unit]
         Description=Kubelet via Hyperkube ACI
         [Service]
+        EnvironmentFile=/etc/kubernetes/kubelet.env
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/run/kubelet-pod.uuid \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
           --mount volume=resolv,target=/etc/resolv.conf \
@@ -50,7 +65,6 @@ systemd:
           --mount volume=var-lib-cni,target=/var/lib/cni \
           --volume var-log,kind=host,source=/var/log \
           --mount volume=var-log,target=/var/log"
-        EnvironmentFile=/etc/kubernetes/kubelet.env
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
         ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
@@ -81,13 +95,12 @@ systemd:
 
 storage:
   files:
-    - path: /etc/kubernetes/kubelet.env
+    - path: /etc/kubernetes/.empty
       filesystem: root
       mode: 0644
       contents:
         inline: |
-          KUBELET_IMAGE_URL={{.kubelet_image_url}}
-          KUBELET_IMAGE_TAG={{.kubelet_image_tag}}
+          empty
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -60,8 +60,8 @@ resource "matchbox_group" "worker" {
     ssh_authorized_key = "${var.tectonic_ssh_authorized_key}"
 
     # extra data
-    etcd_image_tag    = "${var.tectonic_versions["etcd"]}"
-    kubelet_image_url = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
-    kubelet_image_tag = "${element(split(":", var.tectonic_container_images["hyperkube"]), 1)}"
+    etcd_image_tag     = "${var.tectonic_versions["etcd"]}"
+    kubelet_image_url  = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
+    kube_version_image = "${var.tectonic_container_images["kube_version"]}"
   }
 }


### PR DESCRIPTION
* Problem: In the case a cluster is deployed, various Kubernetes updates are applied over time, and then workers are added by re-using the terraform config to scale workers, the Kubelet version would be out-of-date. This could be done by extending `tectonic_metal_worker_names`, `tectonic_metal_worker_domains`, and `tectonic_metal_worker_macs` and re-applying.
* Start the `kubelet-env.service` to detect the Kubelet version from the bootstrapped control plane to create the kubelet.env file if missing

Note: Adding new controllers in tfvars to try to scale controllers is not supported to begin with on bare-metal (controllers are etcd peers), so launching controllers with version mismatch is not a problem to solve. Controller scaling will come once etcd is run via self-hosted etcd.