### PR TITLE
ingress tls_cert_request: add subjectAltName

### DIFF
--- a/modules/tectonic/crypto.tf
+++ b/modules/tectonic/crypto.tf
@@ -26,6 +26,12 @@ resource "tls_cert_request" "ingress" {
   subject {
     common_name = "${element(split(":", var.base_address), 0)}"
   }
+
+  # subject commonName is deprecated per RFC2818 in favor of
+  # subjectAltName
+  dns_names = [
+    "${element(split(":", var.base_address), 0)}",
+  ]
 }
 
 resource "tls_locally_signed_cert" "ingress" {


### PR DESCRIPTION
if a cert doesn’t contain subjectAltNames Chrome >=58 and future
versions of Firefox will give a `NET::ERR_CERT_COMMON_NAME_INVALID`
error even if the CA is trusted and the CN matches.

currently the generated CSR only contain a subject CN.  this change
adds a matching subjectAltName to the ingress cert signing request.