### PR TITLE
Always invoke terraform get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,16 @@ installer-env: $(INSTALLER_BIN) terraformrc.example
 localconfig:
 	mkdir -p $(BUILD_DIR)
 
-$(BUILD_DIR)/.terraform:
+terraform-get:
 	cd $(BUILD_DIR) && $(TF_CMD) get $(TOP_DIR)/platforms/$(PLATFORM)
 
-plan: installer-env $(BUILD_DIR)/.terraform
+plan: installer-env terraform-get
 	cd $(BUILD_DIR) && $(TF_CMD) plan $(TOP_DIR)/platforms/$(PLATFORM)
 
-apply: installer-env $(BUILD_DIR)/.terraform
+apply: installer-env terraform-get
 	cd $(BUILD_DIR) && $(TF_CMD) apply $(TOP_DIR)/platforms/$(PLATFORM)
 
-destroy: installer-env ${BUILD_DIR}/.terraform
+destroy: installer-env terraform-get
 	cd $(BUILD_DIR) && $(TF_CMD) destroy -force $(TOP_DIR)/platforms/$(PLATFORM)
 
 payload:
@@ -113,4 +113,4 @@ structure-check:
 canonical-syntax:
 	terraform fmt -list .
 
-.PHONY: make clean terraform terraform-dev structure-check canonical-syntax docs examples
+.PHONY: make clean terraform terraform-dev structure-check canonical-syntax docs examples terraform-get


### PR DESCRIPTION
Always invoke [terraform get](https://www.terraform.io/docs/commands/get.html) in order to ensure that necessary modules are installed, to avoid build errors, rather than relying on whether the .terraform directory exists, since it might be stale.

See #571 for reference.