### PR TITLE
platforms/metal: Fix race condition adding workers

### DIFF
--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -34,8 +34,7 @@ systemd:
         Description=Determine the Kubelet Image Version
         ConditionPathExists=!/etc/kubernetes/kubelet.env
         [Service]
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes
-        ExecStartPre=/usr/bin/bash -c "docker run --rm -v /etc/kubernetes/kubeconfig:/kubeconfig {{.kube_version_image}} --kubeconfig=/kubeconfig > /etc/kubernetes/kube.version"
+        ExecStartPre=/usr/bin/bash -c "docker run --rm -v /etc/kubernetes:/etc/kubernetes {{.kube_version_image}} --kubeconfig=/etc/kubernetes/kubeconfig > /etc/kubernetes/kube.version"
         ExecStart=/usr/bin/bash -c "echo KUBELET_IMAGE_URL={{.kubelet_image_url}} > /etc/kubernetes/kubelet.env; echo KUBELET_IMAGE_TAG=$(tr '+' '_' < /etc/kubernetes/kube.version) >> /etc/kubernetes/kubelet.env; rm /etc/kubernetes/kube.version"
         Restart=on-failure
         RestartSec=10


### PR DESCRIPTION
* kubelet-env starts and docker creates missing directories so
it could create a directory /etc/kubernetes/kubeconfig
* Terraform races with kubelet-env can if it runs after docker
has run once, the kubeconfig will erroneously be placed in a
directory /etc/kubernetes/kuebconfig/kubeconfig

Impact is that under the right (wrong) circumstances, no workers will join the cluster.

cc @sym3tri 