### PR TITLE
WIP frontend: deep validation

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -109,12 +109,7 @@ export const configActions = {
       throw new Error(`${name} has no field`);
     }
 
-    const deps = FIELD_TO_DEPS[name];
-    if (_.size(deps) === 0) {
-      console.debug("no deps for", name);
-    }
-
-    field.update(dispatch, inputValue, getState, deps, FIELDS, split);
+    field.update(dispatch, inputValue, getState, FIELDS, FIELD_TO_DEPS, split);
   },
 };
 

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -83,6 +83,7 @@ export const AWS_VPC_FORM = 'aws_vpc';
 export const AWS_CONTROLLERS = 'aws_controllers';
 export const AWS_CLUSTER_INFO = 'aws_clusterInfo';
 export const AWS_WORKERS = 'aws_workers';
+export const AWS_REGION_FORM = 'aws_regionForm';
 export const BM_SSH_KEY = 'bm_sshKey';
 export const LICENSING = 'licensing';
 

--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -18,6 +18,7 @@ import {
   AWS_CONTROLLER_SUBNET_IDS,
   AWS_WORKER_SUBNET_IDS,
   AWS_REGION,
+  AWS_REGION_FORM,
   AWS_SECRET_ACCESS_KEY,
   AWS_SESSION_TOKEN,
   STS_ENABLED,
@@ -69,7 +70,7 @@ const awsCredsForm = new Form(AWS_CREDS, [
   },
 });
 
-const selectRegionForm = new Form('SelectRegionForm', [
+const selectRegionForm = new Form(AWS_REGION_FORM, [
   awsCredsForm,
   new Field(AWS_REGION, {
     default: '',

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -34,6 +34,7 @@ import {
   AWS_CREATE_VPC,
   AWS_HOSTED_ZONE_ID,
   AWS_REGION,
+  AWS_REGION_FORM,
   AWS_SUBNETS,
   AWS_VPC_CIDR,
   AWS_VPC_ID,
@@ -61,7 +62,7 @@ const vpcInfoForm = new Form(AWS_VPC_FORM, [
   }),
   new Field(AWS_HOSTED_ZONE_ID, {
     default: '',
-    dependencies: [AWS_REGION],
+    dependencies: [AWS_REGION_FORM],
     validator: (value, clusterConfig, oldValue, extraData) => {
       const empty = validate.nonEmpty(value);
       if (empty) {

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -81,6 +81,7 @@ class Node {
       batches.push([inFlyPath, false]);
     }
 
+    console.debug("validating", this.name);
     const syncError = this.validator(value, clusterConfig, oldValue, extraData);
     if (syncError) {
       console.info("sync error", this.name, syncError);
@@ -164,6 +165,30 @@ class Node {
   }
 }
 
+async function promisify (dispatch, getState, oldCC, isNow, deps, FIELDS) {
+  const { clusterConfig } = getState();
+
+  // TODO: (kans) earlier return [] if not now?
+  const promises = deps.map(field => {
+    const { id } = field;
+    field.ignoreWhen(dispatch, clusterConfig);
+    return field.getExtraStuff(dispatch, clusterConfig, FIELDS, isNow)
+      .then(() => field.validate(dispatch, getState, oldCC, isNow))
+      .then(res => {
+        if (!res) {
+          console.debug(`${id} is invalid`);
+        } else {
+          console.debug(`${id} is valid`);
+        }
+        return res && id;
+      }).catch(err => {
+        console.error(err);
+      });
+  });
+
+  return await Promise.all(promises).then(p => p.filter(id => id));
+}
+
 export class Field extends Node {
   constructor(id, opts={}) {
     super(id, opts);
@@ -181,7 +206,7 @@ export class Field extends Node {
     return clusterConfig[this.id];
   }
 
-  async update (dispatch, value, getState, deps, FIELDS, split) {
+  async update (dispatch, value, getState, FIELDS, FIELD_TO_DEPS, split) {
     const oldCC = getState().clusterConfig;
 
     ++ this.clock_;
@@ -192,10 +217,11 @@ export class Field extends Node {
     if (split && split.length) {
       id = `${id}.${split.join('.')}`;
     }
+
+    console.info("updating", this.name);
     // TODO: (kans) - We need to lock the entire validation chain, not just validate proper
     setIn(id, value, dispatch);
 
-    console.info("validating", this.name);
     const isValid = await this.validate(dispatch, getState, oldCC, isNow);
 
     if (!isValid) {
@@ -208,11 +234,26 @@ export class Field extends Node {
       return;
     }
 
-    for (let dep of deps) {
-      const { clusterConfig } = getState();
-      dep.ignoreWhen(dispatch, clusterConfig);
-      await dep.getExtraStuff(dispatch, clusterConfig, FIELDS, isNow);
-      await dep.validate(dispatch, getState, oldCC, isNow);
+    const visited = new Set();
+    const toVisit = [FIELD_TO_DEPS[this.id]];
+
+    if (!toVisit[0].length) {
+      console.debug("no deps for", this.name);
+      return;
+    }
+
+    while (toVisit.length) {
+      const deps = toVisit.splice(0, 1)[0];
+      // TODO: check for relationship between deps
+      const nextDepIDs = await promisify(dispatch, getState, oldCC, isNow, deps, FIELDS);
+      nextDepIDs.forEach(depID => {
+        const nextDeps = _.filter(FIELD_TO_DEPS[depID], d => !visited.has(d.id));
+        if (!nextDeps.length) {
+          return;
+        }
+        nextDeps.forEach(d => visited.add(d.id));
+        toVisit.push(nextDeps);
+      });
     }
 
     console.info("finish validating", this.name);


### PR DESCRIPTION
Visit all field/form dependencies, recursively after validating input.
This doesn't change much behavior, but will allow us to clean up the VPC page and friends.

I'm not thrilled about passing FIELDS and FIELD_TO_DEPS to Fields which is an abstraction leak, but building a graph ahead of time is hard because we only want to continue down a chain so long as the chain is valid *and* we must never want to visit the same dep twice.