### PR TITLE
modules/aws: create correct count of etcd a-records

### DIFF
--- a/modules/aws/etcd/dns.tf
+++ b/modules/aws/etcd/dns.tf
@@ -17,7 +17,7 @@ resource "aws_route53_record" "etcd_srv_client" {
 }
 
 resource "aws_route53_record" "etc_a_nodes" {
-  count   = "${var.dns_enabled ? 1 : 0}"
+  count   = "${var.dns_enabled ? var.instance_count : 0}"
   type    = "A"
   ttl     = "60"
   zone_id = "${var.dns_zone_id}"


### PR DESCRIPTION
Currently only one A-record for etcd nodes is being created.
This fixes it by considering the instance count of created etcd nodes.