### PR TITLE
Filter logs for credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,8 +78,10 @@ pipeline {
             # Use smoke test configuration for deployment
             ln -sf ${WORKSPACE}/test/aws.tfvars ${WORKSPACE}/build/${CLUSTER}/terraform.tfvars
 
-            make plan
-            make apply
+            alias filter=${WORKSPACE}/installer/scripts/filter.sh
+
+            make plan | filter
+            make apply | filter
 
             # TODO: replace in Go
             CONFIG=${WORKSPACE}/build/${CLUSTER}/terraform.tfvars

--- a/installer/scripts/filter.sh
+++ b/installer/scripts/filter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # filter hides lines with words over MAX chars
 
-MAX=${MAX:-24}
-sed -e "s/[^\ ]\{${MAX},\}/***OMITTED***/g"
+MAX=${MAX:-65}
+sed -e "s/[a-zA-Z0-9\/+]\{${MAX},\}/***OMITTED***/g"
 

--- a/installer/scripts/filter.sh
+++ b/installer/scripts/filter.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# filter hides lines with words over MAX chars
+
+MAX=${MAX:-24}
+sed -e "s/[^\ ]\{${MAX},\}/***OMITTED***/g"
+

--- a/installer/scripts/filter.sh
+++ b/installer/scripts/filter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # filter hides lines with words over MAX chars
 
-MAX=${MAX:-65}
+MAX=${MAX:-500}
 sed -e "s/[a-zA-Z0-9\/+]\{${MAX},\}/***OMITTED***/g"
 


### PR DESCRIPTION
This uses a very rough heurestic (string length) to remove credentials from log output. This is a requirement for opening log output up to the public.

cc/ @philips