### PR TITLE
bootkube: remove redundant content_hash variable

### DIFF
--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -16,7 +16,7 @@
 # combination of all the resources' IDs, it can't be guessed and can only be
 # interpolated once the assets have all been created.
 output "id" {
-  value = "${sha1("${template_dir.bootkube.id} ${local_file.kubeconfig.id} ${local_file.bootkube.id}")}"
+  value = "${sha1("${template_dir.bootkube-bootstrap.id} ${local_file.kubeconfig.id} ${local_file.bootkube.id} ${template_dir.bootkube.id} ${join(" ",local_file.etcd-operator.*.id,local_file.etcd-service.*.id,local_file.bootstrap-etcd.*.id)}")}"
 }
 
 output "kubeconfig" {
@@ -37,13 +37,4 @@ output "ca_key" {
 
 output "systemd_service" {
   value = "${data.template_file.bootkube_service.rendered}"
-}
-
-output "content_hash" {
-  value = "${sha1("${template_dir.bootkube-bootstrap.id} ${template_dir.bootkube.id} ${join(" ",local_file.etcd-operator.*.id,local_file.etcd-service.*.id,local_file.bootstrap-etcd.*.id)}")}"
-
-  description = <<EOF
-This output can be used in datasources like archive_file as part of a hashed filename on generated assets.
-This is necessary, because datasources do not have a `depends_on` directive.
-EOF
 }

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -80,5 +80,5 @@ data "archive_file" "assets" {
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
   # folder, we write it in the TerraForm managed hidden folder `.terraform`.
-  output_path = "${path.cwd}/.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.content_hash}")}.zip"
+  output_path = "${path.cwd}/.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id}")}.zip"
 }


### PR DESCRIPTION
Just recognized while testing bare metal, that module.bootkube.content_hash is redundant with module.bootkube.id.

This fixes it.

/cc @alexsomesan