### PR TITLE
platforms/aws: Support additional security groups

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -10,6 +10,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_az_count | Number of Availability Zones your EC2 instances will be deployed across. This should be less than or equal to the total number available in the region.  Be aware that some regions only have 2. If set worker and master subnet CIDRs are calculated automatically.<br><br>Note: This field MUST be set manually prior to creating the cluster. It MUST NOT be set if availability zones CIDRs are configured using `tectonic_aws_master_custom_subnets` and `tectonic_aws_worker_custom_subnets`. | string | `` |
 | tectonic_aws_config_version | (internal) This declares the version of the AWS configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
 | tectonic_aws_etcd_ec2_type | Instance size for the etcd node(s). Example: `t2.medium`. | string | `t2.medium` |
+| tectonic_aws_etcd_extra_sg_ids | (optional) List of additional security group IDs for etcd nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_aws_etcd_root_volume_iops | The amount of provisioned IOPS for the root block device of etcd nodes. | string | `100` |
 | tectonic_aws_etcd_root_volume_size | The size of the volume in gigabytes for the root block device of etcd nodes. | string | `30` |
 | tectonic_aws_etcd_root_volume_type | The type of volume for the root block device of etcd nodes. | string | `gp2` |
@@ -20,6 +21,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_extra_tags | (optional) Extra AWS tags to be applied to created resources. | map | `<map>` |
 | tectonic_aws_master_custom_subnets | (optional) This configures master availability zones and their corresponding subnet CIDRs directly.<br><br>Example: `{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }`<br><br>Note that `tectonic_aws_az_count` must be unset if this is specified. | map | `<map>` |
 | tectonic_aws_master_ec2_type | Instance size for the master node(s). Example: `t2.medium`. | string | `t2.medium` |
+| tectonic_aws_master_extra_sg_ids | (optional) List of additional security group IDs for master nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_aws_master_root_volume_iops | The amount of provisioned IOPS for the root block device of master nodes. | string | `100` |
 | tectonic_aws_master_root_volume_size | The size of the volume in gigabytes for the root block device of master nodes. | string | `30` |
 | tectonic_aws_master_root_volume_type | The type of volume for the root block device of master nodes. | string | `gp2` |
@@ -28,6 +30,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_vpc_cidr_block | Block of IP addresses used by the VPC. This should not overlap with any other networks, such as a private datacenter connected via Direct Connect. | string | `10.0.0.0/16` |
 | tectonic_aws_worker_custom_subnets | (optional) This configures worker availability zones and their corresponding subnet CIDRs directly.<br><br>Example: `{ eu-west-1a = "10.0.64.0/20", eu-west-1b = "10.0.80.0/20" }`<br><br>Note that `tectonic_aws_az_count` must be unset if this is specified. | map | `<map>` |
 | tectonic_aws_worker_ec2_type | Instance size for the worker node(s). Example: `t2.medium`. | string | `t2.medium` |
+| tectonic_aws_worker_extra_sg_ids | (optional) List of additional security group IDs for worker nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_aws_worker_root_volume_iops | The amount of provisioned IOPS for the root block device of worker nodes. | string | `100` |
 | tectonic_aws_worker_root_volume_size | The size of the volume in gigabytes for the root block device of worker nodes. | string | `30` |
 | tectonic_aws_worker_root_volume_type | The type of volume for the root block device of worker nodes. | string | `gp2` |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -29,6 +29,11 @@ tectonic_aws_az_count = ""
 // Instance size for the etcd node(s). Example: `t2.medium`.
 tectonic_aws_etcd_ec2_type = "t2.medium"
 
+// (optional) List of additional security group IDs for etcd nodes.
+// 
+// Example: `["sg-51530134", "sg-b253d7cc"]`
+// tectonic_aws_etcd_extra_sg_ids = ""
+
 // The amount of provisioned IOPS for the root block device of etcd nodes.
 tectonic_aws_etcd_root_volume_iops = "100"
 
