### PR TITLE
frontend: Move terraform-related buttons & errors next to terraform step

### DIFF
--- a/installer/frontend/components/alert.jsx
+++ b/installer/frontend/components/alert.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const Alert = props => <div className={`alert alert-${props.severity || 'info'}`}
-  style={{padding: 10, paddingBottom: 7, marginBottom: 10, marginTop: 10}}>
+  style={{padding: 15, marginBottom: 10, marginTop: 10}}>
   { !props.noIcon && <span><i className="fa fa-fw fa-exclamation-triangle"></i>&nbsp;</span> }
   {props.children}
 </div>;


### PR DESCRIPTION
Less confusing:

![screen shot 2017-05-09 at 14 48 03](https://cloud.githubusercontent.com/assets/200121/25874311/cfc95212-34c6-11e7-8510-3b629a6aac52.png)
