### PR TITLE
server: Calculate tectonic_kube_etcd_service_ip from service CIDR.

### DIFF
--- a/installer/server/defaults/defaults.go
+++ b/installer/server/defaults/defaults.go
@@ -13,6 +13,7 @@ const (
 	ServiceCIDR = "10.3.0.0/24"
 	apiOffset   = 1
 	dnsOffset   = 10
+	etcdOffset  = 15
 )
 
 // APIServiceIP picks a default IP from the given service CIDR range.
@@ -23,6 +24,11 @@ func APIServiceIP(serviceCIDR string) (net.IP, error) {
 // DNSServiceIP picks a default IP from the given service CIDR range.
 func DNSServiceIP(serviceCIDR string) (net.IP, error) {
 	return offsetServiceIP(serviceCIDR, dnsOffset)
+}
+
+// EtcdServiceIP picks a default IP from the given service CIDR range.
+func EtcdServiceIP(serviceCIDR string) (net.IP, error) {
+	return offsetServiceIP(serviceCIDR, etcdOffset)
 }
 
 func offsetServiceIP(serviceCIDR string, offset int) (net.IP, error) {

--- a/installer/server/terraform.go
+++ b/installer/server/terraform.go
@@ -390,6 +390,14 @@ func newExecutorFromApplyHandlerInput(input *TerraformApplyHandlerInput) (*terra
 		}
 	}
 
+	ip, ok = input.Variables["tectonic_kube_etcd_service_ip"].(string)
+	if !ok || len(ip) == 0 {
+		input.Variables["tectonic_kube_etcd_service_ip"], err = defaults.EtcdServiceIP(serviceCidr)
+		if err != nil {
+			return nil, ctxh.NewAppError(err, fmt.Sprintf("Error calculating etcd service IP: %v", err.Error()), http.StatusInternalServerError)
+		}
+	}
+
 	if len(input.AdminPassword) > 0 {
 		passwordHash, err := bcrypt.GenerateFromPassword(input.AdminPassword, bcryptCost)
 		if err != nil {


### PR DESCRIPTION
Fixes #535.