### PR TITLE
Server: Don't add an extra newline to logs about serving local files.

### DIFF
--- a/installer/api/handlers_frontend.go
+++ b/installer/api/handlers_frontend.go
@@ -75,6 +75,6 @@ func servePublicAsset(w http.ResponseWriter, r *http.Request) {
 
 func serveAssetFromDir(assetDir string, w http.ResponseWriter, r *http.Request) {
 	servePath := path.Join(assetDir, r.URL.Path)
-	log.Infof("Serving LOCAL FILE %s\n", servePath)
+	log.Infof("Serving LOCAL FILE %s", servePath)
 	http.ServeFile(w, r, servePath)
 }


### PR DESCRIPTION
No other log lines do this.