### PR TITLE
Documentation: fix INSTALLER_PATH for release

### DIFF
--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -29,7 +29,7 @@ tar xzvf tectonic-1.6.2-tectonic.1.tar.gz # extract the tarball
 Initialize the Terraform configuration with Installer's location and export the path to that configuration:
 
 ```bash
-$ INSTALLER_PATH=$(pwd)/installer/bin/linux/installer # Edit the platform name.
+$ INSTALLER_PATH=$(pwd)/tectonic-installer/linux/installer # Edit the platform name.
 $ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
 $ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
 ```

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -30,7 +30,7 @@ $ (cd installer && make build)
 Initialize the TerraForm configuration with Installer's location and export the path to that configuration:
 
 ```
-$ INSTALLER_PATH=$(pwd)/installer/bin/linux/installer # Edit the platform name.
+$ INSTALLER_PATH=$(pwd)/tectonic-installer/linux/installer # Edit the platform name.
 $ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
 $ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
 ```

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -33,7 +33,7 @@ $ (cd installer && make build)
 Initialize the Terraform configuration with Installer's location and export the path to that configuration:
 
 ```
-$ INSTALLER_PATH=$(pwd)/installer/bin/linux/installer # Edit the platform name.
+$ INSTALLER_PATH=$(pwd)/tectonic-installer/linux/installer # Edit the platform name.
 $ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
 $ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
 ```

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -34,7 +34,7 @@ $ (cd installer && make build)
 Initialize the TerraForm configuration with Installer's location and export the path to that configuration:
 
 ```
-$ INSTALLER_PATH=$(pwd)/installer/bin/linux/installer # Edit the platform name.
+$ INSTALLER_PATH=$(pwd)/tectonic-installer/linux/installer # Edit the platform name.
 $ sed "s|<PATH_TO_INSTALLER>|$INSTALLER_PATH|g" terraformrc.example > .terraformrc
 $ export TERRAFORM_CONFIG=$(pwd)/.terraformrc
 ```


### PR DESCRIPTION
We changed to using a release tarball rather than the compiled version. But forgot to change the path to the installer - which is different in that case.