### PR TITLE
test: Run make {examples,docs} and check for changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,36 @@ pipeline {
       }
     }
 
+    stage('Generate docs') {
+      steps {
+        sh """#!/bin/bash -ex
+
+        # Prevent "fatal: You don't exist. Go away!" git error
+        git config --global user.name "jenkins tectonic installer"
+        git config --global user.email "jenkins-tectonic-installer@coreos.com"
+        go get github.com/segmentio/terraform-docs
+
+        make docs
+        git diff --exit-code
+        """
+      }
+    }
+
+    stage('Generate examples') {
+      steps {
+        sh """#!/bin/bash -ex
+
+        # Prevent "fatal: You don't exist. Go away!" git error
+        git config --global user.name "jenkins tectonic installer"
+        git config --global user.email "jenkins-tectonic-installer@coreos.com"
+        go get github.com/s-urbaniak/terraform-examples
+
+        make examples
+        git diff --exit-code
+        """
+      }
+    }
+
     stage('Installer: Build & Test') {
       environment {
         GO_PROJECT = '/go/src/github.com/coreos/tectonic-installer'

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ define terraform-docs
 endef
 
 define terraform-examples
-	$(if $(TF_EXAMPLES),,$(error "terraform-examples revision >= 83d7ad6 is required (https://github.com/segmentio/terraform-docs)"))
+	$(if $(TF_EXAMPLES),,$(error "terraform-examples revision >= 83d7ad6 is required (https://github.com/s-urbaniak/terraform-examples)"))
 	terraform-examples $2 $3 $4 $5 > $1
 endef
 


### PR DESCRIPTION
This PR adds an example and a docs stage to our Jenkins build pipeline. It first runs the respective targets and then checks if anything changed.

@s-urbaniak Let me know what you think.

Is there a way to force make to run a target to prevent `make: Nothing to be done for 'examples'.`?