### PR TITLE
Prometheus requires security group rule to access etcd from workers

### DIFF
--- a/modules/aws/vpc/sg-master.tf
+++ b/modules/aws/vpc/sg-master.tf
@@ -167,6 +167,16 @@ resource "aws_security_group_rule" "master_ingress_etcd" {
   self      = true
 }
 
+resource "aws_security_group_rule" "master_ingress_etcd_from_workers" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol                 = "tcp"
+  from_port                = 2379
+  to_port                  = 2379
+  source_security_group_id = "${aws_security_group.worker.id}"
+}
+
 resource "aws_security_group_rule" "master_ingress_bootstrap_etcd" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"


### PR DESCRIPTION
This changes allows Prometheus running on a worker to scrape etcd.
/cc: @brancz 

required by:
https://github.com/coreos-inc/tectonic-prometheus-operator/pull/49
https://github.com/coreos/tectonic-installer/issues/579