### PR TITLE
Improve Makefiles

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -83,3 +83,4 @@ clean:
 	rm -rf bin/
 	rm -f binassets/assets.go
 	rm -rf assets/frontend/scripts
+	rm -rf .workspace/

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -6,23 +6,25 @@ LD_FLAGS="-w -X github.com/coreos/tectonic-installer/installer/server/version.Ve
 
 REPO=github.com/coreos/tectonic-installer/installer
 
+GO_FILES=$(shell find server -type f -name '*.go')
+
 .PHONY: all
 all: build
 
 .PHONY: build
 build: bin/$(OS)/installer
 
-bin/windows/installer.exe: frontend binassets/assets.go
+bin/windows/installer.exe: $(GO_FILES) binassets/assets.go
 	@GOOS=windows go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
-bin/%/installer: frontend binassets/assets.go
+bin/%/installer: $(GO_FILES) binassets/assets.go
 	@GOOS=$* go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 .PHONY: backend
 backend: binassets/assets.go
 	@GOOS=$(OS) go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
-binassets/assets.go: bin/go-bindata
+binassets/assets.go: frontend bin/go-bindata $(shell find assets -type f)
 	@./bin/go-bindata -pkg binassets -o binassets/assets.go -prefix assets assets/...
 
 .PHONY: frontend
@@ -40,6 +42,10 @@ smoke-aws: bin/sanity
 .PHONY: smoke-bare-metal
 smoke-bare-metal: bin/sanity
 	@./tests/scripts/bare-metal/up-down.sh
+
+.PHONY: dist
+dist: release-bins
+	@./scripts/release/make_release_tarball.sh
 
 .PHONY: release
 release: release-bins
@@ -73,7 +79,7 @@ bin/sanity:
 
 .PHONY: clean
 clean:
+	@$(MAKE) -C frontend clean
 	@rm -rf bin/
 	@rm -f binassets/assets.go
-	@rm -rf assets/public/scripts
-	@rm -rf frontend/node_modules
+	@rm -rf assets/frontend/scripts

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -15,17 +15,17 @@ all: build
 build: bin/$(OS)/installer
 
 bin/windows/installer.exe: $(GO_FILES) binassets/assets.go
-	@GOOS=windows go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=windows go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 bin/%/installer: $(GO_FILES) binassets/assets.go
-	@GOOS=$* go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$* go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 .PHONY: backend
 backend: binassets/assets.go
-	@GOOS=$(OS) go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$(OS) go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 binassets/assets.go: frontend bin/go-bindata $(shell find assets -type f)
-	@./bin/go-bindata -pkg binassets -o binassets/assets.go -prefix assets assets/...
+	./bin/go-bindata -pkg binassets -o binassets/assets.go -prefix assets assets/...
 
 .PHONY: frontend
 frontend:
@@ -33,26 +33,26 @@ frontend:
 
 .PHONY: test
 test: build bin/golint
-	@./scripts/test
+	./scripts/test
 
 .PHONY: smoke-aws
 smoke-aws: bin/sanity
-	@../tests/scripts/aws/up-down.sh
+	../tests/scripts/aws/up-down.sh
 
 .PHONY: smoke-bare-metal
 smoke-bare-metal: bin/sanity
-	@./tests/scripts/bare-metal/up-down.sh
+	./tests/scripts/bare-metal/up-down.sh
 
 .PHONY: dist
 dist: release-bins
-	@./scripts/release/make_release_tarball.sh
+	./scripts/release/make_release_tarball.sh
 
 .PHONY: release
 release: release-bins
-	@./scripts/release/upload_installer_bins.sh
-	@./scripts/release/make_release_tarball.sh
-	@./scripts/release/upload_release_tarball.sh
-	@./scripts/release/make_github_release.sh
+	./scripts/release/upload_installer_bins.sh
+	./scripts/release/make_release_tarball.sh
+	./scripts/release/upload_release_tarball.sh
+	./scripts/release/make_github_release.sh
 
 .PHONY: release-bins
 release-bins: \
