### PR TITLE
manifests: etcd operator pod should select master nodes

### DIFF
--- a/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
+++ b/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
@@ -24,6 +24,8 @@ spec:
                   fieldPath: metadata.name
           image: ${etcd_operator_image}
           name: etcd-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists


### PR DESCRIPTION
All system components are sitting on master nodes.
However, etcd operator was somehow dismissed for that.