### PR TITLE
modules/openstack: Add port 10250 to security group

### DIFF
--- a/modules/openstack/nodes/secgroup.tf
+++ b/modules/openstack/nodes/secgroup.tf
@@ -29,4 +29,11 @@ resource "openstack_compute_secgroup_v2" "node" {
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }
+
+  rule {
+    from_port   = 10250
+    to_port     = 10250
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
 }


### PR DESCRIPTION
Kubernetes uses port 10250 to retreive logs.
`kubectl logs …` will fail with a timeout if this port is blocked.