### PR TITLE
AWS: Support bringing your own IAM policy

### DIFF
--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -95,3 +95,9 @@ variable "root_volume_iops" {
   default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
+
+variable "external_master_arn" {
+  type        = "string"
+  default     = ""
+  description = "Instance Profile ARNs value of Master IAM"
+}

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -63,3 +63,9 @@ variable "root_volume_iops" {
   default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
+
+variable "external_worker_arn" {
+  type        = "string"
+  default     = ""
+  description = "Instance Profile ARNs value of Worker IAM"
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -117,9 +117,10 @@ module "masters" {
   autoscaling_group_extra_tags = "${var.tectonic_autoscaling_group_extra_tags}"
   custom_dns_name              = "${var.tectonic_dns_name}"
 
-  root_volume_type = "${var.tectonic_aws_master_root_volume_type}"
-  root_volume_size = "${var.tectonic_aws_master_root_volume_size}"
-  root_volume_iops = "${var.tectonic_aws_master_root_volume_iops}"
+  root_volume_type    = "${var.tectonic_aws_master_root_volume_type}"
+  root_volume_size    = "${var.tectonic_aws_master_root_volume_size}"
+  root_volume_iops    = "${var.tectonic_aws_master_root_volume_iops}"
+  external_master_arn = "${var.tectonic_aws_external_master_arn}"
 }
 
 module "ignition-workers" {
@@ -152,7 +153,8 @@ module "workers" {
   extra_tags                   = "${var.tectonic_aws_extra_tags}"
   autoscaling_group_extra_tags = "${var.tectonic_autoscaling_group_extra_tags}"
 
-  root_volume_type = "${var.tectonic_aws_worker_root_volume_type}"
-  root_volume_size = "${var.tectonic_aws_worker_root_volume_size}"
-  root_volume_iops = "${var.tectonic_aws_worker_root_volume_iops}"
+  root_volume_type    = "${var.tectonic_aws_worker_root_volume_type}"
+  root_volume_size    = "${var.tectonic_aws_worker_root_volume_size}"
+  root_volume_iops    = "${var.tectonic_aws_worker_root_volume_iops}"
+  external_worker_arn = "${var.tectonic_aws_external_worker_arn}"
 }

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -214,3 +214,23 @@ variable "tectonic_aws_region" {
   default     = "eu-west-1"
   description = "The target AWS region for the cluster."
 }
+
+variable "tectonic_aws_external_master_arn" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(optional) Instance Profile ARNs to use for Master AutoScalingGroup instances. If variable is provided Master ASG will use an existing IAM Role. By default roles and
+role policies will be created unless variable is provided. Example: `"arn:aws:iam::982404467199:instance-profile/demo-cluster-master-profile"`
+EOF
+}
+
+variable "tectonic_aws_external_worker_arn" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(optional) Instance Profile ARNs to use for Worker AutoScalingGroup instances. If variable is provided Worker ASG will use an existing IAM Role. By default roles and
+role policies will be created unless variable is provided. Example: `"arn:aws:iam::982404467199:instance-profile/demo-cluster-worker-profile"`
+EOF
+}


### PR DESCRIPTION
New variables `tectonic_aws_external_worker_arn` and `tectonic_aws_external_master_arn` allow users to bring in their own IAM Roles. 
Fixes: https://github.com/coreos/tectonic-installer/issues/666

/cc: @metral , @joshrosso 