### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+
+[*.tpl]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Add [.editorconfig](http://editorconfig.org/) file in order to be able to control editing parameters. I found it necessary to use EditorConfig in order to ensure that newlines weren't added to the end of Terraform template files automatically, since said newlines will make it into the rendered Terraform config and can lead to confusing errors if newlines shouldn't be in the rendered output.