### PR TITLE
platforms/openstack/nova: Add default network

### DIFF
--- a/Documentation/variables/openstack-nova.md
+++ b/Documentation/variables/openstack-nova.md
@@ -8,5 +8,6 @@ This document gives an overview of variables used in the Openstack/Nova platform
 |------|-------------|:----:|:-----:|
 | tectonic_openstack_flavor_id | The flavor ID as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM. | string | - |
 | tectonic_openstack_image_id | The image ID as given in `openstack image list`. Specifies the OS image of the VM. | string | - |
+| tectonic_openstack_network_name | The name of the network to connect to OpenStack compute instances. | string | `public` |
 | tectonic_openstack_nova_config_version | (internal) This declares the version of the OpenStack Nova configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
 

--- a/examples/terraform.tfvars.openstack-nova
+++ b/examples/terraform.tfvars.openstack-nova
@@ -107,6 +107,11 @@ tectonic_openstack_flavor_id = ""
 // Specifies the OS image of the VM.
 tectonic_openstack_image_id = ""
 
+// (optional) The network name as given in `openstack network list`.
+// Specifies the name of the network to use for compute instances.
+// If not provided, defaults to "public"
+// tectonic_openstack_network_name = "public"
+
 // The path the pull secret file in JSON format.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.

--- a/platforms/openstack/nova/nodes.tf
+++ b/platforms/openstack/nova/nodes.tf
@@ -5,6 +5,10 @@ resource "openstack_compute_instance_v2" "master_node" {
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
   security_groups = ["${module.master_nodes.secgroup_name}"]
 
+  network {
+    name = "${var.tectonic_openstack_network_name}"
+  }
+
   metadata {
     role = "master"
   }
@@ -20,6 +24,10 @@ resource "openstack_compute_instance_v2" "worker_node" {
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
   security_groups = ["${module.worker_nodes.secgroup_name}"]
 
+  network {
+    name = "${var.tectonic_openstack_network_name}"
+  }
+
   metadata {
     role = "worker"
   }
@@ -34,6 +42,10 @@ resource "openstack_compute_instance_v2" "etcd_node" {
   image_id        = "${var.tectonic_openstack_image_id}"
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
   security_groups = ["${module.etcd.secgroup_name}"]
+
+  network {
+    name = "${var.tectonic_openstack_network_name}"
+  }
 
   metadata {
     role = "etcd"

--- a/platforms/openstack/nova/variables.tf
+++ b/platforms/openstack/nova/variables.tf
@@ -24,3 +24,13 @@ The image ID as given in `openstack image list`.
 Specifies the OS image of the VM.
 EOF
 }
+
+variable "tectonic_openstack_network_name" {
+  type = "string"
+
+  description = <<EOF
+The name of the network to connect to OpenStack compute instances.
+EOF
+
+  default = "public"
+}


### PR DESCRIPTION
Add a default network to compute nodes. This variable
must be explicitly specified if more than one network
is available to choose from, or the node creation will fail.