### PR TITLE
modules/bootkube: specify the current context

### DIFF
--- a/modules/bootkube/resources/kubeconfig
+++ b/modules/bootkube/resources/kubeconfig
@@ -11,6 +11,8 @@ users:
     client-certificate-data: ${kubelet_cert}
     client-key-data: ${kubelet_key}
 contexts:
-- context:
+- name: local
+  context:
     cluster: local
     user: kubelet
+current-context: local


### PR DESCRIPTION
It's helpful to name the context and specify the current-context for
tooling that keys off of the current-context in a kubeconfig.

In my case I have a PS1 that inspects the current-context to let me
know what Kubernetes cluster I'm working with at the moment.
https://gist.github.com/everett-toews/e5a51e54ec7355a2d6716bfbf6c08fe2