### PR TITLE
openstack/neutron: Fix security groups

### DIFF
--- a/modules/openstack/etcd/output.tf
+++ b/modules/openstack/etcd/output.tf
@@ -5,3 +5,7 @@ output "user_data" {
 output "secgroup_name" {
   value = "${openstack_compute_secgroup_v2.etcd.name}"
 }
+
+output "secgroup_id" {
+  value = "${openstack_compute_secgroup_v2.etcd.id}"
+}

--- a/modules/openstack/nodes/output.tf
+++ b/modules/openstack/nodes/output.tf
@@ -5,3 +5,7 @@ output "user_data" {
 output "secgroup_name" {
   value = "${openstack_compute_secgroup_v2.node.name}"
 }
+
+output "secgroup_id" {
+  value = "${openstack_compute_secgroup_v2.node.id}"
+}

--- a/platforms/openstack/neutron/network.tf
+++ b/platforms/openstack/neutron/network.tf
@@ -23,12 +23,27 @@ resource "openstack_networking_router_interface_v2" "interface" {
   subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
 }
 
+# etcd
+
+resource "openstack_networking_port_v2" "etcd" {
+  count          = "${var.tectonic_etcd_count}"
+  name           = "${var.tectonic_cluster_name}_port_etcd_${count.index}"
+  network_id     = "${openstack_networking_network_v2.network.id}"
+  security_group_ids = ["${module.etcd.secgroup_id}"]
+  admin_state_up = "true"
+
+  fixed_ip {
+    subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+  }
+}
+
 # master
 
 resource "openstack_networking_port_v2" "master" {
   count          = "${var.tectonic_master_count}"
   name           = "${var.tectonic_cluster_name}_port_master_${count.index}"
   network_id     = "${openstack_networking_network_v2.network.id}"
+  security_group_ids = ["${module.master_nodes.secgroup_id}"]
   admin_state_up = "true"
 
   fixed_ip {
@@ -55,6 +70,7 @@ resource "openstack_networking_port_v2" "worker" {
   count          = "${var.tectonic_worker_count}"
   name           = "${var.tectonic_cluster_name}_port_worker_${count.index}"
   network_id     = "${openstack_networking_network_v2.network.id}"
+  security_group_ids = ["${module.worker_nodes.secgroup_id}"]
   admin_state_up = "true"
 
   fixed_ip {

--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -5,14 +5,13 @@ resource "openstack_compute_instance_v2" "etcd_node" {
   name            = "${var.tectonic_cluster_name}_etcd_node_${count.index}"
   image_id        = "${var.tectonic_openstack_image_id}"
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
-  security_groups = ["${module.etcd.secgroup_name}"]
 
   metadata {
     role = "etcd"
   }
 
   network {
-    uuid = "${openstack_networking_network_v2.network.id}"
+    port = "${openstack_networking_port_v2.etcd.*.id[count.index]}"
   }
 
   user_data    = "${module.etcd.user_data[count.index]}"
@@ -26,7 +25,6 @@ resource "openstack_compute_instance_v2" "master_node" {
   name            = "${var.tectonic_cluster_name}_master_node_${count.index}"
   image_id        = "${var.tectonic_openstack_image_id}"
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
-  security_groups = ["${module.master_nodes.secgroup_name}"]
 
   metadata {
     role = "master"
@@ -54,7 +52,6 @@ resource "openstack_compute_instance_v2" "worker_node" {
   name            = "${var.tectonic_cluster_name}_worker_node_${count.index}"
   image_id        = "${var.tectonic_openstack_image_id}"
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
-  security_groups = ["${module.worker_nodes.secgroup_name}"]
 
   metadata {
     role = "worker"


### PR DESCRIPTION
When assigning neutron ports, the `security_groups` attribute is ignored on
`openstack_compute_instance_v2`. Apply all the security groups by id on the
`openstack_networking_port_v2` instead. Also create a specific port for etcd
nodes for consistency with the controllers and nodes.