### PR TITLE
Documentation: Add ec2:DescribeImages to aws-policy.json

### DIFF
--- a/Documentation/files/aws-policy.json
+++ b/Documentation/files/aws-policy.json
@@ -52,6 +52,7 @@
         "ec2:CreateVolume",
         "ec2:DescribeAddresses",
         "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeKeyPairs",


### PR DESCRIPTION
Terraform needs ec2:DescribeImages access in order to look up AMI information at runtime.