@@ -62,8 +62,8 @@ release-bins: \
 
 .PHONY: vendor
 vendor: glide.yaml
-	@glide up -v
-	@glide-vc --use-lock-file --no-tests --only-code
+	glide up -v
+	glide-vc --use-lock-file --no-tests --only-code
 
 .PHONY: tools
 tools: bin/go-bindata bin/sanity bin/golint
@@ -72,14 +72,14 @@ bin/golint:
 	CGO_ENABLED=0 go build -o bin/golint $(REPO)/vendor/github.com/golang/lint/golint
 
 bin/go-bindata:
-	@go build -o bin/go-bindata $(REPO)/vendor/github.com/jteeuwen/go-bindata/go-bindata
+	go build -o bin/go-bindata $(REPO)/vendor/github.com/jteeuwen/go-bindata/go-bindata
 
 bin/sanity:
-	@go test tests/sanity/k8s_test.go -c -o bin/sanity
+	go test tests/sanity/k8s_test.go -c -o bin/sanity
 
 .PHONY: clean
 clean:
-	@$(MAKE) -C frontend clean
-	@rm -rf bin/
-	@rm -f binassets/assets.go
-	@rm -rf assets/frontend/scripts
+	$(MAKE) -C frontend clean
+	rm -rf bin/
+	rm -f binassets/assets.go
+	rm -rf assets/frontend/scripts

--- a/installer/frontend/Makefile
+++ b/installer/frontend/Makefile
@@ -2,8 +2,13 @@
 all: build
 
 .PHONY: build
-build:
-	@yarn install --quiet > /dev/null && yarn run build
+build: node_modules ../assets/frontend/scripts/app-bundle.js
+
+../assets/frontend/scripts/app-bundle.js: node_modules *.jsx *.js $(shell find components -type f -name '*.jsx')
+	@yarn run build
+
+node_modules: package.json yarn.lock
+	@yarn install --quiet > /dev/null
 
 .PHONY: test
 test:
@@ -16,3 +21,8 @@ lint:
 .PHONY: dev
 dev:
 	@yarn run dev
+
+.PHONY: clean
+clean:
+	@rm -f ../assets/frontend/scripts/app-bundle.js
+	@rm -fr node_modules

--- a/installer/frontend/Makefile
+++ b/installer/frontend/Makefile
@@ -5,24 +5,24 @@ all: build
 build: node_modules ../assets/frontend/scripts/app-bundle.js
 
 ../assets/frontend/scripts/app-bundle.js: node_modules *.jsx *.js $(shell find components -type f -name '*.jsx')
-	@yarn run build
+	yarn run build
 
 node_modules: package.json yarn.lock
-	@yarn install --quiet > /dev/null
+	yarn install --quiet > /dev/null
 
 .PHONY: test
 test:
-	@yarn test
+	yarn test
 
 .PHONY: lint
 lint:
-	@yarn run lint
+	yarn run lint
 
 .PHONY: dev
 dev:
-	@yarn run dev
+	yarn run dev
 
 .PHONY: clean
 clean:
-	@rm -f ../assets/frontend/scripts/app-bundle.js
-	@rm -fr node_modules
+	rm -f ../assets/frontend/scripts/app-bundle.js
+	rm -fr node_modules


### PR DESCRIPTION
- Add front-end js as a dependency for binassets.
- Add `make dist` rule to download & create a tarball. (but not upload a release)
- Fix path of frontend assets in `make clean`
- Make all go files a dependency for installer binaries.
- Make all js files a dependency for `yarn build`
- Make `package.json` & `yarn.lock` dependencies for `yarn install`

Fixes multiple issues, such as:
  - `make` rebuilt js even if no js code changed
  - `make` didn't bundle changed js (had to run `make clean && make` to get new js bundled)
  - `make clean` didn't `rm app-bundle.js`
  - `make clean` didn't `rm .workspace` (used for making release)

Fixes issue #528, where make didn't bundle changed js. 

This still rebuilds some go stuff if you run `make`, but it's much better than the current behavior (which rebuilds everything but doesn't bundle it correctly unless you `make clean`).