### PR TITLE
frontend: Fix test that didn't exist when region tfvar PR was merged.

### DIFF
--- a/installer/examples/aws-vpc.json
+++ b/installer/examples/aws-vpc.json
@@ -28,6 +28,7 @@
       "subnet-19ef2650",
       "subnet-36d7e26e"
     ],
+    "tectonic_aws_region": "us-west-1",
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },


### PR DESCRIPTION
#509 didn't have this test, but it did add a new tfvar to the desired output.