### PR TITLE
Export CLUSTER variable from Makefile as Terraform variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TF_DOCS := $(shell which terraform-docs 2> /dev/null)
 TF_EXAMPLES := $(shell which terraform-examples 2> /dev/null)
 TF_RC := $(TOP_DIR)/.terraformrc
 TF_CMD = TERRAFORM_CONFIG=$(TF_RC) terraform
+export TF_VAR_tectonic_cluster_name = $(CLUSTER)
 
 $(info Using build directory [${BUILD_DIR}])
 


### PR DESCRIPTION
The `tectonic_cluster_name` Terraform variable currently has to be defined by the user, but there is a corresponding Makefile variable `CLUSTER` (with a default of `demo`). I figure it might make sense to link the two variables, so that Make configures Terraform's `tectonic_cluster_name` variable via `CLUSTER`.

I'm not 100% sure if it's a good idea to make the two variables correspond to each other, but it seems reasonable enough to me at least, to not have to configure them separately from each other. Creating this PR as a proposal to introduce this behaviour, looking forward to hearing your thoughts on it.