### PR TITLE
Clean workspace after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,4 +105,9 @@ pipeline {
       }
     }
   }
+  post {
+    always {
+      deleteDir()
+    }
+  }
 }


### PR DESCRIPTION
Jenkins executors were filling up with files in build workspaces causing jobs to fail. This cleans the workspace after each execution regardless of success or failure.

Since don't currently perform any caching this should not affect build time.