### PR TITLE
modules/azure: refactor FQDN conditionals and their usage

### DIFF
--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -50,7 +50,7 @@ tectonic_azure_master_vm_size = "Standard_DS2_v2"
 tectonic_azure_ssh_key = ""
 
 // If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure.
-tectonic_azure_use_custom_fqdn = "true"
+tectonic_azure_use_custom_fqdn = true
 
 // Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute.
 tectonic_azure_vnet_cidr_block = "10.0.0.0/16"

--- a/modules/azure/dns/etcd.tf
+++ b/modules/azure/dns/etcd.tf
@@ -6,5 +6,5 @@ resource "azurerm_dns_a_record" "etcd" {
   ttl     = "60"
   records = ["${var.etcd_ip_addresses}"]
 
-  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn ? 1 : 0}"
 }

--- a/modules/azure/dns/main.tf
+++ b/modules/azure/dns/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_dns_zone" "tectonic_azure_dns_zone" {
   name                = "${var.base_domain}"
   resource_group_name = "${var.resource_group_name}"
-  count               = "${var.use_custom_fqdn == "true" ? 1 : 0}"
+  count               = "${var.use_custom_fqdn ? 1 : 0}"
 }

--- a/modules/azure/dns/master.tf
+++ b/modules/azure/dns/master.tf
@@ -6,7 +6,7 @@ resource "azurerm_dns_a_record" "tectonic-api" {
   ttl     = "60"
   records = ["${var.master_ip_addresses}"]
 
-  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "tectonic-console" {
@@ -17,7 +17,7 @@ resource "azurerm_dns_a_record" "tectonic-console" {
   ttl     = "60"
   records = ["${var.console_ip_address}"]
 
-  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "master_nodes" {
@@ -28,5 +28,5 @@ resource "azurerm_dns_a_record" "master_nodes" {
   ttl     = "59"
   records = ["${var.master_ip_addresses}"]
 
-  count = "${var.use_custom_fqdn == "true" ? 1 : 0}"
+  count = "${var.use_custom_fqdn ? 1 : 0}"
 }

--- a/modules/azure/dns/variables.tf
+++ b/modules/azure/dns/variables.tf
@@ -31,6 +31,5 @@ variable "etcd_ip_addresses" {
 }
 
 variable "use_custom_fqdn" {
-  type    = "string"
-  default = "false"
+  default = true
 }

--- a/modules/azure/master/output.tf
+++ b/modules/azure/master/output.tf
@@ -7,17 +7,17 @@ output "console_ip_address" {
 }
 
 output "ingress_external_fqdn" {
-  value = "${azurerm_public_ip.tectonic_console_ip.domain_name_label}.${var.base_domain}"
+  value = "${var.use_custom_fqdn ? "${azurerm_public_ip.tectonic_console_ip.domain_name_label}.${var.base_domain}" : azurerm_public_ip.tectonic_console_ip.fqdn}"
 }
 
 output "ingress_internal_fqdn" {
-  value = "${azurerm_public_ip.tectonic_console_ip.domain_name_label}.${var.base_domain}"
+  value = "${var.use_custom_fqdn ? "${azurerm_public_ip.tectonic_console_ip.domain_name_label}.${var.base_domain}" : azurerm_public_ip.tectonic_console_ip.fqdn}"
 }
 
 output "api_external_fqdn" {
-  value = "${azurerm_public_ip.tectonic_api_ip.domain_name_label}.${var.base_domain}"
+  value = "${var.use_custom_fqdn ?  "${azurerm_public_ip.tectonic_api_ip.domain_name_label}.${var.base_domain}" : azurerm_public_ip.tectonic_api_ip.fqdn}"
 }
 
 output "api_internal_fqdn" {
-  value = "${azurerm_public_ip.tectonic_api_ip.domain_name_label}.${var.base_domain}"
+  value = "${var.use_custom_fqdn ?  "${azurerm_public_ip.tectonic_api_ip.domain_name_label}.${var.base_domain}" : azurerm_public_ip.tectonic_api_ip.fqdn}"
 }

--- a/modules/azure/master/variables.tf
+++ b/modules/azure/master/variables.tf
@@ -88,3 +88,7 @@ variable "tectonic_service_disabled" {
   description = "Specifies whether the tectonic installer systemd unit will be disabled. If true, no tectonic assets will be deployed"
   default     = false
 }
+
+variable "use_custom_fqdn" {
+  default = true
+}

--- a/platforms/azure/dns-todo/worker.tf
+++ b/platforms/azure/dns-todo/worker.tf
@@ -6,5 +6,5 @@ resource "azurerm_dns_a_record" "worker_nodes" {
   name    = "${var.tectonic_cluster_name}-worker-${count.index}"
   ttl     = "59"
   records = ["${azurerm_public_ip.worker_node.ip_address[count.index]}"]
-  count   = "${var.use_custom_fqdn == "true" ? 1 : 0}"
+  count   = "${var.use_custom_fqdn ? 1 : 0}"
 }

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -58,6 +58,8 @@ module "masters" {
   bootkube_service             = "${module.bootkube.systemd_service}"
   tectonic_service             = "${module.tectonic.systemd_service}"
   tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
+
+  use_custom_fqdn = "${var.tectonic_azure_use_custom_fqdn}"
 }
 
 module "workers" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -2,8 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = ""
 
-  kube_apiserver_url = "${var.tectonic_azure_use_custom_fqdn == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
-  oidc_issuer_url    = "${var.tectonic_azure_use_custom_fqdn == "true" ? "https://${var.tectonic_cluster_name}.${var.tectonic_base_domain}/identity" : "https://${module.masters.ingress_internal_fqdn}/identity"}"
+  kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"
+  oidc_issuer_url    = "https://${module.masters.ingress_internal_fqdn}/identity"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -36,10 +36,8 @@ module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "azure"
 
-  master_count = "${var.tectonic_master_count}"
-
-  base_address       = "${var.tectonic_azure_use_custom_fqdn == "true" ? "${var.tectonic_cluster_name}.${var.tectonic_base_domain}" : module.masters.ingress_internal_fqdn}"
-  kube_apiserver_url = "${var.tectonic_azure_use_custom_fqdn == "true" ? "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443" : "https://${module.masters.api_internal_fqdn}:443"}"
+  base_address       = "${module.masters.ingress_internal_fqdn}"
+  kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -71,11 +69,11 @@ resource "null_resource" "tectonic" {
   depends_on = ["module.tectonic", "module.masters"]
 
   triggers {
-    api-endpoint = "${var.tectonic_azure_use_custom_fqdn == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
+    api-endpoint = "${module.masters.api_external_fqdn}"
   }
 
   connection {
-    host  = "${var.tectonic_azure_use_custom_fqdn == "true" ? "${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}" : module.masters.api_external_fqdn}"
+    host  = "${module.masters.api_external_fqdn}"
     user  = "core"
     agent = true
   }

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -84,7 +84,7 @@ variable "tectonic_azure_external_vnet_name" {
 
 variable "tectonic_azure_use_custom_fqdn" {
   description = "If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure."
-  default     = "true"
+  default     = true
 }
 
 variable "tectonic_azure_external_master_subnet_id" {


### PR DESCRIPTION
This PR:
- cleans up the conditional construction of the FQDN's to only occur in the module outputs.
- ensures that the outputs won't use the `base_domain` if `use_custom_fqdn` is not requested, and instead rely on the FQDN Azure sets up.
- removes duplicate `master_count = "${var.tectonic_master_count}"` introduced in https://github.com/coreos/tectonic-installer/pull/557