### PR TITLE
platforms/aws/route53: delete records before deleting the zone

### DIFF
--- a/platforms/aws/route53.tf
+++ b/platforms/aws/route53.tf
@@ -4,8 +4,9 @@ data "aws_route53_zone" "tectonic-ext" {
 }
 
 resource "aws_route53_zone" "tectonic-int" {
-  vpc_id = "${module.vpc.vpc_id}"
-  name   = "${var.tectonic_base_domain}"
+  vpc_id        = "${module.vpc.vpc_id}"
+  name          = "${var.tectonic_base_domain}"
+  force_destroy = true
 
   tags = "${merge(map(
       "Name", "${var.tectonic_cluster_name}_tectonic_int_zone",


### PR DESCRIPTION
Fixes https://github.com/coreos-inc/tectonic-issues/issues/234.

- Should fix eventual consistency related issues & co.
- Should also fix when LB Services have been created: the records will get removed - but probably not the ELBs tho!