@@ -74,6 +79,11 @@ tectonic_aws_external_vpc_public = true
 // Instance size for the master node(s). Example: `t2.medium`.
 tectonic_aws_master_ec2_type = "t2.medium"
 
+// (optional) List of additional security group IDs for master nodes.
+// 
+// Example: `["sg-51530134", "sg-b253d7cc"]`
+// tectonic_aws_master_extra_sg_ids = ""
+
 // The amount of provisioned IOPS for the root block device of master nodes.
 tectonic_aws_master_root_volume_iops = "100"
 
@@ -102,6 +112,11 @@ tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
 
 // Instance size for the worker node(s). Example: `t2.medium`.
 tectonic_aws_worker_ec2_type = "t2.medium"
+
+// (optional) List of additional security group IDs for worker nodes.
+// 
+// Example: `["sg-51530134", "sg-b253d7cc"]`
+// tectonic_aws_worker_extra_sg_ids = ""
 
 // The amount of provisioned IOPS for the root block device of worker nodes.
 tectonic_aws_worker_root_volume_iops = "100"

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -56,7 +56,7 @@ module "etcd" {
   instance_count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : var.tectonic_aws_az_count == 5 ? 5 : 3}"
   az_count       = "${length(data.aws_availability_zones.azs.names)}"
   ec2_type       = "${var.tectonic_aws_etcd_ec2_type}"
-  sg_ids         = ["${module.vpc.etcd_sg_id}"]
+  sg_ids         = "${concat(var.tectonic_aws_etcd_extra_sg_ids, list(module.vpc.etcd_sg_id))}"
 
   ssh_key         = "${var.tectonic_aws_ssh_key}"
   cl_channel      = "${var.tectonic_cl_channel}"
@@ -101,7 +101,7 @@ module "masters" {
 
   subnet_ids = ["${module.vpc.master_subnet_ids}"]
 
-  master_sg_ids  = ["${module.vpc.master_sg_id}"]
+  master_sg_ids  = "${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
   api_sg_ids     = ["${module.vpc.api_sg_id}"]
   console_sg_ids = ["${module.vpc.console_sg_id}"]
 
@@ -144,7 +144,7 @@ module "workers" {
 
   vpc_id     = "${module.vpc.vpc_id}"
   subnet_ids = ["${module.vpc.worker_subnet_ids}"]
-  sg_ids     = ["${module.vpc.worker_sg_id}"]
+  sg_ids     = "${concat(var.tectonic_aws_worker_extra_sg_ids, list(module.vpc.worker_sg_id))}"
 
   ssh_key                      = "${var.tectonic_aws_ssh_key}"
   cl_channel                   = "${var.tectonic_cl_channel}"

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -30,6 +30,39 @@ variable "tectonic_aws_etcd_ec2_type" {
   default     = "t2.medium"
 }
 
+variable "tectonic_aws_etcd_extra_sg_ids" {
+  description = <<EOF
+(optional) List of additional security group IDs for etcd nodes.
+
+Example: `["sg-51530134", "sg-b253d7cc"]`
+EOF
+
+  type    = "list"
+  default = []
+}
+
+variable "tectonic_aws_master_extra_sg_ids" {
+  description = <<EOF
+(optional) List of additional security group IDs for master nodes.
+
+Example: `["sg-51530134", "sg-b253d7cc"]`
+EOF
+
+  type    = "list"
+  default = []
+}
+
+variable "tectonic_aws_worker_extra_sg_ids" {
+  description = <<EOF
+(optional) List of additional security group IDs for worker nodes.
+
+Example: `["sg-51530134", "sg-b253d7cc"]`
+EOF
+
+  type    = "list"
+  default = []
+}
+
 variable "tectonic_aws_vpc_cidr_block" {
   type    = "string"
   default = "10.0.0.0/16"


### PR DESCRIPTION
This allows users to add additional security groups to nodes on AWS. My specific use-case is that I have a `base` security group managed outside the Tectonic config which allows SSH from bastion hosts among other things.