### PR TITLE
Update ELB SG port

### DIFF
--- a/modules/aws/vpc/sg-elb.tf
+++ b/modules/aws/vpc/sg-elb.tf
@@ -20,6 +20,14 @@ resource "aws_security_group" "api" {
     from_port   = 443
     to_port     = 443
   }
+
+  ingress {
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 22
+    to_port     = 22
+  }
+  
 }
 
 resource "aws_security_group" "console" {


### PR DESCRIPTION
Add port 22 to API security group to be able to SSH to master nodes. Please note the ELB already allows SSH but the security group is missing SSH rule.