### PR TITLE
Temporarily remove windows from release binaries.

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -58,8 +58,8 @@ release: release-bins
 .PHONY: release-bins
 release-bins: \
 	bin/linux/installer \
-	bin/darwin/installer \
-	bin/windows/installer.exe
+	bin/darwin/installer
+	# bin/windows/installer.exe TODO re-add me when windows works again
 
 .PHONY: vendor
 vendor: glide.yaml

--- a/installer/scripts/release/get_installer_bins.sh
+++ b/installer/scripts/release/get_installer_bins.sh
@@ -22,6 +22,6 @@ function get_bin() {
     chmod +x "$3"
 }
 
-get_bin "$TECTONIC_BINARY_BUCKET" "build-artifacts/installer/$VERSION/bin/windows/installer.exe" "$INSTALLER_RELEASE_DIR/windows/installer.exe"
+# get_bin "$TECTONIC_BINARY_BUCKET" "build-artifacts/installer/$VERSION/bin/windows/installer.exe" "$INSTALLER_RELEASE_DIR/windows/installer.exe"
 get_bin "$TECTONIC_BINARY_BUCKET" "build-artifacts/installer/$VERSION/bin/darwin/installer"      "$INSTALLER_RELEASE_DIR/darwin/installer"
 get_bin "$TECTONIC_BINARY_BUCKET" "build-artifacts/installer/$VERSION/bin/linux/installer"       "$INSTALLER_RELEASE_DIR/linux/installer"

--- a/installer/scripts/release/make_release_tarball.sh
+++ b/installer/scripts/release/make_release_tarball.sh
@@ -11,7 +11,7 @@ echo "Retrieving TerraForm resources"
 "$DIR/get_terraform_bins.sh"
 
 echo "Copying Tectonic Installer binaries"
-cp "$ROOT/bin/windows/installer.exe" "$INSTALLER_RELEASE_DIR/windows/installer.exe"
+# cp "$ROOT/bin/windows/installer.exe" "$INSTALLER_RELEASE_DIR/windows/installer.exe"
 cp "$ROOT/bin/darwin/installer"      "$INSTALLER_RELEASE_DIR/darwin/installer"
 cp "$ROOT/bin/linux/installer"       "$INSTALLER_RELEASE_DIR/linux/installer"
 

--- a/installer/scripts/release/upload_installer_bins.sh
+++ b/installer/scripts/release/upload_installer_bins.sh
@@ -8,6 +8,6 @@ GIT_SHA=$("$ROOT/../git-version")
 # if AWS credentials are not set, then we should not continue
 check_aws_creds
 
-aws_upload_file "$ROOT/bin/windows/installer.exe" "build-artifacts/installer/$GIT_SHA/bin/windows/installer.exe" "$TECTONIC_BINARY_BUCKET" "application/octet-stream"
+# aws_upload_file "$ROOT/bin/windows/installer.exe" "build-artifacts/installer/$GIT_SHA/bin/windows/installer.exe" "$TECTONIC_BINARY_BUCKET" "application/octet-stream"
 aws_upload_file "$ROOT/bin/darwin/installer" "build-artifacts/installer/$GIT_SHA/bin/darwin/installer" "$TECTONIC_BINARY_BUCKET" "application/octet-stream"
 aws_upload_file "$ROOT/bin/linux/installer" "build-artifacts/installer/$GIT_SHA/bin/linux/installer" "$TECTONIC_BINARY_BUCKET" "application/octet-stream"

--- a/installer/scripts/release/upload_release_tarball.sh
+++ b/installer/scripts/release/upload_release_tarball.sh
@@ -11,4 +11,4 @@ aws_upload_file "$ROOT/$TECTONIC_RELEASE_TARBALL_FILE" "$TECTONIC_RELEASE_TARBAL
 echo "Release tarball is available at $TECTONIC_RELEASE_TARBALL_URL"
 aws_upload_file "$INSTALLER_RELEASE_DIR/linux/installer" "$TECTONIC_RELEASE-linux" "$TECTONIC_RELEASE_BUCKET" application/octet-stream
 aws_upload_file "$INSTALLER_RELEASE_DIR/darwin/installer" "$TECTONIC_RELEASE-darwin" "$TECTONIC_RELEASE_BUCKET" application/octet-stream
-aws_upload_file "$INSTALLER_RELEASE_DIR/windows/installer.exe" "$TECTONIC_RELEASE-windows.exe" "$TECTONIC_RELEASE_BUCKET" application/octet-stream
+# aws_upload_file "$INSTALLER_RELEASE_DIR/windows/installer.exe" "$TECTONIC_RELEASE-windows.exe" "$TECTONIC_RELEASE_BUCKET" application/octet-stream


### PR DESCRIPTION
The installer doesn't work on windows, so we shouldn't get users' hopes up by giving them a windows binary.