### PR TITLE
Variabilize flannel-busybox container image

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -44,6 +44,7 @@ variable "tectonic_container_images" {
     kenc                            = "quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035"
     awscli                          = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
     kube_version                    = "quay.io/coreos/kube-version:0.1.0"
+    busybox                         = "docker.io/library/busybox"
   }
 }
 

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -27,7 +27,7 @@ resource "template_dir" "bootkube" {
     flannel_image          = "${var.container_images["flannel"]}"
     etcd_operator_image    = "${var.container_images["etcd_operator"]}"
     kenc_image             = "${var.container_images["kenc"]}"
-
+    busybox_image          = "${var.container_images["busybox"]}"
     # Choose the etcd endpoints to use.
     # 1. If experimental mode is enabled (self-hosted etcd), then use
     # var.etcd_service_ip.

--- a/modules/bootkube/resources/manifests/kube-flannel.yaml
+++ b/modules/bootkube/resources/manifests/kube-flannel.yaml
@@ -70,7 +70,7 @@ spec:
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
       - name: install-cni
-        image: busybox
+        image: ${busybox_image} 
         command: [ "/bin/sh", "-c", "set -e -x; TMP=/etc/cni/net.d/.tmp-flannel-cfg; cp /etc/kube-flannel/cni-conf.json $TMP; mv $TMP /etc/cni/net.d/10-flannel.conf; while :; do sleep 3600; done" ]
         volumeMounts:
         - name: cni


### PR DESCRIPTION
Flannel Daemonset spec currently hardcodes to `image: busybox`. This commit helps; https://github.com/coreos/tectonic-installer/issues/463