### PR TITLE
*: standardize on k8s-app label

### DIFF
--- a/Documentation/admin/ingress.md
+++ b/Documentation/admin/ingress.md
@@ -85,13 +85,13 @@ metadata:
   name: production-ingress
   namespace: production
   labels:
-    app: ingress
+    k8s-app: ingress
 spec:
   replicas: 2
   template:
     metadata:
       labels:
-        app: ingress
+        k8s-app: ingress
     spec:
       containers:
         - name: nginx-ingress-lb

--- a/Documentation/admin/onboard-service-account.md
+++ b/Documentation/admin/onboard-service-account.md
@@ -47,7 +47,7 @@ If multiple pods running in the same namespace require different levels of acces
       template:
         metadata:
           labels:
-            app: nginx
+            k8s-app: nginx
         spec:
           containers:
           - name: nginx

--- a/Documentation/admin/user-management.md
+++ b/Documentation/admin/user-management.md
@@ -213,7 +213,7 @@ spec:
   template:
     metadata:
       labels:
-        app: nginx
+        k8s-app: nginx
     spec:
       containers:
       - name: nginx

--- a/Documentation/files/logging/fluentd-aggregator-deployment.yaml
+++ b/Documentation/files/logging/fluentd-aggregator-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fluentd-aggregator
   namespace: logging
   labels:
-    app: fluentd-aggregator
+    k8s-app: fluentd-aggregator
     component: log-aggregator
 spec:
   replicas: 2
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       labels:
-        app: fluentd-aggregator
+        k8s-app: fluentd-aggregator
     spec:
       containers:
       - name: fluentd-aggregator

--- a/Documentation/files/logging/fluentd-aggregator-svc.yaml
+++ b/Documentation/files/logging/fluentd-aggregator-svc.yaml
@@ -4,11 +4,11 @@ metadata:
   name: fluentd-aggregator
   namespace: logging
   labels:
-    app: fluentd-aggregator
+    k8s-app: fluentd-aggregator
 spec:
   type: ClusterIP
   selector:
-    app: fluentd-aggregator
+    k8s-app: fluentd-aggregator
   ports:
   - name: fluentd-input
     port: 24224

--- a/Documentation/files/logging/fluentd-configmap.yaml
+++ b/Documentation/files/logging/fluentd-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fluentd-config
   namespace: logging
   labels:
-    app: fluentd
+    k8s-app: fluentd
 data:
   fluentd.conf: |
     # Use the config specified by the FLUENTD_CONFIG environment variable, or

--- a/Documentation/files/logging/fluentd-ds.yaml
+++ b/Documentation/files/logging/fluentd-ds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fluentd
   namespace: logging
   labels:
-    app: fluentd
+    k8s-app: fluentd
     component: logging-agent
 spec:
   minReadySeconds: 10
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: fluentd
+        k8s-app: fluentd
     spec:
       containers:
       - name: fluentd

--- a/Documentation/files/logging/fluentd-svc.yaml
+++ b/Documentation/files/logging/fluentd-svc.yaml
@@ -4,12 +4,12 @@ metadata:
   name: fluentd
   namespace: logging
   labels:
-    app: fluentd
+    k8s-app: fluentd
 spec:
   type: ClusterIP
   clusterIP: None
   selector:
-    app: fluentd
+    k8s-app: fluentd
   ports:
   # Exposes Prometheus metrics
   - name: prometheus-metrics

--- a/Documentation/files/logging/monitoring/fluentd-prometheus-service-monitor.yaml
+++ b/Documentation/files/logging/monitoring/fluentd-prometheus-service-monitor.yaml
@@ -4,12 +4,12 @@ metadata:
   name: fluentd
   namespace: logging
   labels:
-    app: fluentd
+    k8s-app: fluentd
 spec:
   jobLabel: app
   selector:
     matchExpressions:
