### PR TITLE
config.tf: pull_secret_path and license_path optional

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -26,9 +26,9 @@ This document gives an overview of variables used in all platforms of the Tecton
 | tectonic_kube_apiserver_service_ip | The Kubernetes service IP used to reach kube-apiserver inside the cluster as returned by `kubectl -n default get service kubernetes`. | string | `10.3.0.1` |
 | tectonic_kube_dns_service_ip | The Kubernetes service IP used to reach kube-dns inside the cluster as returned by `kubectl -n kube-system get service kube-dns`. | string | `10.3.0.10` |
 | tectonic_kube_etcd_service_ip | The Kubernetes service IP used to reach self-hosted etcd inside the cluster as returned by `kubectl -n kube-system get service etcd-service`. | string | `10.3.0.15` |
-| tectonic_license_path | The path to the tectonic licence file.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
+| tectonic_license_path | The path to the tectonic licence file.<br><br>Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`. | string | `` |
 | tectonic_master_count | The number of master nodes to be created. This applies only to cloud platforms. | string | `1` |
-| tectonic_pull_secret_path | The path the pull secret file in JSON format.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
+| tectonic_pull_secret_path | The path the pull secret file in JSON format.<br><br>Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`. | string | `` |
 | tectonic_service_cidr | This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. | string | `10.3.0.0/16` |
 | tectonic_update_app_id | (internal) The Tectonic Omaha update App ID | string | `6bc7b986-4654-4a0f-94b3-84ce6feb1db4` |
 | tectonic_update_channel | (internal) The Tectonic Omaha update channel | string | `tectonic-1.6` |

--- a/config.tf
+++ b/config.tf
@@ -209,22 +209,24 @@ EOF
 }
 
 variable "tectonic_pull_secret_path" {
-  type = "string"
+  type    = "string"
+  default = ""
 
   description = <<EOF
 The path the pull secret file in JSON format.
 
-Note: This field MUST be set manually prior to creating the cluster.
+Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 EOF
 }
 
 variable "tectonic_license_path" {
-  type = "string"
+  type    = "string"
+  default = ""
 
   description = <<EOF
 The path to the tectonic licence file.
 
-Note: This field MUST be set manually prior to creating the cluster.
+Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 EOF
 }
 

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -183,7 +183,7 @@ tectonic_kube_etcd_service_ip = "10.3.0.15"
 
 // The path to the tectonic licence file.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_license_path = ""
 
 // The number of master nodes to be created.
@@ -192,7 +192,7 @@ tectonic_master_count = "1"
 
 // The path the pull secret file in JSON format.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -140,7 +140,7 @@ tectonic_kube_etcd_service_ip = "10.3.0.15"
 
 // The path to the tectonic licence file.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_license_path = ""
 
 // The number of master nodes to be created.
@@ -149,7 +149,7 @@ tectonic_master_count = "1"
 
 // The path the pull secret file in JSON format.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -92,7 +92,7 @@ tectonic_kube_etcd_service_ip = "10.3.0.15"
 
 // The path to the tectonic licence file.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_license_path = ""
 
 // The number of master nodes to be created.
@@ -200,7 +200,7 @@ tectonic_metal_worker_names = ""
 
 // The path the pull secret file in JSON format.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -92,7 +92,7 @@ tectonic_kube_etcd_service_ip = "10.3.0.15"
 
 // The path to the tectonic licence file.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_license_path = ""
 
 // The number of master nodes to be created.
@@ -122,7 +122,7 @@ tectonic_openstack_subnet_cidr = "192.168.1.0/24"
 
 // The path the pull secret file in JSON format.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.

--- a/examples/terraform.tfvars.openstack-nova
+++ b/examples/terraform.tfvars.openstack-nova
@@ -92,7 +92,7 @@ tectonic_kube_etcd_service_ip = "10.3.0.15"
 
 // The path to the tectonic licence file.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_license_path = ""
 
 // The number of master nodes to be created.
@@ -112,7 +112,7 @@ tectonic_openstack_network_name = "public"
 
 // The path the pull secret file in JSON format.
 // 
-// Note: This field MUST be set manually prior to creating the cluster.
+// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -44,8 +44,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -43,8 +43,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -50,8 +50,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${var.tectonic_license_path}"
-  pull_secret_path = "${var.tectonic_pull_secret_path}"
+  license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -43,8 +43,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -43,8 +43,8 @@ module "tectonic" {
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
 
-  license_path     = "${pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
+  license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email         = "${var.tectonic_admin_email}"
   admin_password_hash = "${var.tectonic_admin_password_hash}"


### PR DESCRIPTION
Currently both variables need to be set even if tectonic_vanilla_k8s is
set to true.

This fixes it.

Fixes #133