### PR TITLE
cluster names/bucket names

### DIFF
--- a/platforms/aws/s3.tf
+++ b/platforms/aws/s3.tf
@@ -3,8 +3,12 @@ data "aws_region" "current" {
 }
 
 resource "aws_s3_bucket" "tectonic" {
-  bucket = "${var.tectonic_cluster_name}.${data.aws_region.current.name}.${var.tectonic_base_domain}"
-  acl    = "private"
+  # Buckets must start with a lower case name and are limited to 63 characters,
+  # so we prepende the letter 'a' and use the md5 hex digest for the case of a long domain
+  # leaving 29 chars for the cluster name.
+  bucket = "a${var.tectonic_cluster_name}-${md5("${data.aws_region.current.name}-${var.tectonic_base_domain}")}"
+
+  acl = "private"
 }
 
 # Bootkube / Tectonic assets


### PR DESCRIPTION
We use cluster names for generating bucket names with the region and domain.
However, buckets must start with a lower case letter and are restricted to 63 chars,
so this commit prepends the letter 'a' and md5s the region name and domain.  It also switches dashes for dots as the delimitter because double dashes are allowed but dashes next to dots are not.