### PR TITLE
modules/aws: configure ELB connection timeouts

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -8,6 +8,9 @@ This document gives an overview of variables used in the AWS platform of the Tec
 |------|-------------|:----:|:-----:|
 | tectonic_autoscaling_group_extra_tags | (optional) Extra AWS tags to be applied to created autoscaling group resources. This is a list of maps having the keys `key`, `value` and `propagate_at_launch`.<br><br>Example: `[ { key = "foo", value = "bar", propagate_at_launch = true } ]` | list | `<list>` |
 | tectonic_aws_config_version | (internal) This declares the version of the AWS configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
+| tectonic_aws_elb_connection_draining | (optional) Boolean to enable connection draining on ELBs. | string | `false` |
+| tectonic_aws_elb_connection_draining_timeout | (optional) The time in seconds to allow for connections to drain on ELBs. | string | `300` |
+| tectonic_aws_elb_idle_timeout | (optional) The time in seconds that the connection is allowed to be idle on ELBs. The default is set to the maximum allowed setting. | string | `3600` |
 | tectonic_aws_etcd_ec2_type | Instance size for the etcd node(s). Example: `t2.medium`. | string | `t2.medium` |
 | tectonic_aws_etcd_root_volume_iops | The amount of provisioned IOPS for the root block device of etcd nodes. | string | `100` |
 | tectonic_aws_etcd_root_volume_size | The size of the volume in gigabytes for the root block device of etcd nodes. | string | `30` |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -16,6 +16,16 @@ tectonic_admin_password_hash = ""
 // Example: `[ { key = "foo", value = "bar", propagate_at_launch = true } ]`
 // tectonic_autoscaling_group_extra_tags = ""
 
+// (optional) Boolean to enable connection draining on ELBs.
+// tectonic_aws_elb_connection_draining = false
+
+// (optional) The time in seconds to allow for connections to drain on ELBs.
+// tectonic_aws_elb_connection_draining_timeout = "300"
+
+// (optional) The time in seconds that the connection is allowed to be idle on ELBs.
+// The default is set to the maximum allowed setting.
+// tectonic_aws_elb_idle_timeout = "3600"
+
 // Instance size for the etcd node(s). Example: `t2.medium`.
 tectonic_aws_etcd_ec2_type = "t2.medium"
 

--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -4,6 +4,10 @@ resource "aws_elb" "api-internal" {
   internal        = true
   security_groups = ["${var.api_sg_ids}"]
 
+  idle_timeout                = "${var.elb_idle_timeout}"
+  connection_draining         = "${var.elb_connection_draining}"
+  connection_draining_timeout = "${var.elb_connection_draining_timeout}"
+
   listener {
     instance_port     = 443
     instance_protocol = "tcp"
@@ -43,6 +47,10 @@ resource "aws_elb" "api-external" {
   subnets         = ["${var.subnet_ids}"]
   internal        = false
   security_groups = ["${var.api_sg_ids}"]
+
+  idle_timeout                = "${var.elb_idle_timeout}"
+  connection_draining         = "${var.elb_connection_draining}"
+  connection_draining_timeout = "${var.elb_connection_draining_timeout}"
 
   listener {
     instance_port     = 22
@@ -90,6 +98,10 @@ resource "aws_elb" "console" {
   subnets         = ["${var.subnet_ids}"]
   internal        = "${var.public_vpc ? false : true}"
   security_groups = ["${var.console_sg_ids}"]
+
+  idle_timeout                = "${var.elb_idle_timeout}"
+  connection_draining         = "${var.elb_connection_draining}"
+  connection_draining_timeout = "${var.elb_connection_draining_timeout}"
 
   listener {
     instance_port     = 32001

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -95,3 +95,15 @@ variable "root_volume_iops" {
   default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
+
+variable "elb_idle_timeout" {
+  type = "string"
+}
+
+variable "elb_connection_draining" {
+  type = "string"
+}
+
+variable "elb_connection_draining_timeout" {
+  type = "string"
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -119,6 +119,10 @@ module "masters" {
   root_volume_type = "${var.tectonic_aws_master_root_volume_type}"
   root_volume_size = "${var.tectonic_aws_master_root_volume_size}"
   root_volume_iops = "${var.tectonic_aws_master_root_volume_iops}"
+
+  elb_idle_timeout                = "${var.tectonic_aws_elb_idle_timeout}"
+  elb_connection_draining         = "${var.tectonic_aws_elb_connection_draining}"
+  elb_connection_draining_timeout = "${var.tectonic_aws_elb_connection_draining_timeout}"
 }
 
 module "ignition-workers" {

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -194,3 +194,30 @@ variable "tectonic_aws_region" {
   default     = "eu-west-1"
   description = "The target AWS region for the cluster."
 }
+
+variable "tectonic_aws_elb_idle_timeout" {
+  type    = "string"
+  default = "3600"
+
+  description = <<EOF
+(optional) The time in seconds that the connection is allowed to be idle on ELBs.
+The default is set to the maximum allowed setting.
+EOF
+}
+
+variable "tectonic_aws_elb_connection_draining" {
+  default = false
+
+  description = <<EOF
+(optional) Boolean to enable connection draining on ELBs.
+EOF
+}
+
+variable "tectonic_aws_elb_connection_draining_timeout" {
+  type    = "string"
+  default = "300"
+
+  description = <<EOF
+(optional) The time in seconds to allow for connections to drain on ELBs.
+EOF
+}


### PR DESCRIPTION
This adds support for configuring the following ELB connection timeout
properties:

- ELB idle timeout
- ELB connection draining

Fixes #390