### PR TITLE
Always destroy clusters after smoke

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,17 +99,29 @@ pipeline {
   }
   post {
     always {
-      // Destroy all clusters within workspace
       checkout scm
-      unstash 'installer'
-      sh '''
-        for c in ${WORKSPACE}/build/*; do
-          export CLUSTER=$(basename ${c})
-          echo "Destroying ${CLUSTER}..."
-          make destroy || true
-        done
-      '''
 
+      withCredentials([file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_pull_secret_path'),
+                       file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_license_path'),
+                       [
+                         $class: 'UsernamePasswordMultiBinding',
+                         credentialsId: 'tectonic-aws',
+                         usernameVariable: 'AWS_ACCESS_KEY_ID',
+                         passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+                       ]
+                       ]) {
+        // Destroy all clusters within workspace
+        unstash 'installer'
+        sh '''
+          for c in ${WORKSPACE}/build/*; do
+            export CLUSTER=$(basename ${c})
+            export TF_VAR_tectonic_cluster_name=$(echo ${CLUSTER} | awk '{print tolower($0)}')
+
+            echo "Destroying ${CLUSTER}..."
+            make destroy || true
+          done
+        '''
+      }
       // Cleanup workspace
       deleteDir()
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,8 +101,10 @@ pipeline {
     always {
       // Destroy all clusters within workspace
       checkout scm
+      unstash 'installer'
       sh '''
-        for CLUSTER in ${WORKSPACE}/build; do
+        for c in ${WORKSPACE}/build/*; do
+          export CLUSTER=$(basename ${c})
           echo "Destroying ${CLUSTER}..."
           make destroy || true
         done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,14 +79,6 @@ pipeline {
             ln -sf ${WORKSPACE}/test/aws.tfvars ${WORKSPACE}/build/${CLUSTER}/terraform.tfvars
 
             make plan
-
-            # always cleanup cluster
-            shutdown()
-            {
-              make destroy
-            }
-            trap shutdown EXIT
-
             make apply
 
             # TODO: replace in Go
@@ -107,6 +99,16 @@ pipeline {
   }
   post {
     always {
+      // Destroy all clusters within workspace
+      checkout scm
+      sh '''
+        for CLUSTER in ${WORKSPACE}/build; do
+          echo "Destroying ${CLUSTER}..."
+          make destroy || true
+        done
+      '''
+
+      // Cleanup workspace
       deleteDir()
     }
   }


### PR DESCRIPTION
Moved the cluster destruction invocation the `post` section of the Jenkinsfile which ensures that cluster cleanup regardless of build status.