### PR TITLE
platforms/openstack: Use tectonic_vanilla_k8s flag

### DIFF
--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -103,7 +103,7 @@ resource "null_resource" "tectonic" {
       "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",
       "sudo mv /home/core/tectonic /opt/",
-      "sudo systemctl start tectonic",
+      "sudo systemctl start ${var.tectonic_vanilla_k8s ? "bootkube.service" : "tectonic.service"}",
     ]
   }
 }

--- a/platforms/openstack/nova/nodes.tf
+++ b/platforms/openstack/nova/nodes.tf
@@ -62,7 +62,7 @@ resource "null_resource" "tectonic" {
       "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",
       "sudo mv /home/core/tectonic /opt/",
-      "sudo systemctl start tectonic",
+      "sudo systemctl start ${var.tectonic_vanilla_k8s ? "bootkube.service" : "tectonic.service"}",
     ]
   }
 }


### PR DESCRIPTION
The tectonic_vanilla_k8s flag was previously defined, but not
actually used. Conditionally deploy Tectonic assets based
on the value of this flag.

See also: #607 #194 