### PR TITLE
frontend: Scroll only if user is scrolled to the bottom of logs.

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -640,7 +640,7 @@ hr.spacer {
 }
 
 .log-contents {
-  max-height: 500px;
+  height: 400px;
 }
 
 .log-contents__block {

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -47,12 +47,7 @@ class TF_PowerOn extends React.Component {
 
   componentWillUpdate ({output}) {
     const node = this.outputNode;
-    if (this.state.showLogs || this.state.showLogs === null) {
-      this.shouldScroll = true;
-      return;
-    }
-
-    if (!node || output === this.props.output) {
+    if (!node || output === this.props.output || this.state.showLogs === false) {
       this.shouldScroll = false;
       return;
     }
@@ -62,7 +57,7 @@ class TF_PowerOn extends React.Component {
 
   componentDidUpdate () {
     if (this.shouldScroll && this.outputNode) {
-      this.outputNode.scrollTop = this.outputNode.scrollHeight - this.outputNode.clientHeight;
+      this.outputNode.scrollTop = this.outputNode.scrollHeight;
     }
   }
 


### PR DESCRIPTION
Also, fix bug where auto-scrolling did not occur at the start of terraform apply/destory.