### PR TITLE
Documentation/install/bare-metal: Document ssh-agent requirement

### DIFF
--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -14,6 +14,7 @@ Following this guide will deploy a Tectonic cluster on virtual or physical hardw
 * Machines with known MAC addresses and stable domain names.
 * Tectonic Account - Register for a [Tectonic Account][register], which is free for up to 10 nodes. You will need to provide the cluster license and pull secret below.
 * `ipmitool` or `virt-install` will be used to actually boot the machines.
+* A SSH keypair whose private key is present in your system's ssh-agent.
 
 ## Getting Started
 


### PR DESCRIPTION
If the key is not in the ssh-agent, Terraform won't be able to SSH into the nodes and proceed. This is quite difficult to diagnose because there is no log whatsoever if the DEBUG logs were not enabled. At least, have this mentioned in the documentation once..