### PR TITLE
Remove invalid AWS arguments

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -44,8 +44,6 @@ resource "aws_autoscaling_group" "masters" {
     propagate_at_launch = true
   }
 
-  tags = ["${var.autoscaling_group_extra_tags}"]
-
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -67,8 +67,6 @@ resource "aws_autoscaling_group" "workers" {
     propagate_at_launch = true
   }
 
-  tags = ["${var.autoscaling_group_extra_tags}"]
-
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
Remove invalid argument `tags` to `aws_autoscaling_group`, fixes #571 .