### PR TITLE
installer/vendor: Update terraform-provider-matchbox to v0.1.2

### DIFF
--- a/installer/glide.lock
+++ b/installer/glide.lock
@@ -1,5 +1,5 @@
-hash: fa4ce61de4f1d341d916532bec759a7b7e77b9d793f8eb9b26665d156109c85f
-updated: 2017-05-12T13:32:15.225510604-07:00
+hash: 30221ed8dda5459151ca5e548474e4f92096ff926dd498c47b63cae372716927
+updated: 2017-05-16T13:31:15.722129599-07:00
 imports:
 - name: github.com/ajeddeloh/yaml
   version: 1072abfea31191db507785e2e0c1b8d1440d35a5
@@ -133,7 +133,7 @@ imports:
   - httputil
   - timeutil
 - name: github.com/coreos/terraform-provider-matchbox
-  version: 4c66aa75b60489a4220730d70b0446e25b0c9a0a
+  version: 016482b8add5122d41cce5e05d4f1730c5a9ff77
   subpackages:
   - matchbox
 - name: github.com/coreos/yaml

--- a/installer/glide.yaml
+++ b/installer/glide.yaml
@@ -352,7 +352,7 @@ import:
 - package: github.com/mitchellh/mapstructure
   version: 281073eb9eb092240d33ef253c404f1cca550309
 - package: github.com/coreos/terraform-provider-matchbox 
-  version: 4c66aa75b60489a4220730d70b0446e25b0c9a0a
+  version: v0.1.2
   subpackages:
   - matchbox
 - package: github.com/hashicorp/vault
@@ -361,6 +361,12 @@ import:
   - helper/compressutil
   - helper/jsonutil
   - helper/pgpkeys
+- package: golang.org/x/crypto
+  version: 5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3
+  subpackages:
+  - curve25519
+  - ssh
+  - ssh/terminal
 - package: github.com/hashicorp/go-getter
   version: 615ccd8621bdb3837e18be586ce15655ef52b185
   subpackages:

--- a/installer/vendor/github.com/coreos/terraform-provider-matchbox/matchbox/matchbox.go
+++ b/installer/vendor/github.com/coreos/terraform-provider-matchbox/matchbox/matchbox.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	defaultTimeout = 30 * time.Second
+	defaultTimeout = 25 * time.Second
 )
 
 // Config configures a matchbox client.

--- a/installer/vendor/github.com/coreos/terraform-provider-matchbox/matchbox/provider.go
+++ b/installer/vendor/github.com/coreos/terraform-provider-matchbox/matchbox/provider.go
@@ -1,6 +1,8 @@
 package matchbox
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -39,13 +41,18 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	ca := d.Get("ca").(string)
 	clientCert := d.Get("client_cert").(string)
 	clientKey := d.Get("client_key").(string)
+	endpoint := d.Get("endpoint").(string)
 
 	config := &Config{
-		Endpoint:   d.Get("endpoint").(string),
+		Endpoint:   endpoint,
 		ClientCert: []byte(clientCert),
 		ClientKey:  []byte(clientKey),
 		CA:         []byte(ca),
 	}
 
-	return NewMatchboxClient(config)
+	client, err := NewMatchboxClient(config)
+	if err != nil {
+		return client, fmt.Errorf("failed to create Matchbox client or connect to %s: %v", endpoint, err)
+	}
+	return client, err
 }


### PR DESCRIPTION
* Update terraform-provider-matchbox from v0.1.0 to v0.1.2. See release notes https://github.com/coreos/terraform-provider-matchbox/releases
* Also pin crypto package which was unpinned and causing glide update to fail. No diff in vendor from that.

Closes #712