### PR TITLE
License collection

### DIFF
--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -16,6 +16,9 @@ FROM golang:1.8-wheezy
 RUN go get -u github.com/golang/lint/golint
 RUN go get github.com/jstemmer/go-junit-report
 
+### License parser
+RUN go get github.com/estroz/license-bill-of-materials
+
 ### Install Terraform, NodeJS and Yarn
 ENV TERRAFORM_VERSION="0.8.8"
 ENV NODE_VERSION="v6.10.0"

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -54,6 +54,10 @@ release: release-bins
 	./scripts/release/upload_release_tarball.sh
 	./scripts/release/make_github_release.sh
 
+.PHONY: license-parse
+license-parse:
+	./scripts/license-gen/collect_project_licenses.sh
+
 .PHONY: release-bins
 release-bins: \
 	bin/linux/installer \

--- a/installer/scripts/license-gen/collect_project_licenses.sh
+++ b/installer/scripts/license-gen/collect_project_licenses.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+
+### Usage ###
+# collect_project_licenses.sh aggregates license information from a packages'
+# immediate dependencies for both Go and JS repositories listed in
+# 'pkg_lists/go_pkg_inputs.txt' and 'pkg_lists/js_pkg_inputs.txt', respectively.
+# Go dependency licenses are aggregated using 'license-bill-of-materials', a
+# program that finds licenses using the 'go list' command (see
+# https://github.com/coreos/license-bill-of-materials). JS dependency licenses
+# are aggregated by parsing all node_modules/*/package.json files, which
+# contain a 'license(s)' field. Each set of licenses has the form:
+# [
+#   {
+#     "package": "package name",
+#     "licenses": [{
+#       "type": "license type",
+#       "confidence": N
+#     }, ...]
+#   }
+# ]
+# Once all dependency licenses have been aggregated into JSON arrays in files,
+# all arrays are concatenated into one large array in FINAL_LICENSE_FILE.
+
+### Dependencies ###
+# bash, jq, yarn, git, license-bill-of-materials
+
+set -eu
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FINAL_LICENSE_DIR="$DIR"/licenses
+FINAL_LICENSE_FILE="$FINAL_LICENSE_DIR"/all_licenses.json
+# Temporary data locations
+TMP_DIR=$(mktemp -d -p /tmp)
+
+if [ ! -d "$FINAL_LICENSE_DIR" ]; then mkdir -p "$FINAL_LICENSE_DIR"; fi
+echo "[]" > "$FINAL_LICENSE_FILE"
+
+# Package input files
+go_pkg_inputs="$DIR"/pkg_lists/go_pkg_inputs.txt
+js_pkg_inputs="$DIR"/pkg_lists/js_pkg_inputs.txt
+tmp_shared_file=$(mktemp -p "$TMP_DIR")
+
+# Temporarily create a new GOPATH
+old_gopath="$GOPATH"
+new_gopath="$TMP_DIR"/tmp_gopath
+export GOPATH="$new_gopath"
+mkdir -p "$GOPATH"/{src,bin,pkg}
+
+# Clean up transient files and unset vars
+clean_up() {
+  rm -f "$tmp_shared_file"
+  rm -rf "$TMP_DIR"
+  export GOPATH="$old_gopath"
+  exit
+}
+trap clean_up SIGHUP SIGINT SIGTERM EXIT
+
+# Parse JS deps using jq and send to dst
+parse_js_licenses() {
+  local src="${1:-}"
+  local dst="${2:-}"
+
+  echo "[]" > "$dst"
+  # Create JSON objects using string concatenation
+  # TODO: remove duplicates (?)
+  tmp_json_arr=$(mktemp -p "$TMP_DIR")
+  trap "rm -f $tmp_json_arr; exit" SIGHUP SIGINT SIGTERM EXIT
+  # For every package.json found, parse out repository and license info.
+  # jq runs through a package.json to find the 'repository' (or a 'url' child
+  # if present) key, and check if a 'licenses' key exists:
+  # if so, then use that array (remove 'url', append 'confidence' score); else
+  # create a 'licenses' array by checking if there are multiple licenses
+  # listed (will be separated by AND/OR); if so, split all licenses by separator
+  # and create objects for each; else create a single object with license.
+  # Finally, append each new object to the final array.
+  while read -r dep; do
+    obj=$(cat "$dep" | jq '{
+      project: (.repository | (.url)?//.),
+      licenses:
+        (if (.licenses)? then
+          .licenses | map((del(.url))?
+          | .+{confidence: 1})
+        else
+          .license | if (. | test(" AND | OR ")) then
+            . | gsub("\\(|\\)";"")
+            | split(" AND | OR "; "g")
+            | map({type: ., confidence: 1})
+          else
+            [{type: ., confidence: 1}]
+          end
+        end)
+    }')
+    cat "$dst" | jq ".+[${obj}]" > "$tmp_json_arr"
+    cat "$tmp_json_arr" > "$dst"
+  done < "$src"
+}
+# Clone repository and test if clone was unsuccessful
+clone_package() {
+  if ! git clone "$1" > /dev/null 2>&1; then
+    echo "Failed to clone: $1"
+    return 1
+  fi
+  echo "Cloned: $1"
+  return 0
+}
+# Get all main.go file paths and write to a file
+# NOTE: ignores paths that contain *test*, *vendor*, and *workspace*
+find_trim_main_paths() {
+  find . \
+    -name main.go \
+    -not -path '*test*' \
+    -not -path '*vendor*' \
+    -not -path '*workspace*' \
+    -printf '%h\n' | uniq > "$1"
+  sed -i 's@^\.\(\/\)\?@@g' "$1"
+}
+
+# Grab all Golang dependencies and install under TMP_DIR
+pushd . > /dev/null
+while read -r url; do
+  # Continue loop if line is a comment
+  if grep '^\s*#.*' <<< "$url" > /dev/null; then continue; fi
+
+  # Make organization dir from SSH repo URL
+  # Ex. git@github.com:org/repo.git -> $GOPATH/src/github.com/org
+  org_dir=$(echo "$url" | sed 's|.*@\(.*\):\(.*\)\/.*|'"$GOPATH"'\/src\/\1\/\2|g')
+  repo=$(echo "$url" | sed 's|.*\/\(.*\)\..*|\1|g')
+  if [ ! -d "$org_dir" ]; then mkdir -p "$org_dir"; fi
+  cd "$org_dir"
+
+  # Exit loop if package cannot be downloaded
+  if ! clone_package "$url"; then exit 1; fi
+  # Find all main.go files
+  cd "$repo"
+  find_trim_main_paths "$tmp_shared_file"
+
+  # Create an organization_repo_license.json file
+  subd_path="${org_dir##*/}_${repo}"
+  go_pkg_json_file="${FINAL_LICENSE_DIR}/${subd_path}_license.json"
+  go_pkg_rel_path="$(echo "$org_dir" | sed 's|.*\/src\/\(.*\)|\1|g')/${repo}"
+  # Construct full paths to each main.go parent dir, starting after src/
+  dep_loc_set=$(sed 's|^\(.*\)$|'"${go_pkg_rel_path}"'\/\1|g' "$tmp_shared_file" | tr '\n' ' ')
+
+  # If no main.go's can be found, 'go list' won't work, so skip
+  if [ -z "$dep_loc_set" ]; then echo "No license info: $go_pkg_rel_path"; continue; fi
+
+  # NOTE: license-bill-of-materials will return a non-zero exit code if one or
+  # more dependencies' license cannot be found, even if other dependencies
+  # in the same package/repo have licenses. Unset 'e' to prevent exit
+  set +e
+  "${old_gopath}"/bin/license-bill-of-materials $dep_loc_set > "$go_pkg_json_file"
+  set -e
+done < "$go_pkg_inputs"
+popd > /dev/null
+
+# Grab all JS dependency license info from package.json files (usually in
+# frontend dirs)
+pushd . > /dev/null
+while read -r loc; do
+  if grep '^\s*#.*' <<< "$loc" > /dev/null; then continue; fi
+
+  # Retrieve each dependency of the current package
+  subd_path=$(echo "${loc#*/}" | sed 's@\/@_@g')
+  js_pkg_json_file="${FINAL_LICENSE_DIR}/${subd_path}_license.json"
+  # Install all non-dev deps. Exit if any errors occur while installing
+
+  # Install non-dev node dependencies
+  cd "${GOPATH}/src/${loc}"
+  if ! yarn install --production --no-lockfiles; then
+    echo "Error installing node modules."
+    exit 1
+  fi
+
+  # Find all package.json files in node_modules
+  find node_modules/ -type f -name package.json > "$tmp_shared_file"
+
+  # Parse all package.json files for project and license fields
+  parse_js_licenses "$tmp_shared_file" "$js_pkg_json_file"
+done < "$js_pkg_inputs"
+popd > /dev/null
+
+# Append all licenses into one file
+while read -r file; do
+  # Concatenate all JSON arrays in a license file (might be 2-3 from
+  # license-bill-of-materials output)
+  json_license=$(cat "$file" | jq '.[]' | jq -s '.')
+
+  # Concatenate with final array
+  cat "$FINAL_LICENSE_FILE" | jq ".+${json_license}" > "$tmp_shared_file"
+  cat "$tmp_shared_file" > "$FINAL_LICENSE_FILE"
+done < <(find "$FINAL_LICENSE_DIR" -name '*_license.json')
+
+# TODO: JSON output to Tectonic frontend (REST?)
+echo "License JSON files:  $FINAL_LICENSE_DIR"
+echo "Aggregated licenses: $FINAL_LICENSE_FILE"
+
+clean_up

--- a/installer/scripts/license-gen/licenses/all_licenses.json
+++ b/installer/scripts/license-gen/licenses/all_licenses.json
@@ -1,0 +1,10503 @@
+[
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/beorn7/perks/quantile",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/codegangsta/negroni",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-systemd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg/capnslog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/spdystream",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      },
+      {
+        "type": "Open Software License 3.0",
+        "confidence": 0.4606413994169096
+      }
+    ]
+  },
+  {
+    "project": "github.com/elazarl/go-bindata-assetfs",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful-swagger12",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/evanphx/json-patch",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/garyburd/redigo",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/analysis",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/loads",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9090909090909091
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/context",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/mux",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/grpc-ecosystem/go-grpc-prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/grpc-ecosystem/grpc-gateway",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes/kubernetes/staging/src/k8s.io/client-go/examples",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/mxk/go-flowrate/flowrate",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9707112970711297
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/pkg/errors",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_model/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "github.com/xyproto/simpleredis",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/natefinch/lumberjack.v2",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/gengo",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/gke-certificates-controller/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/gke-certificates-controller/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/gke-certificates-controller/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/gke-certificates-controller/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/gke-certificates-controller/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-apiserver/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-apiserver/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-apiserver/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-apiserver/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-apiserver/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-apiserver/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-controller-manager/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-controller-manager/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-controller-manager/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-controller-manager/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-controller-manager/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-controller-manager/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-proxy/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-proxy/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-proxy/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-proxy/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-proxy/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kubelet/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kubelet/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kubelet/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kubelet/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kubelet/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kubelet/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kubelet/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/kubelet/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kubelet/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kubelet/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-apiserver/app",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-apiserver/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-apiserver/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-controller-manager/app",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/client/metrics/prometheus",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/client/metrics/prometheus\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/client/metrics/prometheus (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/client/metrics/prometheus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/client/metrics/prometheus (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/kubectl/cmd",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/kubectl/cmd\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/kubectl/cmd (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/kubectl/cmd (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/kubectl/cmd/util",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/kubectl/cmd/util\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/util (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/kubectl/cmd/util (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/util",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/util\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/util (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/util (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/util (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/util/logs",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/util/logs\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/util/logs (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/util/logs (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/util/logs (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/version/prometheus",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/version/prometheus\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/version/prometheus (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/version/prometheus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/version/prometheus (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/version/verflag",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/version/verflag\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/pkg/version/verflag (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/version/verflag (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/version/verflag (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app",
+    "error": "cannot find package \"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/kubernetes/vendor/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options (from $GOPATH)"
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ajeddeloh/yaml",
+    "licenses": [
+      {
+        "type": "The Unlicense",
+        "confidence": 0.35294117647058826
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "github.com/alecthomas/units",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/container-linux-config-transpiler/config",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/coreos-cloudinit/config",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-semver/semver",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-systemd/unit",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/ignition/config",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/matchbox",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg/flagutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/yaml",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/vincent-petithory/dataurl",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "go4.org/errorutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:yargs/yargs-parser.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/yargs/yargs.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:yargs/y18n.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/npm/wrappy",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "chalk/wrap-ansi",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/nexdrew/which-module.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github/fetch",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/r3dm/warning.git",
+    "licenses": [
+      {
+        "type": "BSD-2-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kemitchell/validate-npm-package-license.js",
+    "licenses": [
+      {
+        "type": "Apache-2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/TooTallNate/util-deprecate.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/faisalman/ua-parser-js.git",
+    "licenses": [
+      {
+        "type": "GPL-2.0",
+        "confidence": 1
+      },
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "blesh/symbol-observable",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/strip-bom",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "chalk/strip-ansi",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/string-width",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/rvagg/string_decoder.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kevva/strict-uri-encode",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "shinnn/spdx-license-ids",
+    "licenses": [
+      {
+        "type": "Unlicense",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kemitchell/spdx-expression-parse.js",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      },
+      {
+        "type": "CC-BY-3.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kemitchell/spdx-correct.js",
+    "licenses": [
+      {
+        "type": "Apache-2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/mozilla/source-map.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "YuzuJS/setImmediate",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/yargs/set-blocking.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/npm/node-semver",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/node-resolve.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+ssh://git@github.com/yargs/require-main-filename.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/troygoode/node-require-directory.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/gaearon/redux-thunk.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/reactjs/redux.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/nodejs/readable-stream",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/rvagg/string_decoder.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/read-pkg-up",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "reactjs/react-router",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/read-pkg",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/reactjs/react-redux.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/rackt/react-modal.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/react",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/react",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/query-string",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/bestiejs/punycode.js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "reactjs/prop-types",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/then/promise.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/calvinmetcalf/process-nextick-args.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "floatdrop/pinkie-promise",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "floatdrop/pinkie",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/pify",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/path-type",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/jbgutierrez/path-parse.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/path-is-absolute",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/path-exists",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/parse-json",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/os-locale",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/object-assign",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/once",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/number-is-nan",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/npm/normalize-package-data.git",
+    "licenses": [
+      {
+        "type": "BSD-2-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/bitinn/node-fetch.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/minimist.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/minimatch.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/zertosh/loose-envify.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/load-json-file",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/lcid",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/auth0/jwt-decode",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/json-stable-stringify.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/substack/jsonify.git",
+    "licenses": [
+      {
+        "type": "Public Domain",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/js-cookie/js-cookie.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lydell/js-tokens",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/wayfind/is-utf8.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/matthew-andrews/isomorphic-fetch.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/juliangruber/isarray.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/is-stream",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/is-fullwidth-code-point",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/is-builtin-module",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/qix-/node-is-arrayish.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/invert-kv",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/zertosh/invariant",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/inherits",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/npm/inflight.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/facebook/immutable-js.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/ashtuchkin/iconv-lite.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/npm/hosted-git-info.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/mridgway/hoist-non-react-statics.git",
+    "licenses": [
+      {
+        "type": "BSD",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/mjackson/history.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/node-glob.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/stefanpenner/get-caller-file.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/isaacs/node-graceful-fs",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/isaacs/fs.realpath.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/eligrey/FileSaver.js",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/find-up",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/fbjs",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/zloirock/core-js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/JedWatson/exenv.git",
+    "licenses": [
+      {
+        "type": "BSD",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/estools/estraverse.git",
+    "licenses": [
+      {
+        "type": "BSD-2-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "qix-/node-error-ex",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/andris9/encoding.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:maxogden/element-class.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/substack/node-deep-equal.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/decamelize",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/react",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/core-util-is",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/zloirock/core-js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/node-concat-map.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/code-point-at",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/JedWatson/classnames.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/yargs/cliui.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/builtin-modules",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/camelcase",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:Rich-Harris/BabyParse.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:calvinmetcalf/buffer-shims.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/juliangruber/brace-expansion.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/juliangruber/balanced-match.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/mcavage/node-assert-plus.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/kriskowal/asap.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/ternjs/acorn.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "chalk/ansi-regex",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:yargs/yargs-parser.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/yargs/yargs.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:yargs/y18n.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/Raynos/xtend.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/driverdan/node-XMLHttpRequest.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/npm/wrappy",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "chalk/wrap-ansi",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/nexdrew/which-module.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github/fetch",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/BerkeleyTrue/warning.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/wearefractal/vinyl.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/pvorb/node-clone.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kemitchell/validate-npm-package-license.js",
+    "licenses": [
+      {
+        "type": "Apache-2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/AriaMinaei/utila.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/TooTallNate/util-deprecate.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/faisalman/ua-parser-js.git",
+    "licenses": [
+      {
+        "type": "GPL-2.0",
+        "confidence": 1
+      },
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/to-fast-properties",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/rvagg/through2.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "blesh/symbol-observable",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/strip-bom",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "chalk/strip-ansi",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/string-width",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/rvagg/string_decoder.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kevva/strict-uri-encode",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/alexei/sprintf.js.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "shinnn/spdx-license-ids",
+    "licenses": [
+      {
+        "type": "Unlicense",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kemitchell/spdx-expression-parse.js",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      },
+      {
+        "type": "CC-BY-3.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "kemitchell/spdx-correct.js",
+    "licenses": [
+      {
+        "type": "Apache-2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/mozilla/source-map.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "dashed/shallowequal",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "YuzuJS/setImmediate",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/yargs/set-blocking.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/npm/node-semver",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/mbostock/rw.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/node-resolve.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/rimraf.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/troygoode/node-require-directory.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/wearefractal/replace-ext.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+ssh://git@github.com/yargs/require-main-filename.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/facebook/regenerator/tree/master/packages/regenerator-runtime",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/gaearon/redux-thunk.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/erikras/redux-form",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/reactjs/redux.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/nodejs/readable-stream",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/read-pkg-up",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/read-pkg",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/olahol/react-tagsinput",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "ReactTraining/react-router",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/gaearon/react-side-effect.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/JedWatson/exenv.git",
+    "licenses": [
+      {
+        "type": "BSD",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/reactjs/react-redux.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/reactjs/react-modal.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/mcumpl/react-lightweight-tooltip.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/nfl/react-helmet",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/react",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/react",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/react",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/query-string",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/then/promise.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/bestiejs/punycode.js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/calvinmetcalf/process-nextick-args.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "floatdrop/pinkie-promise",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "floatdrop/pinkie",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/pify",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/path-type",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/jbgutierrez/path-parse.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/path-is-absolute",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/path-exists",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/parse-json",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/os-locale",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/once",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/object-assign",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "zeit/ms",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/number-is-nan",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/npm/normalize-package-data.git",
+    "licenses": [
+      {
+        "type": "BSD-2-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/bitinn/node-fetch.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/moment/moment.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/minimist.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/minimatch.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/zertosh/loose-envify.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lodash/lodash",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/load-json-file",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/lcid",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/substack/jsonify.git",
+    "licenses": [
+      {
+        "type": "Public Domain",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/json-stable-stringify.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "nodeca/js-yaml",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "lydell/js-tokens",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/js-cookie/js-cookie.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/matthew-andrews/isomorphic-fetch.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/juliangruber/isarray.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/wayfind/is-utf8.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/is-stream",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/then/is-promise.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/is-fullwidth-code-point",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/is-builtin-module",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/qix-/node-is-arrayish.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/invert-kv",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/zertosh/invariant",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/inherits",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/npm/inflight.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/facebook/immutable-js.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/ashtuchkin/iconv-lite.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/npm/hosted-git-info.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/mridgway/hoist-non-react-statics.git",
+    "licenses": [
+      {
+        "type": "BSD",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "mjackson/history",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/zhiyelee/graceful-readlink.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/isaacs/node-graceful-fs",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/node-glob.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/stefanpenner/get-caller-file.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/bevacqua/fuzzysearch.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+https://github.com/isaacs/fs.realpath.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/FortAwesome/Font-Awesome.git",
+    "licenses": [
+      {
+        "type": "OFL-1.1",
+        "confidence": 1
+      },
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/find-up",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/eligrey/FileSaver.js",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "facebook/fbjs",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/zloirock/core-js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/JedWatson/exenv.git",
+    "licenses": [
+      {
+        "type": "BSD",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/estools/esutils.git",
+    "licenses": [
+      {
+        "type": "BSD",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/estools/estraverse.git",
+    "licenses": [
+      {
+        "type": "BSD-2-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/jquery/esprima.git",
+    "licenses": [
+      {
+        "type": "BSD-2-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/bjyoungblood/es6-error.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "qix-/node-error-ex",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:maxogden/element-class.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/andris9/encoding.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "deoxxa/duplexer2",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/substack/node-deep-equal.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/visionmedia/debug.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/decamelize",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-zoom.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-voronoi.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-transition.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-timer.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-time-format.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-time.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-shape.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-selection.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-scale.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-request.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-random.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-queue.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-quadtree.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-polygon.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-path.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-interpolate.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-hierarchy.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-geo.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-format.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-force.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-ease.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-dsv.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-drag.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-dispatch.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-color.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-collection.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-chord.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-brush.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-axis.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3-array.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/zloirock/core-js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/isaacs/core-util-is",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/d3/d3.git",
+    "licenses": [
+      {
+        "type": "BSD-3-Clause",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/thlorenz/convert-source-map.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/substack/node-concat-map.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/tj/commander.js.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/code-point-at",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/hughsk/clone-stats",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/pvorb/node-clone.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "http://github.com/yargs/cliui.git",
+    "licenses": [
+      {
+        "type": "ISC",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/JedWatson/classnames.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/camelcase",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "sindresorhus/builtin-modules",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git@github.com:calvinmetcalf/buffer-shims.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/juliangruber/brace-expansion.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/blueimp/JavaScript-MD5.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git://github.com/juliangruber/balanced-match.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-types",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-runtime",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-preset-react",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-self",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-flow-strip-types",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-jsx",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-flow",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/babel/babel/tree/master/packages/babel-helper-builder-react-jsx",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/caolan/async.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/kriskowal/asap.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/mcavage/node-assert-plus.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "chalk/ansi-regex",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "nodeca/argparse",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "git+ssh://git@github.com/ryanhefner/Array.prototype.findIndex.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "https://github.com/ternjs/acorn.git",
+    "licenses": [
+      {
+        "type": "MIT",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/container-linux-update-operator/cmd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg/flagutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/container-linux-update-operator/pkg/agent",
+    "error": "cannot find package \"github.com/coreos/container-linux-update-operator/pkg/agent\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/container-linux-update-operator/vendor/github.com/coreos/container-linux-update-operator/pkg/agent (vendor tree)\n\t/usr/local/go/src/github.com/coreos/container-linux-update-operator/pkg/agent (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/container-linux-update-operator/pkg/agent (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/container-linux-update-operator/pkg/analytics",
+    "error": "cannot find package \"github.com/coreos/container-linux-update-operator/pkg/analytics\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/container-linux-update-operator/vendor/github.com/coreos/container-linux-update-operator/pkg/analytics (vendor tree)\n\t/usr/local/go/src/github.com/coreos/container-linux-update-operator/pkg/analytics (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/container-linux-update-operator/pkg/analytics (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/container-linux-update-operator/pkg/operator",
+    "error": "cannot find package \"github.com/coreos/container-linux-update-operator/pkg/operator\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/container-linux-update-operator/vendor/github.com/coreos/container-linux-update-operator/pkg/operator (vendor tree)\n\t/usr/local/go/src/github.com/coreos/container-linux-update-operator/pkg/operator (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/container-linux-update-operator/pkg/operator (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/container-linux-update-operator/pkg/version",
+    "error": "cannot find package \"github.com/coreos/container-linux-update-operator/pkg/version\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/container-linux-update-operator/vendor/github.com/coreos/container-linux-update-operator/pkg/version (vendor tree)\n\t/usr/local/go/src/github.com/coreos/container-linux-update-operator/pkg/version (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/container-linux-update-operator/pkg/version (from $GOPATH)"
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd-operator/pkg/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/dgrijalva/jwt-go",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/engine-api/types",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-connections/nat",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-units",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/evanphx/json-patch",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/exponent-io/jsonpath",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes-incubator/bootkube",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apimachinery",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apiserver/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "vbom.ml/util/sortorder",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/beorn7/perks/quantile",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/codegangsta/negroni",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-systemd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/kubernetes/staging/src/k8s.io/client-go/examples",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg/capnslog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/spdystream",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      },
+      {
+        "type": "Open Software License 3.0",
+        "confidence": 0.4606413994169096
+      }
+    ]
+  },
+  {
+    "project": "github.com/elazarl/go-bindata-assetfs",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/evanphx/json-patch",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/garyburd/redigo",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/context",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/mux",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/grpc-ecosystem/grpc-gateway",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/mxk/go-flowrate/flowrate",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9707112970711297
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/pkg/errors",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_model/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "github.com/xyproto/simpleredis",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/natefinch/lumberjack.v2",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/gengo",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/gke-certificates-controller/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/gke-certificates-controller/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/gke-certificates-controller/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/gke-certificates-controller/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/gke-certificates-controller/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-apiserver/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-apiserver/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-apiserver/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-apiserver/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-apiserver/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-apiserver/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-apiserver/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-apiserver/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-controller-manager/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-controller-manager/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-controller-manager/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-controller-manager/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-controller-manager/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-controller-manager/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-controller-manager/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-controller-manager/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-proxy/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-proxy/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-proxy/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-proxy/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-proxy/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kube-proxy/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kube-proxy/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kube-proxy/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kube-proxy/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kube-proxy/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kubelet/app",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kubelet/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kubelet/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kubelet/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kubelet/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/kubelet/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/kubelet/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/kubelet/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/kubelet/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/kubelet/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/conversion-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/informer-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/lister-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators",
+    "error": "cannot find package \"k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-apiserver/app",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-apiserver/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-apiserver/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-controller-manager/app",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/client/metrics/prometheus",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/client/metrics/prometheus\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/client/metrics/prometheus (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/client/metrics/prometheus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/client/metrics/prometheus (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/kubectl/cmd",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/kubectl/cmd\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/kubectl/cmd (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/kubectl/cmd (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/kubectl/cmd/util",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/kubectl/cmd/util\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/kubectl/cmd/util (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/util (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/kubectl/cmd/util (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/util",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/util\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/util (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/util (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/util (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/util/logs",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/util/logs\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/util/logs (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/util/logs (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/util/logs (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/version/prometheus",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/version/prometheus\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/version/prometheus (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/version/prometheus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/version/prometheus (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/version/verflag",
+    "error": "cannot find package \"k8s.io/kubernetes/pkg/version/verflag\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/pkg/version/verflag (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/pkg/version/verflag (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/pkg/version/verflag (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app",
+    "error": "cannot find package \"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options",
+    "error": "cannot find package \"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/kubernetes/vendor/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options (vendor tree)\n\t/usr/local/go/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options (from $GOPATH)"
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/beevik/etree",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 0.9658536585365853
+      }
+    ]
+  },
+  {
+    "project": "github.com/cockroachdb/cockroach-go/crdb",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/dex",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-sql-driver/mysql",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/handlers",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 0.9852216748768473
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/mux",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/gtank/cryptopasta",
+    "licenses": [
+      {
+        "type": "Creative Commons Zero v1.0 Universal",
+        "confidence": 0.9642857142857143
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/lib/pq",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/mattn/go-sqlite3",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/pquerna/cachecontrol",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/russellhaering/goxmldsig",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/genproto/googleapis/rpc/status",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/asn1-ber.v1",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/ldap.v2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/square/go-jose.v2",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/square/go-jose.v2/json",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes/dns/cmd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/miekg/dns",
+    "licenses": [
+      {
+        "type": "BSD 3-clause Clear License",
+        "confidence": 0.1476510067114094
+      },
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9311740890688259
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/util",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/dns/pkg/dns/config",
+    "error": "cannot find package \"k8s.io/dns/pkg/dns/config\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/dns/vendor/k8s.io/dns/pkg/dns/config (vendor tree)\n\t/usr/local/go/src/k8s.io/dns/pkg/dns/config (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/dns/pkg/dns/config (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/dns/pkg/dnsmasq",
+    "error": "cannot find package \"k8s.io/dns/pkg/dnsmasq\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/dns/vendor/k8s.io/dns/pkg/dnsmasq (vendor tree)\n\t/usr/local/go/src/k8s.io/dns/pkg/dnsmasq (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/dns/pkg/dnsmasq (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/dns/pkg/e2e",
+    "error": "cannot find package \"k8s.io/dns/pkg/e2e\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/dns/vendor/k8s.io/dns/pkg/e2e (vendor tree)\n\t/usr/local/go/src/k8s.io/dns/pkg/e2e (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/dns/pkg/e2e (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/dns/pkg/sidecar",
+    "error": "cannot find package \"k8s.io/dns/pkg/sidecar\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/dns/vendor/k8s.io/dns/pkg/sidecar (vendor tree)\n\t/usr/local/go/src/k8s.io/dns/pkg/sidecar (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/dns/pkg/sidecar (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/dns/pkg/version",
+    "error": "cannot find package \"k8s.io/dns/pkg/version\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/dns/vendor/k8s.io/dns/pkg/version (vendor tree)\n\t/usr/local/go/src/k8s.io/dns/pkg/version (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/dns/pkg/version (from $GOPATH)"
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-omaha/omaha",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/mock/gomock",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apimachinery",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/client",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg/kubeutil",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg/omaha",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg/updater",
+    "error": "No license detected"
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/prometheus-operator",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ericchiang/k8s",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-kit/kit/log",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-logfmt/logfmt",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-stack/stack",
+    "licenses": [
+      {
+        "type": "The Unlicense",
+        "confidence": 0.35294117647058826
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/jpillora/go-ogle-analytics",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9787234042553191
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/pkg/errors",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sync/errgroup",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sys/unix",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sys/unix",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/fsnotify.v1",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/fsnotify.v1",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/beorn7/perks/quantile",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-semver/semver",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-systemd/journal",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/dgrijalva/jwt-go",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/docker/pkg/mount",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/engine-api/types",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/engine-api/types",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-connections/nat",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-connections/nat",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-units",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      },
+      {
+        "type": "Open Software License 3.0",
+        "confidence": 0.4606413994169096
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-units",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      },
+      {
+        "type": "Open Software License 3.0",
+        "confidence": 0.4606413994169096
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/evanphx/json-patch",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/evanphx/json-patch",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/godbus/dbus",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 0.9903846153846154
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/cadvisor/info/v1",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/cadvisor/info/v1",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes/contrib",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/opencontainers/runc/libcontainer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_model/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net/context",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/api",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/api/googleapi/internal/uritemplates",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/cloud",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/third_party/forked/json",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/third_party/forked/reflect",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-etcd/etcd",
+    "error": "cannot find package \"github.com/coreos/go-etcd/etcd\" in any of:\n\t/usr/local/go/src/github.com/coreos/go-etcd/etcd (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/go-etcd/etcd (from $GOPATH)"
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "error": "cannot find package \"github.com/spf13/pflag\" in any of:\n\t/usr/local/go/src/github.com/spf13/pflag (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/spf13/pflag (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/contrib/election/lib",
+    "error": "cannot find package \"k8s.io/contrib/election/lib\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/contrib/election/vendor/k8s.io/contrib/election/lib (vendor tree)\n\t/usr/local/go/src/k8s.io/contrib/election/lib (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/contrib/election/lib (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/contrib/prometheus-to-sd/config",
+    "error": "cannot find package \"k8s.io/contrib/prometheus-to-sd/config\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/contrib/prometheus-to-sd/vendor/k8s.io/contrib/prometheus-to-sd/config (vendor tree)\n\t/usr/local/go/src/k8s.io/contrib/prometheus-to-sd/config (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/contrib/prometheus-to-sd/config (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/contrib/prometheus-to-sd/translator",
+    "error": "cannot find package \"k8s.io/contrib/prometheus-to-sd/translator\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/contrib/prometheus-to-sd/vendor/k8s.io/contrib/prometheus-to-sd/translator (vendor tree)\n\t/usr/local/go/src/k8s.io/contrib/prometheus-to-sd/translator (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/contrib/prometheus-to-sd/translator (from $GOPATH)"
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/prometheus-operator",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-kit/kit/log",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-logfmt/logfmt",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-stack/stack",
+    "licenses": [
+      {
+        "type": "The Unlicense",
+        "confidence": 0.35294117647058826
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/mock/gomock",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/jpillora/go-ogle-analytics",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9787234042553191
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/pkg/errors",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sync/errgroup",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/third_party/forked/golang",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/client",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-prometheus-operator/cmd/operator",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-prometheus-operator/pkg/manifests",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-prometheus-operator/pkg/operator",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-prometheus-operator/third_party/clock",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-prometheus-operator/third_party/workqueue",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd/pkg/fileutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-systemd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg/capnslog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/engine-api",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/engine-api/client/transport/cancellable",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-connections",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/go-units",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/godbus/dbus",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 0.9903846153846154
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/mock/gomock",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/opencontainers/runc/libcontainer/user",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apimachinery",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/cmd/kube-version-operator",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/cmd/node-agent",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/pkg/atomic",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/pkg/cluster",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/pkg/cluster/components",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/pkg/cluster/components/internal/migrations/1_5_x",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/pkg/node",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/kube-version-operator/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/client",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg/kubeutil",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-channel-operator/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "cloud.google.com/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/beorn7/perks/quantile",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/blang/semver",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd-operator",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-semver/semver",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/groupcache/lru",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/mock/gomock",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/grpc-ecosystem/go-grpc-prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/grpc-ecosystem/grpc-gateway",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_model/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/third_party/forked/golang",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "bitbucket.org/ww/goautoneg",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/client",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/operator-client/pkg/types",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-etcd-operator",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-etcd-operator/pkg/mapping",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-etcd-operator/test/mapping",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/armon/go-proxyproto",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/beorn7/perks/quantile",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-reap",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/howeyc/gopass",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 0.9850746268656716
+      }
+    ]
+  },
+  {
+    "project": "github.com/imdario/mergo",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes/ingress",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/paultag/sniff/parser",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/pkg/errors",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_model/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto/ssh/terminal",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sys/unix",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apimachinery",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/kubernetes/pkg/util",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/ingress/controllers/gce/backends",
+    "error": "cannot find package \"k8s.io/ingress/controllers/gce/backends\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/gce/backends (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/gce/backends (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/gce/backends (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/gce/controller",
+    "error": "cannot find package \"k8s.io/ingress/controllers/gce/controller\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/gce/controller (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/gce/controller (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/gce/controller (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/gce/loadbalancers",
+    "error": "cannot find package \"k8s.io/ingress/controllers/gce/loadbalancers\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/gce/loadbalancers (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/gce/loadbalancers (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/gce/loadbalancers (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/gce/storage",
+    "error": "cannot find package \"k8s.io/ingress/controllers/gce/storage\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/gce/storage (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/gce/storage (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/gce/storage (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/gce/utils",
+    "error": "cannot find package \"k8s.io/ingress/controllers/gce/utils\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/gce/utils (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/gce/utils (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/gce/utils (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/nginx/pkg/config",
+    "error": "cannot find package \"k8s.io/ingress/controllers/nginx/pkg/config\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/nginx/pkg/config (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/nginx/pkg/config (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/nginx/pkg/config (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/nginx/pkg/metric/collector",
+    "error": "cannot find package \"k8s.io/ingress/controllers/nginx/pkg/metric/collector\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/nginx/pkg/metric/collector (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/nginx/pkg/metric/collector (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/nginx/pkg/metric/collector (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/nginx/pkg/template",
+    "error": "cannot find package \"k8s.io/ingress/controllers/nginx/pkg/template\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/nginx/pkg/template (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/nginx/pkg/template (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/nginx/pkg/template (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/controllers/nginx/pkg/version",
+    "error": "cannot find package \"k8s.io/ingress/controllers/nginx/pkg/version\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/controllers/nginx/pkg/version (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/controllers/nginx/pkg/version (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/controllers/nginx/pkg/version (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/ingress",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/ingress\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/ingress (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/ingress (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/ingress (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/ingress/annotations/parser",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/ingress/annotations/parser\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/ingress/annotations/parser (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/ingress/annotations/parser (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/ingress/annotations/parser (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/ingress/controller",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/ingress/controller\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/ingress/controller (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/ingress/controller (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/ingress/controller (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/ingress/defaults",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/ingress/defaults\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/ingress/defaults (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/ingress/defaults (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/ingress/defaults (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/ingress/errors",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/ingress/errors\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/ingress/errors (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/ingress/errors (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/ingress/errors (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/ingress/resolver",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/ingress/resolver\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/ingress/resolver (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/ingress/resolver (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/ingress/resolver (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/k8s",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/k8s\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/k8s (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/k8s (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/k8s (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/net/dns",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/net/dns\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/net/dns (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/net/dns (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/net/dns (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/ingress/core/pkg/net/ssl",
+    "error": "cannot find package \"k8s.io/ingress/core/pkg/net/ssl\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes/ingress/vendor/k8s.io/ingress/core/pkg/net/ssl (vendor tree)\n\t/usr/local/go/src/k8s.io/ingress/core/pkg/net/ssl (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/ingress/core/pkg/net/ssl (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/etcd-operator",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "error": "cannot find package \"github.com/Sirupsen/logrus\" in any of:\n\t/usr/local/go/src/github.com/Sirupsen/logrus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/Sirupsen/logrus (from $GOPATH)"
+  },
+  {
+    "project": "github.com/aws/aws-sdk-go/aws",
+    "error": "cannot find package \"github.com/aws/aws-sdk-go/aws\" in any of:\n\t/usr/local/go/src/github.com/aws/aws-sdk-go/aws (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/aws/aws-sdk-go/aws (from $GOPATH)"
+  },
+  {
+    "project": "github.com/aws/aws-sdk-go/aws/session",
+    "error": "cannot find package \"github.com/aws/aws-sdk-go/aws/session\" in any of:\n\t/usr/local/go/src/github.com/aws/aws-sdk-go/aws/session (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/aws/aws-sdk-go/aws/session (from $GOPATH)"
+  },
+  {
+    "project": "github.com/aws/aws-sdk-go/service/s3",
+    "error": "cannot find package \"github.com/aws/aws-sdk-go/service/s3\" in any of:\n\t/usr/local/go/src/github.com/aws/aws-sdk-go/service/s3 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/aws/aws-sdk-go/service/s3 (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/etcd/clientv3",
+    "error": "cannot find package \"github.com/coreos/etcd/clientv3\" in any of:\n\t/usr/local/go/src/github.com/coreos/etcd/clientv3 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/etcd/clientv3 (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
+    "error": "cannot find package \"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes\" in any of:\n\t/usr/local/go/src/github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/etcd/pkg/transport",
+    "error": "cannot find package \"github.com/coreos/etcd/pkg/transport\" in any of:\n\t/usr/local/go/src/github.com/coreos/etcd/pkg/transport (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/etcd/pkg/transport (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/go-semver/semver",
+    "error": "cannot find package \"github.com/coreos/go-semver/semver\" in any of:\n\t/usr/local/go/src/github.com/coreos/go-semver/semver (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos/go-semver/semver (from $GOPATH)"
+  },
+  {
+    "project": "github.com/golang/glog",
+    "error": "cannot find package \"github.com/golang/glog\" in any of:\n\t/usr/local/go/src/github.com/golang/glog (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/golang/glog (from $GOPATH)"
+  },
+  {
+    "project": "github.com/jpillora/go-ogle-analytics",
+    "error": "cannot find package \"github.com/jpillora/go-ogle-analytics\" in any of:\n\t/usr/local/go/src/github.com/jpillora/go-ogle-analytics (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/jpillora/go-ogle-analytics (from $GOPATH)"
+  },
+  {
+    "project": "github.com/pborman/uuid",
+    "error": "cannot find package \"github.com/pborman/uuid\" in any of:\n\t/usr/local/go/src/github.com/pborman/uuid (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/pborman/uuid (from $GOPATH)"
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "error": "cannot find package \"github.com/prometheus/client_golang/prometheus\" in any of:\n\t/usr/local/go/src/github.com/prometheus/client_golang/prometheus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/prometheus/client_golang/prometheus (from $GOPATH)"
+  },
+  {
+    "project": "golang.org/x/net/context",
+    "error": "cannot find package \"golang.org/x/net/context\" in any of:\n\t/usr/local/go/src/golang.org/x/net/context (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/golang.org/x/net/context (from $GOPATH)"
+  },
+  {
+    "project": "golang.org/x/time/rate",
+    "error": "cannot find package \"golang.org/x/time/rate\" in any of:\n\t/usr/local/go/src/golang.org/x/time/rate (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/golang.org/x/time/rate (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/api/errors",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/api/errors\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/api/errors (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/api/errors (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/api/resource",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/api/resource\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/api/resource (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/api/resource (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/apis/meta/v1\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/apis/meta/v1 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/apis/meta/v1 (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/labels",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/labels\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/labels (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/labels (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/runtime",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/runtime\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/runtime (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/runtime (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/runtime/schema",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/runtime/schema\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/runtime/schema (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/runtime/schema (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/runtime/serializer",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/runtime/serializer\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/runtime/serializer (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/runtime/serializer (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/types",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/types\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/types (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/types (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/util/intstr",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/util/intstr\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/util/intstr (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/util/intstr (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/util/runtime",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/util/runtime\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/util/runtime (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/util/runtime (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/util/strategicpatch",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/util/strategicpatch\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/util/strategicpatch (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/util/strategicpatch (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/util/wait",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/util/wait\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/util/wait (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/util/wait (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/watch",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/watch\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/watch (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/watch (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/kubernetes",
+    "error": "cannot find package \"k8s.io/client-go/kubernetes\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/kubernetes (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/kubernetes (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/api",
+    "error": "cannot find package \"k8s.io/client-go/pkg/api\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/api (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/api (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/api/v1",
+    "error": "cannot find package \"k8s.io/client-go/pkg/api/v1\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/api/v1 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/api/v1 (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/apis/apps/v1beta1",
+    "error": "cannot find package \"k8s.io/client-go/pkg/apis/apps/v1beta1\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/apis/apps/v1beta1 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/apis/apps/v1beta1 (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/apis/extensions/v1beta1",
+    "error": "cannot find package \"k8s.io/client-go/pkg/apis/extensions/v1beta1\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/apis/extensions/v1beta1 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/apis/extensions/v1beta1 (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/apis/storage/v1beta1",
+    "error": "cannot find package \"k8s.io/client-go/pkg/apis/storage/v1beta1\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/apis/storage/v1beta1 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/apis/storage/v1beta1 (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+    "error": "cannot find package \"k8s.io/client-go/plugin/pkg/client/auth/gcp\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/plugin/pkg/client/auth/gcp (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/plugin/pkg/client/auth/gcp (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/rest",
+    "error": "cannot find package \"k8s.io/client-go/rest\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/rest (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/rest (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/tools/record",
+    "error": "cannot find package \"k8s.io/client-go/tools/record\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/tools/record (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/tools/record (from $GOPATH)"
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-licensing/license",
+    "licenses": [
+      {
+        "type": "SIL Open Font License 1.1",
+        "confidence": 0.18585858585858586
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/dex",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-oidc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/asn1-ber.v1",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/ldap.v2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/square/go-jose.v2",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/square/go-jose.v2/json",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/bridge/auth",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/bridge/cmd/bridge",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/bridge/pkg/proxy",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/bridge/server",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/bridge/verify",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/bridge/version",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic-licensing/tectonic-kubernetes",
+    "error": "No license detected"
+  },
+  {
+    "project": "github.com/coreos-inc/spartakus/cmd/spartakus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/thockin/glogr",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/thockin/logr",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/kubernetes-incubator/spartakus/pkg/collector",
+    "error": "cannot find package \"github.com/kubernetes-incubator/spartakus/pkg/collector\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/spartakus/vendor/github.com/kubernetes-incubator/spartakus/pkg/collector (vendor tree)\n\t/usr/local/go/src/github.com/kubernetes-incubator/spartakus/pkg/collector (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes-incubator/spartakus/pkg/collector (from $GOPATH)"
+  },
+  {
+    "project": "github.com/kubernetes-incubator/spartakus/pkg/database",
+    "error": "cannot find package \"github.com/kubernetes-incubator/spartakus/pkg/database\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/spartakus/vendor/github.com/kubernetes-incubator/spartakus/pkg/database (vendor tree)\n\t/usr/local/go/src/github.com/kubernetes-incubator/spartakus/pkg/database (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes-incubator/spartakus/pkg/database (from $GOPATH)"
+  },
+  {
+    "project": "github.com/kubernetes-incubator/spartakus/pkg/version",
+    "error": "cannot find package \"github.com/kubernetes-incubator/spartakus/pkg/version\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/spartakus/vendor/github.com/kubernetes-incubator/spartakus/pkg/version (vendor tree)\n\t/usr/local/go/src/github.com/kubernetes-incubator/spartakus/pkg/version (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes-incubator/spartakus/pkg/version (from $GOPATH)"
+  },
+  {
+    "project": "github.com/kubernetes-incubator/spartakus/pkg/volunteer",
+    "error": "cannot find package \"github.com/kubernetes-incubator/spartakus/pkg/volunteer\" in any of:\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/spartakus/vendor/github.com/kubernetes-incubator/spartakus/pkg/volunteer (vendor tree)\n\t/usr/local/go/src/github.com/kubernetes-incubator/spartakus/pkg/volunteer (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/kubernetes-incubator/spartakus/pkg/volunteer (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos/kenc",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "error": "cannot find package \"github.com/Sirupsen/logrus\" in any of:\n\t/usr/local/go/src/github.com/Sirupsen/logrus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/Sirupsen/logrus (from $GOPATH)"
+  },
+  {
+    "project": "github.com/godbus/dbus",
+    "error": "cannot find package \"github.com/godbus/dbus\" in any of:\n\t/usr/local/go/src/github.com/godbus/dbus (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/godbus/dbus (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/apimachinery/pkg/util/sets",
+    "error": "cannot find package \"k8s.io/apimachinery/pkg/util/sets\" in any of:\n\t/usr/local/go/src/k8s.io/apimachinery/pkg/util/sets (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/apimachinery/pkg/util/sets (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/kubernetes",
+    "error": "cannot find package \"k8s.io/client-go/kubernetes\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/kubernetes (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/kubernetes (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/api/v1",
+    "error": "cannot find package \"k8s.io/client-go/pkg/api/v1\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/api/v1 (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/api/v1 (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/pkg/labels",
+    "error": "cannot find package \"k8s.io/client-go/pkg/labels\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/pkg/labels (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/pkg/labels (from $GOPATH)"
+  },
+  {
+    "project": "k8s.io/client-go/rest",
+    "error": "cannot find package \"k8s.io/client-go/rest\" in any of:\n\t/usr/local/go/src/k8s.io/client-go/rest (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/k8s.io/client-go/rest (from $GOPATH)"
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/cenkalti/backoff",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/cespare/xxhash",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/fsnotify/fsnotify",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9090909090909091
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/hcl",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/julienschmidt/httprouter",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9527896995708155
+      }
+    ]
+  },
+  {
+    "project": "github.com/magiconair/properties",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 0.9577464788732394
+      }
+    ]
+  },
+  {
+    "project": "github.com/mitchellh/mapstructure",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/pelletier/go-toml",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/alertmanager",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/prometheus/pkg/labels",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/satori/go.uuid",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/afero",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cast",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/cobra",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9573241061130334
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/jwalterweatherman",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/viper",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/weaveworks/mesh",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sys/unix",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/apparentlymart/go-cidr/cidr",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/aws/aws-sdk-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/bgentry/go-netrc/netrc",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.978494623655914
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-semver/semver",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/ipnets",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/matchbox/matchbox",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg/flagutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/tectonic-installer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/terraform-provider-matchbox/matchbox",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/dghubble/sessions",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-ini/ini",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/gorilla/securecookie",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/errwrap",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-cleanhttp",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-getter",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-multierror",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-plugin",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-uuid",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-version",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/hcl",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/hil",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/logutils",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/terraform",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/vault/helper",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/yamux",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/jmespath/go-jmespath",
+    "licenses": [
+      {
+        "type": "The Unlicense",
+        "confidence": 0.35294117647058826
+      }
+    ]
+  },
+  {
+    "project": "github.com/kardianos/osext",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/keybase/go-crypto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/mitchellh/copystructure",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mitchellh/go-homedir",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mitchellh/hashstructure",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mitchellh/mapstructure",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/mitchellh/reflectwalk",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/satori/go.uuid",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/shirou/gopsutil",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.921875
+      }
+    ]
+  },
+  {
+    "project": "github.com/toqueteos/webbrowser",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/crypto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/grpc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.979253112033195
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic/stats-extender/pkg/extender",
+    "error": "cannot find package \"github.com/coreos-inc/tectonic/stats-extender/pkg/extender\" in any of:\n\t/usr/local/go/src/github.com/coreos-inc/tectonic/stats-extender/pkg/extender (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/tectonic/stats-extender/pkg/extender (from $GOPATH)"
+  },
+  {
+    "project": "github.com/coreos-inc/tectonic/stats-extender/pkg/version",
+    "error": "cannot find package \"github.com/coreos-inc/tectonic/stats-extender/pkg/version\" in any of:\n\t/usr/local/go/src/github.com/coreos-inc/tectonic/stats-extender/pkg/version (from $GOROOT)\n\t/tmp/tmp.lTTrrzPv8D/tmp_gopath/src/github.com/coreos-inc/tectonic/stats-extender/pkg/version (from $GOPATH)"
+  },
+  {
+    "project": "github.com/Azure/azure-sdk-for-go/arm",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/Azure/go-autorest/autorest",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/Sirupsen/logrus",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/asaskevich/govalidator",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/aws/aws-sdk-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/beorn7/perks/quantile",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/dgrijalva/jwt-go",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-ini/ini",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8914728682170543
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/protobuf/proto",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.92
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/snappy",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/consul/api",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/go-cleanhttp",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/hashicorp/serf/coordinate",
+    "licenses": [
+      {
+        "type": "Mozilla Public License 2.0",
+        "confidence": 0.9971724787935909
+      }
+    ]
+  },
+  {
+    "project": "github.com/jmespath/go-jmespath",
+    "licenses": [
+      {
+        "type": "The Unlicense",
+        "confidence": 0.35294117647058826
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/julienschmidt/httprouter",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9527896995708155
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/miekg/dns",
+    "licenses": [
+      {
+        "type": "BSD 3-clause Clear License",
+        "confidence": 0.1476510067114094
+      },
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9311740890688259
+      }
+    ]
+  },
+  {
+    "project": "github.com/opentracing-contrib/go-stdlib/nethttp",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9875518672199171
+      }
+    ]
+  },
+  {
+    "project": "github.com/opentracing/opentracing-go",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_golang/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/client_model/go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/common",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/procfs",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/prometheus/prometheus",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/samuel/go-zookeeper/zk",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/syndtr/goleveldb/leveldb",
+    "licenses": [
+      {
+        "type": "BSD 2-clause \"Simplified\" License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/sys/unix",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/time/rate",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/api",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/api/googleapi/internal/uritemplates",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/cloud",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/fsnotify.v1",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apimachinery",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/purell",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9916666666666667
+      }
+    ]
+  },
+  {
+    "project": "github.com/PuerkitoBio/urlesc",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/aws/aws-sdk-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/etcd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/flannel",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-iptables/iptables",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/go-systemd",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/coreos/pkg",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/davecgh/go-spew/spew",
+    "licenses": [
+      {
+        "type": "ISC License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/denverdino/aliyungo",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9657534246575342
+      }
+    ]
+  },
+  {
+    "project": "github.com/docker/distribution",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/emicklei/go-restful",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/ghodss/yaml",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.8357142857142857
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-ini/ini",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonpointer",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/jsonreference",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/spec",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      },
+      {
+        "type": "The Unlicense",
+        "confidence": 0.3422459893048128
+      }
+    ]
+  },
+  {
+    "project": "github.com/go-openapi/swag",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/gogo/protobuf",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9090909090909091
+      }
+    ]
+  },
+  {
+    "project": "github.com/golang/glog",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9966703662597114
+      }
+    ]
+  },
+  {
+    "project": "github.com/google/gofuzz",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/jmespath/go-jmespath",
+    "licenses": [
+      {
+        "type": "The Unlicense",
+        "confidence": 0.35294117647058826
+      }
+    ]
+  },
+  {
+    "project": "github.com/jonboulle/clockwork",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "github.com/juju/ratelimit",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9409937888198758
+      }
+    ]
+  },
+  {
+    "project": "github.com/mailru/easyjson",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "github.com/spf13/pflag",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "github.com/ugorji/go/codec",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9946524064171123
+      }
+    ]
+  },
+  {
+    "project": "github.com/vishvananda/netlink",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "github.com/vishvananda/netns",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9680365296803652
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/net",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/oauth2",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "golang.org/x/text",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/api",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9663865546218487
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/api/googleapi/internal/uritemplates",
+    "licenses": [
+      {
+        "type": "MIT License",
+        "confidence": 0.9891304347826086
+      }
+    ]
+  },
+  {
+    "project": "google.golang.org/cloud",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 0.9988925802879292
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/inf.v0",
+    "licenses": [
+      {
+        "type": "BSD 3-clause \"New\" or \"Revised\" License",
+        "confidence": 0.9752066115702479
+      }
+    ]
+  },
+  {
+    "project": "gopkg.in/yaml.v2",
+    "licenses": [
+      {
+        "type": "GNU Lesser General Public License v3.0",
+        "confidence": 0.9528301886792453
+      },
+      {
+        "type": "MIT License",
+        "confidence": 0.8975609756097561
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/apimachinery",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  },
+  {
+    "project": "k8s.io/client-go",
+    "licenses": [
+      {
+        "type": "Apache License 2.0",
+        "confidence": 1
+      }
+    ]
+  }
+]

--- a/installer/scripts/license-gen/pkg_lists/go_pkg_inputs.txt
+++ b/installer/scripts/license-gen/pkg_lists/go_pkg_inputs.txt
@@ -1,0 +1,32 @@
+# OS/Platform Team
+git@github.com:coreos-inc/container-linux-update-operator.git
+git@github.com:coreos/matchbox.git
+# Kube Lifecycle Team
+git@github.com:kubernetes-incubator/bootkube.git
+git@github.com:coreos-inc/operator-client.git
+git@github.com:coreos-inc/tectonic-channel-operator.git
+git@github.com:coreos-inc/kube-version-operator.git
+git@github.com:coreos/kubernetes.git
+# Tectonic Team
+git@github.com:coreos/tectonic-installer.git
+git@github.com:coreos-inc/bridge.git
+git@github.com:coreos-inc/spartakus.git
+git@github.com:coreos/dex.git
+# etcd Team
+git@github.com:coreos-inc/tectonic-etcd-operator.git
+git@github.com:coreos/etcd-operator.git
+git@github.com:coreos/kenc.git
+# Monitoring Team
+git@github.com:coreos/prometheus-operator.git
+git@github.com:coreos-inc/tectonic-prometheus-operator.git
+git@github.com:prometheus/prometheus.git
+# No main.go file: git@github.com:prometheus/node_exporter.git
+git@github.com:prometheus/alertmanager.git
+# Kubernetes + Addons
+git@github.com:kubernetes/kubernetes.git
+# No main.go file: git@github.com:kubernetes/heapster.git
+git@github.com:kubernetes/contrib.git
+git@github.com:kubernetes/ingress.git
+git@github.com:kubernetes/dns.git
+# Other
+git@github.com:coreos/flannel.git

--- a/installer/scripts/license-gen/pkg_lists/js_pkg_inputs.txt
+++ b/installer/scripts/license-gen/pkg_lists/js_pkg_inputs.txt
@@ -1,0 +1,3 @@
+# Tectonic frontend
+github.com/coreos/tectonic-installer/installer/frontend
+github.com/coreos-inc/bridge/frontend


### PR DESCRIPTION
**PR details**: `collect_project_licenses.sh` downloads all dependencies of projects [listed](https://docs.google.com/spreadsheets/d/1gJIAHgEB8Av1gFNWznsx0nI_GHAEoN4gsiOc1NskJNc/edit#gid=0) which have 'Needs license info' == 'yes', finds their license info, and aggregates JSON output into a single list in a file. Go dependency licenses collected using [license-bill-of-materials](https://github.com/coreos/license-bill-of-materials); JS dependency license info collected using `package.json` files post-installation.

**Tests**: I tested the script locally. Will run in any environment that has Go, `yarn`, `jq`, and the `license-bill-of-materials` binary installed.
**Sample output**:
```
[
  {
    "project": "github.com/docker/distribution",
    "licenses": [
      {
        "type": "Apache License 2.0",
        "confidence": 1
      }
    ]
  },
  {
    "project": "github.com/docker/spdystream",
    "licenses": [
      {
        "type": "Apache License 2.0",
        "confidence": 0.9680365296803652
      },
      {
        "type": "Open Software License 3.0",
        "confidence": 0.4606413994169096
      }
    ]
  },
  ...
]
```