### PR TITLE
Fix license and pull secret / reenable Pod logging test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
       steps {
         parallel (
           "TerraForm: AWS": {
-            withCredentials([file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_pull_secret_path'),
-                             file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_license_path'),
+            withCredentials([file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_pull_secret_path'),
+                             file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_license_path'),
                              [
                                $class: 'UsernamePasswordMultiBinding',
                                credentialsId: 'tectonic-aws',

--- a/installer/tests/sanity/k8s_test.go
+++ b/installer/tests/sanity/k8s_test.go
@@ -59,8 +59,8 @@ func TestCluster(t *testing.T) {
 
 	// wait for all nodes to become available
 	t.Run("AllNodesRunning", testAllNodesRunning)
-	t.Run("AllPodsRunning", testAllPodsRunning)
 	t.Run("GetLogs", testLogs)
+	t.Run("AllPodsRunning", testAllPodsRunning)
 	t.Run("KillAPIServer", testKillAPIServer)
 }
 
@@ -113,8 +113,6 @@ func testAllPodsRunning(t *testing.T) {
 }
 
 func testLogs(t *testing.T) {
-	// TODO: Diagnose why this fails.
-	t.SkipNow()
 	c := newClient(t)
 
 	namespace := "tectonic-system"


### PR DESCRIPTION
The pull secret and license had been swapped in the Jenkinsfile causing Tectonic resources to not be created since the pull secret was missing.

Also enabled Pod logging test since the cause of it's failures should be this issue.