-    - {key: app, operator: In, values: [fluentd, fluentd-aggregator]}
+    - {key: k8s-app, operator: In, values: [fluentd, fluentd-aggregator]}
   namespaceSelector:
     any: false
     matchNames:

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -138,7 +138,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: node
-    app: flannel
+    k8s-app: flannel
 data:
   cni-conf.json: |
     {

--- a/Documentation/tutorials/first-app.md
+++ b/Documentation/tutorials/first-app.md
@@ -85,13 +85,13 @@ metadata:
   name: simple-deployment
   namespace: default
   labels:
-    app: simple
+    k8s-app: simple
 spec:
   replicas: 3
   template:
     metadata:
       labels:
-        app: simple
+        k8s-app: simple
     spec:
       containers:
         - name: nginx
@@ -113,7 +113,7 @@ metadata:
   namespace: default
 spec:
   selector:
-    app: simple
+    k8s-app: simple
   ports:
   - protocol: TCP
     port: 80

--- a/Documentation/tutorials/rolling-deployments.md
+++ b/Documentation/tutorials/rolling-deployments.md
@@ -38,7 +38,7 @@ kind: Deployment
 metadata:
   name: simple-deployment
   labels:
-    app: simple
+    k8s-app: simple
 spec:
   replicas: 3
   revisionHistoryLimit: 2
@@ -50,7 +50,7 @@ spec:
   template:
     metadata:
       labels:
-        app: simple
+        k8s-app: simple
     spec:
       containers:
         - name: nginx
@@ -107,7 +107,7 @@ kind: Deployment
 metadata:
   name: simple-deployment
   labels:
-    app: simple
+    k8s-app: simple
 spec:
   replicas: 3
   revisionHistoryLimit: 2
@@ -119,7 +119,7 @@ spec:
   template:
     metadata:
       labels:
-        app: simple
+        k8s-app: simple
     spec:
       containers:
         - name: nginx

--- a/Documentation/tutorials/scale-app.md
+++ b/Documentation/tutorials/scale-app.md
@@ -19,7 +19,7 @@ kind: Deployment
 metadata:
   name: cookies
   labels:
-    app: simple
+    k8s-app: simple
 spec:
   replicas: 3
   strategy:
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       labels:
-        app: cookies
+        k8s-app: cookies
     spec:
       containers:
         - name: cookies-container

--- a/Documentation/tutorials/second-app.md
+++ b/Documentation/tutorials/second-app.md
@@ -31,7 +31,7 @@ spec:
   template:
     metadata:
       labels:
-        app: redis
+        k8s-app: redis
         role: master
         tier: backend
     spec:
@@ -55,7 +55,7 @@ metadata:
   name: redis-master
   namespace: default
   labels:
-    app: redis
+    k8s-app: redis
     tier: backend
     role: master
 spec:
@@ -63,7 +63,7 @@ spec:
   - port: 6379
     targetPort: 6379
   selector:
-    app: redis
+    k8s-app: redis
     tier: backend
     role: master
 ```
@@ -81,7 +81,7 @@ spec:
   template:
     metadata:
       labels:
-        app: redis
+        k8s-app: redis
         role: slave
         tier: backend
     spec:
@@ -109,14 +109,14 @@ metadata:
   name: redis-slave
   namespace: default
   labels:
-    app: redis
+    k8s-app: redis
     tier: backend
     role: slave
 spec:
   ports:
   - port: 6379
   selector:
-    app: redis
+    k8s-app: redis
     tier: backend
     role: slave
 ```
@@ -134,7 +134,7 @@ spec:
   template:
     metadata:
       labels:
-        app: guestbook
+        k8s-app: guestbook
         tier: frontend
     spec:
       containers:
@@ -160,14 +160,14 @@ metadata:
   name: frontend
   namespace: default
   labels:
-    app: guestbook
+    k8s-app: guestbook
     tier: frontend
 spec:
   type: LoadBalancer
   ports:
   - port: 80
   selector:
-    app: guestbook
+    k8s-app: guestbook
     tier: frontend
 ```
 
@@ -183,7 +183,7 @@ service "redis-slave" created
 deployment "redis-slave" created
 $ kubectl get deploy/frontend svc/frontend -o wide
 NAME           CLUSTER-IP   EXTERNAL-IP                                                             PORT(S)        AGE       SELECTOR
-svc/frontend   10.3.0.175   aaebd8247ef2311e6a045021d1620193-54019671.us-west-2.elb.amazonaws.com   80:31020/TCP   1m        app=guestbook,tier=frontend
+svc/frontend   10.3.0.175   aaebd8247ef2311e6a045021d1620193-54019671.us-west-2.elb.amazonaws.com   80:31020/TCP   1m        k8s-app=guestbook,tier=frontend
 
 NAME              DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 deploy/frontend   3         3         3            3           1m

--- a/installer/tests/sanity/k8s_test.go
+++ b/installer/tests/sanity/k8s_test.go
@@ -312,7 +312,7 @@ func waitForAPIServer(t *testing.T) <-chan struct{} {
 
 func getAPIServers(client *kubernetes.Clientset) (*v1.PodList, error) {
 	const (
-		apiServerSelector   = "component=kube-apiserver"
+		apiServerSelector   = "k8s-app=kube-apiserver"
 		kubeSystemNamespace = "kube-system"
 	)
 	pods, err := client.Core().Pods(kubeSystemNamespace).List(v1.ListOptions{LabelSelector: apiServerSelector})

--- a/modules/bootkube/resources/manifests/kenc.yaml
+++ b/modules/bootkube/resources/manifests/kenc.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: kube-system
   labels:
     tier: control-plane
-    component: kube-etcd-network-checkpointer
+    k8s-app: kube-etcd-network-checkpointer
 spec:
   template:
     metadata:
       labels:
         tier: control-plane
-        component: kube-etcd-network-checkpointer
+        k8s-app: kube-etcd-network-checkpointer
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: control-plane
-    component: kube-apiserver
+    k8s-app: kube-apiserver
 spec:
   updateStrategy:
     rollingUpdate:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         tier: control-plane
-        component: kube-apiserver
+        k8s-app: kube-apiserver
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ""

--- a/modules/bootkube/resources/manifests/kube-controller-manager-disruption.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager-disruption.yaml
@@ -8,4 +8,4 @@ spec:
   selector:
     matchLabels:
       tier: control-plane
-      component: kube-controller-manager
+      k8s-app: kube-controller-manager

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -5,14 +5,14 @@ metadata:
   namespace: kube-system
   labels:
     tier: control-plane
-    component: kube-controller-manager
+    k8s-app: kube-controller-manager
 spec:
   replicas: 2
   template:
     metadata:
       labels:
         tier: control-plane
-        component: kube-controller-manager
+        k8s-app: kube-controller-manager
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -27,7 +27,7 @@ spec:
                   operator: In
                   values:
                   - control-plane
-                - key: component
+                - key: k8s-app
                   operator: In
                   values:
                   - kube-contoller-manager

--- a/modules/bootkube/resources/manifests/kube-flannel.yaml
+++ b/modules/bootkube/resources/manifests/kube-flannel.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: node
-    app: flannel
+    k8s-app: flannel
 data:
   cni-conf.json: |
     {
@@ -31,7 +31,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: node
-    app: flannel
+    k8s-app: flannel
 spec:
   updateStrategy:
     rollingUpdate:
@@ -41,7 +41,7 @@ spec:
     metadata:
       labels:
         tier: node
-        app: flannel
+        k8s-app: flannel
     spec:
       containers:
       - name: kube-flannel

--- a/modules/bootkube/resources/manifests/kube-proxy.yaml
+++ b/modules/bootkube/resources/manifests/kube-proxy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: node
-    component: kube-proxy
+    k8s-app: kube-proxy
 spec:
   updateStrategy:
     rollingUpdate:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         tier: node
-        component: kube-proxy
+        k8s-app: kube-proxy
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:

--- a/modules/bootkube/resources/manifests/kube-scheduler-disruption.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler-disruption.yaml
@@ -8,4 +8,4 @@ spec:
   selector:
     matchLabels:
       tier: control-plane
-      component: kube-scheduler
+      k8s-app: kube-scheduler

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: control-plane
-    component: kube-scheduler
+    k8s-app: kube-scheduler
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         tier: control-plane
-        component: kube-scheduler
+        k8s-app: kube-scheduler
     spec:
       affinity:
         podAntiAffinity:
@@ -27,7 +27,7 @@ spec:
                   operator: In
                   values:
                   - control-plane
-                - key: component
+                - key: k8s-app
                   operator: In
                   values:
                   - kube-scheduler

--- a/modules/bootkube/resources/manifests/pod-checkpointer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpointer.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     tier: control-plane
-    component: pod-checkpointer
+    k8s-app: pod-checkpointer
 spec:
   updateStrategy:
     rollingUpdate:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         tier: control-plane
-        component: pod-checkpointer
+        k8s-app: pod-checkpointer
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:

--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: tectonic-console
+    k8s-app: tectonic-console
     component: ui
   name: tectonic-console
   namespace: tectonic-system
@@ -10,7 +10,7 @@ spec:
   replicas: 2
   selector:
     matchLabels:
-      app: tectonic-console
+      k8s-app: tectonic-console
       component: ui
   strategy:
     rollingUpdate:
@@ -21,7 +21,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        app: tectonic-console
+        k8s-app: tectonic-console
         component: ui
       name: tectonic-console
     spec:

--- a/modules/tectonic/resources/manifests/console/service.yaml
+++ b/modules/tectonic/resources/manifests/console/service.yaml
@@ -4,11 +4,11 @@ metadata:
   name: tectonic-console
   namespace: tectonic-system
   labels:
-    app: tectonic-console
+    k8s-app: tectonic-console
     component: ui
 spec:
   selector:
-    app: tectonic-console
+    k8s-app: tectonic-console
     component: ui
   type: NodePort
   ports:

--- a/modules/tectonic/resources/manifests/identity/deployment.yaml
+++ b/modules/tectonic/resources/manifests/identity/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tectonic-identity
   namespace: tectonic-system
   labels:
-    app: tectonic-identity
+    k8s-app: tectonic-identity
     component: identity
 spec:
   replicas: 1
@@ -20,7 +20,7 @@ spec:
     metadata:
       name: tectonic-identity
       labels:
-        app: tectonic-identity
+        k8s-app: tectonic-identity
         component: identity
     spec:
       volumes:

--- a/modules/tectonic/resources/manifests/identity/services.yaml
+++ b/modules/tectonic/resources/manifests/identity/services.yaml
@@ -4,11 +4,11 @@ metadata:
   name: tectonic-identity
   namespace: tectonic-system
   labels:
-    app: tectonic-identity
+    k8s-app: tectonic-identity
     component: identity
 spec:
   selector:
-    app: tectonic-identity
+    k8s-app: tectonic-identity
     component: identity
   ports:
   - name: worker
@@ -22,7 +22,7 @@ metadata:
   namespace: tectonic-system
 spec:
   selector:
-    app: tectonic-identity
+    k8s-app: tectonic-identity
     component: identity
   ports:
   - name: api

--- a/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       labels:
-        app: default-http-backend
+        k8s-app: default-http-backend
     spec:
       terminationGracePeriodSeconds: 60
       containers:

--- a/modules/tectonic/resources/manifests/ingress/default-backend/service.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: default-http-backend
   namespace: tectonic-system
   labels:
-   app: default-http-backend
+   k8s-app: default-http-backend
 spec:
   ports:
   - port: 80
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     name: http
   selector:
-   app: default-http-backend
+   k8s-app: default-http-backend

--- a/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
+++ b/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tectonic-ingress-controller
   namespace: tectonic-system
   labels:
-    app: tectonic-lb
+    k8s-app: tectonic-lb
     component: ingress-controller
     type: nginx
 spec:
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        app: tectonic-lb
+        k8s-app: tectonic-lb
         component: ingress-controller
         type: nginx
     spec:

--- a/modules/tectonic/resources/manifests/ingress/hostport/service.yaml
+++ b/modules/tectonic/resources/manifests/ingress/hostport/service.yaml
@@ -5,12 +5,12 @@ metadata:
   name: tectonic-lb
   namespace: tectonic-system
   labels:
-    app: tectonic-lb
+    k8s-app: tectonic-lb
     component: ingress-controller
 spec:
   type: ClusterIP
   selector:
-    app: tectonic-lb
+    k8s-app: tectonic-lb
     component: ingress-controller
   ports:
     - name: http

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tectonic-ingress-controller
   namespace: tectonic-system
   labels:
-    app: tectonic-lb
+    k8s-app: tectonic-lb
     component: ingress-controller
     type: nginx
 spec:
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        app: tectonic-lb
+        k8s-app: tectonic-lb
         component: ingress-controller
         type: nginx
     spec:

--- a/modules/tectonic/resources/manifests/ingress/nodeport/service.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/service.yaml
@@ -5,12 +5,12 @@ metadata:
   name: tectonic-lb
   namespace: tectonic-system
   labels:
-    app: tectonic-lb
+    k8s-app: tectonic-lb
     component: ingress-controller
 spec:
   type: NodePort
   selector:
-    app: tectonic-lb
+    k8s-app: tectonic-lb
     component: ingress-controller
   ports:
     - name: https

--- a/modules/tectonic/resources/manifests/monitoring/node-exporter-ds.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/node-exporter-ds.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       name: node-exporter
       labels:
-        app: node-exporter
+        k8s-app: node-exporter
     spec:
       hostNetwork: true
       hostPID: true

--- a/modules/tectonic/resources/manifests/monitoring/node-exporter-svc.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/node-exporter-svc.yaml
@@ -4,7 +4,6 @@ metadata:
   name: node-exporter
   namespace: tectonic-system
   labels:
-    app: node-exporter
     k8s-app: node-exporter
 spec:
   type: ClusterIP
@@ -14,4 +13,4 @@ spec:
     port: 9100
     protocol: TCP
   selector:
-    app: node-exporter
+    k8s-app: node-exporter

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-k8s-apps-http.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-k8s-apps-http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8s-apps-http
   namespace: tectonic-system
   labels:
-    k8s-apps: http
+    k8s-app: http
 spec:
   jobLabel: k8s-app
   selector:

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kubelet.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kubelet.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubelet
   namespace: tectonic-system
   labels:
-    k8s-apps: http
+    k8s-app: http
 spec:
   jobLabel: k8s-app
   endpoints:

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchExpression:
-    - {key: k8s-apps, operator: Exists}
+    - {key: k8s-app, operator: Exists}
   ruleSelector:
     matchLabels:
       role: prometheus-rulefiles

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-operator.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-operator.yaml
@@ -4,13 +4,13 @@ metadata:
   name: prometheus-operator
   namespace: tectonic-system
   labels:
-    operator: prometheus
+    k8s-app: prometheus-operator
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        operator: prometheus
+        k8s-app: prometheus-operator
     spec:
       serviceAccountName: prometheus-operator
       containers:

--- a/modules/tectonic/resources/manifests/stats-emitter.yaml
+++ b/modules/tectonic/resources/manifests/stats-emitter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tectonic-stats-emitter
   namespace: tectonic-system
   labels:
-    app: tectonic-stats-emitter
+    k8s-app: tectonic-stats-emitter
     component: stats-emitter
 spec:
   replicas: 1
@@ -12,7 +12,7 @@ spec:
     metadata:
       name: tectonic-stats-emitter
       labels:
-        app: tectonic-stats-emitter
+        k8s-app: tectonic-stats-emitter
         component: stats-emitter
       annotations:
         # TODO(squat): add backoff to stats-emitter so we don't need init pod.


### PR DESCRIPTION
This standardizes using the `k8s-app` as the de-facto label for identifying components. Discussed in https://github.com/coreos/tectonic-installer/issues/489.

My approach was for anything using 1 label to identify a component I changed that label to `k8s-app`. Mostly this consists of substitutions from `app` -> `k8s-app`. Control plane components were using the `component` label.

In cases in which there were two labels identifying a component as the same value I delete one of them and made sure the other was `k8s-app`. Mostly this consists of removing an `app` label and keeping the `k8s-app` one around. 

There are some outstanding questions I have about certain labels:
 * I see a lot of component labels floating around that differ from the `app` label. Are these redundant? Delete? For example:
     * `installer/assets/stats-emitter-deployment.yaml`
     * `modules/tectonic/resources/manifests/console/service.yaml`
 * Here are some files I was unsure what to do with:
     * ~~`installer/assets/monitoring/prometheus-k8s.json`~~
     * ~~`installer/assets/monitoring/prometheus-operator.yaml`~~
     * `Documentation/files/logging/monitoring/prometheus-fluentd.yaml`
 * Its not safe to change the label selector for `modules/bootkube/resources/experimental/manifests/etcd-service.yaml`
until the etcd-operator updates to use the k8s-app label as well. So we won't change this for now and etcd pods will sort of be the odd one out for now.
 * Not familiar with jobLabel field in `Documentation/files/logging/monitoring/fluentd-prometheus-service-monitor.yaml`
    * Presumably should also just change to k8s-app
