### PR TITLE
*: Add RollingUpdate strategy to DS manifests

### DIFF
--- a/installer/assets/self-hosted/kube-apiserver.yaml.tmpl
+++ b/installer/assets/self-hosted/kube-apiserver.yaml.tmpl
@@ -6,6 +6,10 @@ metadata:
   labels:
     k8s-app: kube-apiserver
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -7,6 +7,10 @@ metadata:
     tier: control-plane
     component: kube-apiserver
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/kube-flannel.yaml
+++ b/modules/bootkube/resources/manifests/kube-flannel.yaml
@@ -33,6 +33,10 @@ metadata:
     tier: node
     app: flannel
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/kube-proxy.yaml
+++ b/modules/bootkube/resources/manifests/kube-proxy.yaml
@@ -7,6 +7,10 @@ metadata:
     tier: node
     component: kube-proxy
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/pod-checkpointer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpointer.yaml
@@ -7,6 +7,10 @@ metadata:
     tier: control-plane
     component: pod-checkpointer
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
+++ b/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
@@ -8,6 +8,10 @@ metadata:
     component: ingress-controller
     type: nginx
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/modules/tectonic/resources/manifests/monitoring/node-exporter-ds.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/node-exporter-ds.yaml
@@ -4,6 +4,10 @@ metadata:
   name: node-exporter
   namespace: tectonic-system
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       name: node-exporter

--- a/modules/tectonic/resources/manifests/updater/node-agent.yaml
+++ b/modules/tectonic/resources/manifests/updater/node-agent.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     k8s-app: node-agent
 spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
New KVO uses upstream DS rolling updates, and so now we need to specifiy
the correct strategy.