### PR TITLE
platforms/metal: Fix missing kube_version_image that was stripped

### DIFF
--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -59,7 +59,8 @@ resource "matchbox_group" "worker" {
     ssh_authorized_key = "${var.tectonic_ssh_authorized_key}"
 
     # extra data
-    kubelet_image_url = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
-    kubelet_image_tag = "${element(split(":", var.tectonic_container_images["hyperkube"]), 1)}"
+    kubelet_image_url  = "${element(split(":", var.tectonic_container_images["hyperkube"]), 0)}"
+    kubelet_image_tag  = "${element(split(":", var.tectonic_container_images["hyperkube"]), 1)}"
+    kube_version_image = "${var.tectonic_container_images["kube_version"]}"
   }
 }


### PR DESCRIPTION
* A merge conflict stripped this required template variable
* I added this in https://github.com/coreos/tectonic-installer/commit/92bb19bb095cf845d7734f1dd34c0d8cf7e9ea56, but I think git clobbered it in https://github.com/coreos/tectonic-installer/commit/1827f92aaf5537bc57e66ea48278fdb969c6e37f