### PR TITLE
Fix idempotency for plan / apply: don't render optional manifests into template_dir outputs

### DIFF
--- a/modules/aws/ignition/resources/init-assets.sh
+++ b/modules/aws/ignition/resources/init-assets.sh
@@ -49,10 +49,6 @@ fi
 unzip -o -d /opt/tectonic/ /opt/tectonic/tectonic.zip
 rm /opt/tectonic/tectonic.zip
 
-# Move optional experimental manifests into bootkube friendly locations
-[ -d /opt/tectonic/experimental ] && mv /opt/tectonic/experimental/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/experimental
-[ -d /opt/tectonic/bootstrap-experimental ] && mv /opt/tectonic/bootstrap-experimental/* /opt/tectonic/bootstrap-manifests/ && rm -r /opt/tectonic/bootstrap-experimental
-
 # Populate the kubelet.env file.
 mkdir -p /etc/kubernetes
 echo "KUBELET_IMAGE_URL=${kubelet_image_url}" > /etc/kubernetes/kubelet.env

--- a/modules/aws/ignition/resources/init-assets.sh
+++ b/modules/aws/ignition/resources/init-assets.sh
@@ -49,6 +49,10 @@ fi
 unzip -o -d /opt/tectonic/ /opt/tectonic/tectonic.zip
 rm /opt/tectonic/tectonic.zip
 
+# Move optional experimental manifests into bootkube friendly locations
+[ -d /opt/tectonic/experimental ] && mv /opt/tectonic/experimental/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/experimental
+[ -d /opt/tectonic/bootstrap-experimental ] && mv /opt/tectonic/bootstrap-experimental/* /opt/tectonic/bootstrap-manifests/ && rm -r /opt/tectonic/bootstrap-experimental
+
 # Populate the kubelet.env file.
 mkdir -p /etc/kubernetes
 echo "KUBELET_IMAGE_URL=${kubelet_image_url}" > /etc/kubernetes/kubelet.env

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -102,7 +102,7 @@ resource "local_file" "etcd-operator" {
   depends_on = ["template_dir.bootkube"]
 
   content  = "${data.template_file.etcd-operator.rendered}"
-  filename = "${path.cwd}/generated/manifests/etcd-operator.yaml"
+  filename = "${path.cwd}/generated/experimental/etcd-operator.yaml"
 }
 
 data "template_file" "etcd-service" {
@@ -118,7 +118,7 @@ resource "local_file" "etcd-service" {
   depends_on = ["template_dir.bootkube"]
 
   content  = "${data.template_file.etcd-service.rendered}"
-  filename = "${path.cwd}/generated/manifests/etcd-service.yaml"
+  filename = "${path.cwd}/generated/experimental/etcd-service.yaml"
 }
 
 data "template_file" "bootstrap-etcd" {
@@ -134,7 +134,7 @@ resource "local_file" "bootstrap-etcd" {
   depends_on = ["template_dir.bootkube-bootstrap"]
 
   content  = "${data.template_file.bootstrap-etcd.rendered}"
-  filename = "${path.cwd}/generated/bootstrap-manifests/bootstrap-etcd.yaml"
+  filename = "${path.cwd}/generated/bootstrap-experimental/bootstrap-etcd.yaml"
 }
 
 # etcd certs

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -6,6 +6,10 @@
 # be missing for now, making bootkube crash.
 mkdir -p /etc/kubernetes/manifests/
 
+# Move optional experimental manifests into bootkube friendly locations
+[ -d /opt/tectonic/experimental ] && mv /opt/tectonic/experimental/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/experimental
+[ -d /opt/tectonic/bootstrap-experimental ] && mv /opt/tectonic/bootstrap-experimental/* /opt/tectonic/bootstrap-manifests/ && rm -r /opt/tectonic/bootstrap-experimental
+
 /usr/bin/rkt run \
   --trust-keys-from-https \
   --volume assets,kind=host,source=$(pwd) \


### PR DESCRIPTION
Currently, attempting a `plan` immediately after a successfull `apply` falsely reports that changes are still necessary. A subsequent `apply` for these supposed changes leads to other changes being reported by further `plans`. A vicious circle is created.

This is caused by a previous change to support optional manifests which renders additional manifests into the output location of a `template_dir` resource. Because `template_dir` checksums the contents of this location to determine if changes are necessary, it leads to above mentioned behaviour.

This fix avoids rendering the optional manifests into the location checksummed by `template_dir`. Consequently, calling `plan` or `apply` after a successful build reports no changes necessary.

/cc: @sym3tri 