### PR TITLE
Documentation/install/aws: specify go version 1.8

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -10,7 +10,7 @@ Generally, the AWS platform templates adhere to the standards defined by the pro
 
 * **DNS**: Ensure that the DNS zone is already created and available in Route 53 for the account. For example if the `tectonic_base_domain` is set to `kube.example.com` a Route 53 zone must exist for this domain and the AWS nameservers must be configured for the domain.
 * **Tectonic Account**: Register for a [Tectonic Account][register], which is free for up to 10 nodes. You will need to provide the cluster license and pull secret below.
-* **Make, go, yarn**: This guide uses `make`, `go` and `yarn` to build the Tectonic Installer.
+* **Make, go, yarn**: This guide uses `make`, `go1.8` and `yarn` to build the Tectonic Installer.
 * **Terraform**: Install [Terraform][terraform] v0.8.8 on your system.
 
 ## Getting Started

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -12,7 +12,7 @@ Following this guide will deploy a Tectonic cluster on virtual or physical hardw
 * DNS records for the Kubernetes controller(s) and Tectonic Ingress worker(s). See [DNS](https://coreos.com/tectonic/docs/latest/install/bare-metal#networking).
 * Machines with BIOS options set to boot from disk normally, but PXE prior to installation.
 * Machines with known MAC addresses and stable domain names.
-* make,go,npm - This guide uses `make`, `go`, and `npm` to build the Tectonic Installer.
+* make,go,npm - This guide uses `make`, `go1.8`, and `npm` to build the Tectonic Installer.
 * Tectonic Account - Register for a [Tectonic Account][register], which is free for up to 10 nodes. You will need to provide the cluster license and pull secret below.
 
 ## Getting Started


### PR DESCRIPTION
Specify which version of go should be used. `make build` will fail if not at version 1.8