### PR TITLE
Always cache go builds with -i

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -15,14 +15,14 @@ all: build
 build: bin/$(OS)/installer
 
 bin/windows/installer.exe: $(GO_FILES) assets/bindata.go
-	GOOS=windows go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=windows go build -i -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 bin/%/installer: $(GO_FILES) assets/bindata.go
-	GOOS=$* go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$* go build -i -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 .PHONY: backend
 backend: assets/bindata.go
-	GOOS=$(OS) go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$(OS) go build -i -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 assets/bindata.go: frontend bin/go-bindata $(shell find assets -type f | grep -v .go)
 	./bin/go-bindata -pkg assets -o assets/bindata.go -ignore=bindata.go -ignore=doc.go -ignore=assets.go -prefix assets assets/...
@@ -73,10 +73,10 @@ vendor: glide.yaml
 tools: bin/go-bindata bin/sanity bin/golint
 
 bin/golint:
-	CGO_ENABLED=0 go build -o bin/golint $(REPO)/vendor/github.com/golang/lint/golint
+	CGO_ENABLED=0 go build -i -o bin/golint $(REPO)/vendor/github.com/golang/lint/golint
 
 bin/go-bindata:
-	go build -o bin/go-bindata $(REPO)/vendor/github.com/jteeuwen/go-bindata/go-bindata
+	go build -i -o bin/go-bindata $(REPO)/vendor/github.com/jteeuwen/go-bindata/go-bindata
 
 bin/sanity:
 	go test tests/sanity/k8s_test.go -c -o bin/sanity


### PR DESCRIPTION
This PR for updates the Makefile for the installer to always pass `-i` when performing a Go build. This will cause the build to be cached in `$GOPATH/pkg` and will speed up future builds.