### PR TITLE
platforms/aws: use element() instead of indexing

### DIFF
--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -3,11 +3,11 @@ data "ignition_config" "etcd" {
 
   systemd = [
     "${data.ignition_systemd_unit.locksmithd.id}",
-    "${data.ignition_systemd_unit.etcd3.*.id[count.index]}",
+    "${element(data.ignition_systemd_unit.etcd3.*.id, count.index)}",
   ]
 
   files = [
-    "${data.ignition_file.node_hostname.*.id[count.index]}",
+    "${element(data.ignition_file.node_hostname.*.id, count.index)}",
   ]
 }
 


### PR DESCRIPTION
This allows us to destroy clusters, but I'm not sure how safe it is :-/