### PR TITLE
metal: add tectonic_ssh_private_key variable

### DIFF
--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -208,6 +208,10 @@ tectonic_ssh_authorized_key = ""
 // The Tectonic statistics collection URL to which to report.
 tectonic_stats_url = "https://stats-collector.tectonic.com"
 
+// (optional) SSH private key file corresponding to tectonic_ssh_authorized_key. If not provided, SSH agent will be used.
+// Example: `/root/.ssh/id_rsa`
+// tectonic_ssh_private_key_path = ""
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/platforms/metal/remote.tf
+++ b/platforms/metal/remote.tf
@@ -2,10 +2,11 @@ resource "null_resource" "etcd_secrets" {
   count = "${var.tectonic_etcd_tls_enabled ? length(var.tectonic_metal_controller_domains) : 0}"
 
   connection {
-    type    = "ssh"
-    host    = "${element(var.tectonic_metal_controller_domains, count.index)}"
-    user    = "core"
-    timeout = "60m"
+    type        = "ssh"
+    host        = "${element(var.tectonic_metal_controller_domains, count.index)}"
+    user        = "core"
+    timeout     = "60m"
+    private_key = "${file(var.tectonic_ssh_private_key_path != "" ? pathexpand(var.tectonic_ssh_private_key_path) : "/dev/null")}"
   }
 
   provisioner "file" {
@@ -52,10 +53,11 @@ resource "null_resource" "kubeconfig" {
   depends_on = ["null_resource.etcd_secrets"]
 
   connection {
-    type    = "ssh"
-    host    = "${element(concat(var.tectonic_metal_controller_domains, var.tectonic_metal_worker_domains), count.index)}"
-    user    = "core"
-    timeout = "60m"
+    type        = "ssh"
+    host        = "${element(concat(var.tectonic_metal_controller_domains, var.tectonic_metal_worker_domains), count.index)}"
+    user        = "core"
+    timeout     = "60m"
+    private_key = "${file(var.tectonic_ssh_private_key_path != "" ? pathexpand(var.tectonic_ssh_private_key_path) : "/dev/null")}"
   }
 
   provisioner "file" {
@@ -78,10 +80,11 @@ resource "null_resource" "bootstrap" {
   depends_on = ["null_resource.kubeconfig"]
 
   connection {
-    type    = "ssh"
-    host    = "${element(var.tectonic_metal_controller_domains, 0)}"
-    user    = "core"
-    timeout = "60m"
+    type        = "ssh"
+    host        = "${element(var.tectonic_metal_controller_domains, 0)}"
+    user        = "core"
+    timeout     = "60m"
+    private_key = "${file(var.tectonic_ssh_private_key_path != "" ? pathexpand(var.tectonic_ssh_private_key_path) : "/dev/null")}"
   }
 
   provisioner "file" {

--- a/platforms/metal/variables.tf
+++ b/platforms/metal/variables.tf
@@ -185,3 +185,9 @@ SSH public key to use as an authorized key.
 Example: `ssh-rsa AAAB3N...`
 EOF
 }
+
+variable "tectonic_ssh_private_key_path" {
+  type        = "string"
+  description = "SSH private key file corresponding to tectonic_ssh_authorized_key. If not provided, SSH agent will be used."
+  default     = ""
+}


### PR DESCRIPTION
Allow users to specify the SSH private key via a variable in cases where
ssh-agent isn't available or configured.