### PR TITLE
frontend: fixes error cycles...

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -118,11 +118,10 @@ export const configActions = {
   },
 };
 
-export const validateAllFields = (originalClusterConfig, cb) => async (dispatch, getState) => {
-  // Just shake the array really hard until all the nodes fall out...
+export const validateAllFields = cb => async (dispatch, getState) => {
+  const initialCC = getState().clusterConfig;
   const unvisitedFields = new Set(_.values(FIELDS));
   const visitedNames = new Set();
-
   const isNow = () => true;
 
   const visit = async field => {
@@ -137,9 +136,10 @@ export const validateAllFields = (originalClusterConfig, cb) => async (dispatch,
 
     // TODO: (kans) this is bad
     await field.getExtraStuff(dispatch, clusterConfig, FIELDS, isNow);
-    await field.validate(dispatch, getState, originalClusterConfig, isNow);
+    await field.validate(dispatch, getState, initialCC, isNow);
   };
 
+  // Just shake the array really hard until all the nodes fall out...
   while (unvisitedFields.size > 0) {
     const toVisit = [];
 

--- a/installer/frontend/app.jsx
+++ b/installer/frontend/app.jsx
@@ -59,7 +59,7 @@ try {
   console.error('Error restoring state from sessionStorage:', e);
 }
 
-store.dispatch(validateAllFields(store.getState().clusterConfig, () => {
+store.dispatch(validateAllFields(() => {
   TectonicGA.initialize();
 
   try {

--- a/installer/frontend/components/restore.jsx
+++ b/installer/frontend/components/restore.jsx
@@ -12,14 +12,13 @@ import { CLUSTER_NAME } from '../cluster-config';
 
 const UPLOAD_ERROR_NAME = 'UPLOAD_ERROR_NAME';
 
-const handleUpload = (blob, cb) => (dispatch, getState) => {
+const handleUpload = (blob, cb) => dispatch => {
   TectonicGA.sendEvent('Installer Button', 'click', 'User uploads progress file');
 
   if (!blob) {
     return;
   }
 
-  const originalState = getState().clusterConfig;
   readFile(blob)
     .then(result => {
       try {
@@ -35,7 +34,8 @@ const handleUpload = (blob, cb) => (dispatch, getState) => {
             error: null,
           },
         });
-        dispatch(validateAllFields(originalState, cb));
+        // the restored state may contain errors, so we don't want to use an old version.
+        dispatch(validateAllFields(cb));
       } catch(e) {
         dispatch({
           type: eventErrorsActionTypes.ERROR,


### PR DESCRIPTION
when loading data from a progress more than once.

thanks @brianredbeard - The ["actual" bug](https://github.com/coreos/tectonic-installer/pull/701/files#diff-79f9bf65af286bdd5209bf91d5898793L38) is bad cache invalidation -  the fix resulted in cleaner code, too.  