### PR TITLE
installer/assets: Bump kubernetes appversion

### DIFF
--- a/installer/assets/candidate/app-version-kubernetes.json
+++ b/installer/assets/candidate/app-version-kubernetes.json
@@ -9,11 +9,11 @@
     }
   },
   "spec": {
-    "desiredVersion": "1.5.6+tectonic.1",
+    "desiredVersion": "1.6.2+tectonic.1",
     "paused": false
   },
   "status": {
-    "currentVersion": "1.5.6+tectonic.1",
+    "currentVersion": "1.6.2+tectonic.1",
     "paused": false
   }
 }


### PR DESCRIPTION
We need to ship 1.6.2 with the correct app version values, so updates next release work properly.