### PR TITLE
Docs: bump aws download installer url.

### DIFF
--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -70,6 +70,6 @@ For those new to Tectonic and Kubernetes, the [Tectonic Tutorials][tutorials] pr
 [install-aws-requirements-creds]: requirements.md#privileges
 [install-aws-requirements-evpc]: requirements.md#using-an-existing-vpc
 [tutorials]: ../../tutorials/index.md
-[latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.5.7-tectonic.1.tar.gz
+[latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.6.2-tectonic.1.tar.gz
 [install-aws-troubleshooting]: ../../troubleshooting/faq.md
 [tf-state]: https://www.terraform.io/docs/state/


### PR DESCRIPTION
@coresolve 

*note* there will be a hotpatch for the docs on coreos.com for this so it gets fixed before the next release.