### PR TITLE
platforms/metal: Add NoSchedule taint to controllers

### DIFF
--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -74,6 +74,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=node-role.kubernetes.io/master \
+          --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid


### PR DESCRIPTION
Release notes say "Segregates control-plane / user workloads to master / worker nodes respectively", so you do need this taint on the controller kubelet.

https://github.com/coreos/matchbox/pull/528