### PR TITLE
modules/.../monitoring: revert label changes

### DIFF
--- a/modules/tectonic/resources/manifests/monitoring/node-exporter-ds.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/node-exporter-ds.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       name: node-exporter
       labels:
-        k8s-app: node-exporter
+        app: node-exporter
     spec:
       hostNetwork: true
       hostPID: true

--- a/modules/tectonic/resources/manifests/monitoring/node-exporter-svc.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/node-exporter-svc.yaml
@@ -4,6 +4,7 @@ metadata:
   name: node-exporter
   namespace: tectonic-system
   labels:
+    app: node-exporter
     k8s-app: node-exporter
 spec:
   type: ClusterIP
@@ -13,4 +14,4 @@ spec:
     port: 9100
     protocol: TCP
   selector:
-    k8s-app: node-exporter
+    app: node-exporter

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-k8s-apps-http.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-k8s-apps-http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: k8s-apps-http
   namespace: tectonic-system
   labels:
-    k8s-app: http
+    k8s-apps: http
 spec:
   jobLabel: k8s-app
   selector:

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kubelet.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kubelet.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubelet
   namespace: tectonic-system
   labels:
-    k8s-app: http
+    k8s-apps: http
 spec:
   jobLabel: k8s-app
   endpoints:

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
@@ -11,7 +11,7 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorSelector:
     matchExpression:
-    - {key: k8s-app, operator: Exists}
+    - {key: k8s-apps, operator: Exists}
   ruleSelector:
     matchLabels:
       role: prometheus-rulefiles

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-operator.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-operator.yaml
@@ -4,13 +4,13 @@ metadata:
   name: prometheus-operator
   namespace: tectonic-system
   labels:
-    k8s-app: prometheus-operator
+    operator: prometheus
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        k8s-app: prometheus-operator
+        operator: prometheus
     spec:
       serviceAccountName: prometheus-operator
       containers:


### PR DESCRIPTION
Revert any labels changes to the monitoring assets made in PR:  https://github.com/coreos/tectonic-installer/pull/517

Fixes: https://github.com/coreos/tectonic-installer/issues/576

@brancz @fabxc @aaronlevy 