### PR TITLE
Cache x-compilation objects (incl. std) to GOPATH

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
         go version
         cd $GO_PROJECT/installer
 
-        make clean
         make tools
         make build
         make test

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -88,3 +88,4 @@ clean:
 	rm -f assets/bindata.go
 	rm -rf assets/frontend/scripts
 	rm -rf .workspace/
+	rm -rf $(GOPATH)/pkg/

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -15,14 +15,14 @@ all: build
 build: bin/$(OS)/installer
 
 bin/windows/installer.exe: $(GO_FILES) assets/bindata.go
-	GOOS=windows GOOARCH=amd64 go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=windows GOOARCH=amd64 go build -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 bin/%/installer: $(GO_FILES) assets/bindata.go
-	GOOS=$* GOOARCH=amd64 go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$* GOOARCH=amd64 go build -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 .PHONY: backend
 backend: assets/bindata.go
-	go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	go build -o bin/$(OS)/installer -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 assets/bindata.go: frontend bin/go-bindata $(shell find assets -type f | grep -v .go)
 	./bin/go-bindata -pkg assets -o assets/bindata.go -ignore=bindata.go -ignore=doc.go -ignore=assets.go -prefix assets assets/...
@@ -76,7 +76,7 @@ bin/golint:
 	CGO_ENABLED=0 go build -o bin/golint $(REPO)/vendor/github.com/golang/lint/golint
 
 bin/go-bindata:
-	go build -o bin/go-bindata $(REPO)/vendor/github.com/jteeuwen/go-bindata/go-bindata
+	go build -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/go-bindata $(REPO)/vendor/github.com/jteeuwen/go-bindata/go-bindata
 
 bin/sanity:
 	go test tests/sanity/k8s_test.go -c -o bin/sanity

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -15,14 +15,14 @@ all: build
 build: bin/$(OS)/installer
 
 bin/windows/installer.exe: $(GO_FILES) assets/bindata.go
-	GOOS=windows GOOARCH=amd64 go build -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=windows GOOARCH=amd64 go build -v -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 bin/%/installer: $(GO_FILES) assets/bindata.go
-	GOOS=$* GOOARCH=amd64 go build -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$* GOOARCH=amd64 go build -v -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 .PHONY: backend
 backend: assets/bindata.go
-	go build -o bin/$(OS)/installer -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	go build -o bin/$(OS)/installer -v -i -pkgdir $(GOPATH)/pkg/$(shell go env GOOS)_$(shell go env GOARCH) -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 assets/bindata.go: frontend bin/go-bindata $(shell find assets -type f | grep -v .go)
 	./bin/go-bindata -pkg assets -o assets/bindata.go -ignore=bindata.go -ignore=doc.go -ignore=assets.go -prefix assets assets/...

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -22,7 +22,7 @@ bin/%/installer: $(GO_FILES) assets/bindata.go
 
 .PHONY: backend
 backend: assets/bindata.go
-	GOOS=$(OS) GOOARCH=amd64 go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 assets/bindata.go: frontend bin/go-bindata $(shell find assets -type f | grep -v .go)
 	./bin/go-bindata -pkg assets -o assets/bindata.go -ignore=bindata.go -ignore=doc.go -ignore=assets.go -prefix assets assets/...

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -15,14 +15,14 @@ all: build
 build: bin/$(OS)/installer
 
 bin/windows/installer.exe: $(GO_FILES) assets/bindata.go
-	GOOS=windows go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=windows GOOARCH=amd64 go build -o bin/windows/installer.exe -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 bin/%/installer: $(GO_FILES) assets/bindata.go
-	GOOS=$* go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$* GOOARCH=amd64 go build -o bin/$*/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 .PHONY: backend
 backend: assets/bindata.go
-	GOOS=$(OS) go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
+	GOOS=$(OS) GOOARCH=amd64 go build -o bin/$(OS)/installer -ldflags $(LD_FLAGS) $(REPO)/cmd/installer
 
 assets/bindata.go: frontend bin/go-bindata $(shell find assets -type f | grep -v .go)
 	./bin/go-bindata -pkg assets -o assets/bindata.go -ignore=bindata.go -ignore=doc.go -ignore=assets.go -prefix assets assets/...

--- a/release.groovy
+++ b/release.groovy
@@ -53,6 +53,7 @@ pipeline {
                     export GITHUB_CREDENTIALS=$GITHUB_CREDENTIALS
                     go version
                     cd $GO_PROJECT/installer
+                    make clean
                     make build
                     make test
                     make release


### PR DESCRIPTION
Caching x-compilation objects effectively reduces Go build time from >2mins to ~6secs on every platforms (timed on a Mid-2014 MacBook Pro, assuming executor has built at least once). Given the fact that we are currently compiling twice for each CI run, this is significant. This is due to the fact that we were recompiling both the standard library, our dependencies and our binary every time - `go build` thrashes most of the results by default.

When building releases, we clean the environment entirely, to be on the safe side, even though the Go compiler can be trusted.