### PR TITLE
tectonic-installer/config.tf: Add a link to the doc describing how to generate bcyp-encoded hash of a password

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -196,7 +196,7 @@ variable "tectonic_admin_email" {
 
 variable "tectonic_admin_password_hash" {
   type        = "string"
-  description = "bcrypt hash of admin password to use with Tectonic Console"
+  description = "bcrypt hash of admin password to use with Tectonic Console. Generate a bcrypt hash of the password by using the tool given at https://github.com/coreos/bcrypt-tool."
 }
 
 variable "tectonic_ca_cert" {


### PR DESCRIPTION
ref: https://github.com/coreos-inc/tectonic-issues/issues/245