### PR TITLE
metal: implement tectonic_vanilla_k8s

### DIFF
--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -96,6 +96,7 @@ systemd:
         ExecStartPost=/bin/touch /opt/tectonic/init_bootkube.done
         [Install]
         WantedBy=multi-user.target
+{{ if eq .exclude_tectonic "0" }}
     - name: tectonic.service
       contents: |
         [Unit]
@@ -113,6 +114,7 @@ systemd:
         ExecStartPost=/bin/touch /opt/tectonic/init_tectonic.done
         [Install]
         WantedBy=multi-user.target
+{{end}}
 storage:
   files:
     - path: /etc/kubernetes/kubelet.env

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -36,6 +36,7 @@ resource "matchbox_group" "controller" {
     etcd_initial_cluster = "${join(",", formatlist("%s=http://%s:2380", var.tectonic_metal_controller_names, var.tectonic_metal_controller_domains))}"
     k8s_dns_service_ip   = "${var.tectonic_kube_dns_service_ip}"
     ssh_authorized_key   = "${var.tectonic_ssh_authorized_key}"
+    exclude_tectonic     = "${var.tectonic_vanilla_k8s}"
 
     # extra data
     etcd_image_tag    = "v${var.tectonic_versions["etcd"]}"

--- a/platforms/metal/remote.tf
+++ b/platforms/metal/remote.tf
@@ -44,7 +44,7 @@ resource "null_resource" "bootstrap" {
       "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",
       "sudo mv /home/core/tectonic /opt/",
-      "sudo systemctl start tectonic",
+      "sudo systemctl start ${var.tectonic_vanilla_k8s ? "bootkube" : "tectonic"}",
     ]
   }
 }


### PR DESCRIPTION
Setting `tectonic_vanilla_k8s` to `true` now correctly omits the tectonic systemd unit.

Follows https://github.com/coreos/tectonic-installer/pull/194