### PR TITLE
Define master_count so that baremetal works again. Broken by PR #468.

### DIFF
--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -67,6 +67,7 @@ module "tectonic" {
   kubectl_client_id = "tectonic-kubectl"
   ingress_kind      = "HostPort"
   experimental      = "${var.tectonic_experimental}"
+  master_count      = "${length(var.tectonic_metal_controller_names)}"
 }
 
 data "archive_file" "assets" {


### PR DESCRIPTION
Fixes https://github.com/coreos-inc/tectonic-issues/issues/240

Regression introduced in #468
