### PR TITLE
Tolerate API errors while waiting for Pods to be ready

### DIFF
--- a/installer/tests/sanity/k8s_test.go
+++ b/installer/tests/sanity/k8s_test.go
@@ -94,7 +94,8 @@ func testAllPodsRunning(t *testing.T) {
 
 		pods, err := c.Core().Pods("").List(v1.ListOptions{})
 		if err != nil {
-			t.Fatalf("could not list pods: %v", err)
+			t.Logf("could not list pods: %v", err)
+			pods = &v1.PodList{}
 		}
 
 		allReady := len(pods.Items) != 0


### PR DESCRIPTION
Smoke tests have been failing because of API server errors listing Pods while waiting for them all to be ready. This seemed to happen after fixing deploying Tectonic components, since these components get deployed during the test potentially the extra load increases the number of failures. 

This change makes the Pod status check tolerant of Pod listing failure during the check. Any failures will be logged in the test.

If we see frequent API server failures logged we should determine if there is a regression. 