### PR TITLE
Update ASG tags for compatibility with Terraform 0.9.6

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -32,19 +32,19 @@ resource "aws_autoscaling_group" "masters" {
 
   load_balancers = ["${aws_elb.api-internal.id}", "${join("",aws_elb.api-external.*.id)}", "${aws_elb.console.id}"]
 
-  tag {
-    key                 = "Name"
-    value               = "${var.cluster_name}-master"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "kubernetes.io/cluster/${var.cluster_name}"
-    value               = "owned"
-    propagate_at_launch = true
-  }
-
-  tags = ["${var.autoscaling_group_extra_tags}"]
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.cluster_name}-master"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "kubernetes.io/cluster/${var.cluster_name}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    "${var.autoscaling_group_extra_tags}"
+  ]
 
   lifecycle {
     create_before_destroy = true

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -55,19 +55,19 @@ resource "aws_autoscaling_group" "workers" {
   launch_configuration = "${aws_launch_configuration.worker_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
-  tag {
-    key                 = "Name"
-    value               = "${var.cluster_name}-worker"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "kubernetes.io/cluster/${var.cluster_name}"
-    value               = "owned"
-    propagate_at_launch = true
-  }
-
-  tags = ["${var.autoscaling_group_extra_tags}"]
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.cluster_name}-worker"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "kubernetes.io/cluster/${var.cluster_name}"
+      value               = "owned"
+      propagate_at_launch = true
+    },
+    "${var.autoscaling_group_extra_tags}"
+  ]
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
Using Terraform 0.9.6-dev (built from HEAD), the AWS platform target now converges without needing to use the custom `aws` module or `terraform` binary. 🎉