### PR TITLE
tectonic: parametrize missing images

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -60,6 +60,7 @@ variable "tectonic_container_images" {
     awscli                          = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
     kube_version                    = "quay.io/coreos/kube-version:0.1.0"
     tectonic_etcd_operator          = "quay.io/coreos/tectonic-etcd-operator:v0.0.1"
+    pod_infra_image                 = "gcr.io/google_containers/pause-amd64:3.0"
   }
 }
 

--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -42,6 +42,7 @@ data "template_file" "kubelet" {
     node_label             = "${var.kubelet_node_label}"
     node_taints_param      = "${var.kubelet_node_taints != "" ? "--register-with-taints=${var.kubelet_node_taints}" : ""}"
     kubeconfig_s3_location = "${var.kubeconfig_s3_location}"
+    pod_infra_image        = "${var.container_images["pod_infra_image"]}"
   }
 }
 

--- a/modules/aws/ignition/resources/services/kubelet.service
+++ b/modules/aws/ignition/resources/services/kubelet.service
@@ -34,7 +34,8 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster-domain=cluster.local \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
-  --cloud-provider=aws
+  --cloud-provider=aws \
+  --pod-infra-container-image={{.pod_infra_image}}
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
 
 Restart=always

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -38,7 +38,7 @@ resource "template_dir" "tectonic" {
     alertmanager_version           = "${var.versions["alertmanager"]}"
     tectonic_version               = "${var.versions["tectonic"]}"
     etcd_version                   = "${var.versions["etcd"]}"
-    tectonic_etcd_operator_version = "${element(split(":", var.container_images["tectonic_etcd_operator"]), 1)}"
+    tectonic_etcd_operator_version = "${replace(var.container_images["tectonic_etcd_operator"],var.image_re,"$2")}"
 
     etcd_cluster_size = "${var.master_count > 2 ? 3 : 1}"
 
@@ -89,6 +89,8 @@ resource "template_dir" "tectonic" {
     certificates_strategy    = "${var.ca_generated == "true" ? "installerGeneratedCA" : "userProvidedCA"}"
     identity_api_service     = "${var.identity_api_service}"
     tectonic_updater_enabled = "${var.experimental ? "true" : "false"}"
+
+    image_re = "${var.image_re}"
   }
 }
 

--- a/modules/tectonic/resources/manifests/monitoring/alertmanager.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/alertmanager.yaml
@@ -8,7 +8,7 @@ metadata:
     alertmanager: main
 spec:
   replicas: 2
-  baseImage: ${element(split(":",alertmanager_image),0)}
+  baseImage: ${replace(alertmanager_image,image_re,"$1")}
   version: ${alertmanager_version}
   externalUrl: ${prometheus_external_url}
   resources:

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
@@ -8,7 +8,7 @@ metadata:
     prometheus: k8s
 spec:
   replicas: 1
-  baseImage: ${element(split(":",prometheus_image),0)}
+  baseImage: ${replace(prometheus_image,image_re,"$1")}
   version: ${prometheus_version}
   externalUrl: ${prometheus_external_url}
   serviceAccountName: prometheus-k8s

--- a/modules/tectonic/resources/manifests/updater/container-linux-update-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/container-linux-update-operator.yaml
@@ -22,6 +22,8 @@ spec:
         image: ${container_linux_update_operator_image}
         command:
         - "/bin/update-operator"
+        - "-agent-image-repo"
+        - ${replace(container_linux_update_operator_image,image_re,"$1")}
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -6,12 +6,12 @@ metadata:
 data:
   config.yaml: |+
     prometheusOperator:
-      baseImage: ${element(split(":",prometheus_operator_image),0)}
-      prometheusConfigReloaderBaseImage: ${element(split(":",prometheus_config_reload_image),0)}
-      configReloaderBaseImage: ${element(split(":",config_reload_image),0)}
+      baseImage: ${replace(prometheus_operator_image,image_re,"$1")}
+      prometheusConfigReloaderBaseImage: ${replace(prometheus_config_reload_image,image_re,"$1")}
+      configReloaderBaseImage: ${replace(config_reload_image,image_re,"$1")}
     prometheusK8s:
-      baseImage: ${element(split(":",prometheus_image),0)}
+      baseImage: ${replace(prometheus_image,image_re,"$1")}
     alertmanagerMain:
-      baseImage: ${element(split(":",alertmanager_image),0)}
+      baseImage: ${replace(alertmanager_image,image_re,"$1")}
     ingress:
       baseAddress: ${console_base_address}

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -117,3 +117,11 @@ variable "stats_url" {
   description = "The statistics collection URL to which to report."
   type        = "string"
 }
+
+variable "image_re" {
+  description = <<EOF
+(internal) Regular expression used to extract repo and tag components from image strings
+EOF
+
+  type = "string"
+}

--- a/modules/update-payload/assets.tf
+++ b/modules/update-payload/assets.tf
@@ -27,6 +27,6 @@ resource "template_dir" "upload_payload" {
     kubernetes_version             = "${var.tectonic_versions["kubernetes"]}"
     monitoring_version             = "${var.tectonic_versions["monitoring"]}"
     tectonic_version               = "${var.tectonic_versions["tectonic"]}"
-    tectonic_etcd_operator_version = "${element(split(":", var.tectonic_container_images["tectonic_etcd_operator"]), 1)}"
+    tectonic_etcd_operator_version = "${replace(var.tectonic_container_images["tectonic_etcd_operator"],var.tectonic_image_re,"$2")}"
   }
 }

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -76,6 +76,8 @@ module "tectonic" {
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
+
+  image_re = "${var.tectonic_image_re}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -63,6 +63,8 @@ module "tectonic" {
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
+
+  image_re = "${var.tectonic_image_re}"
 }
 
 resource "null_resource" "tectonic" {

--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -85,7 +85,8 @@ systemd:
           --node-labels=node-role.kubernetes.io/master \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns={{.k8s_dns_service_ip}} \
-          --cluster_domain=cluster.local
+          --cluster_domain=cluster.local \
+          --pod-infra-container-image={{.pod_infra_image}}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -74,7 +74,8 @@ systemd:
           --hostname-override={{.domain_name}} \
           --node-labels=node-role.kubernetes.io/node \
           --cluster_dns={{.k8s_dns_service_ip}} \
-          --cluster_domain=cluster.local
+          --cluster_domain=cluster.local \
+          --pod-infra-container-image={{.pod_infra_image}}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
         Restart=always
         RestartSec=5

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -53,6 +53,9 @@ resource "matchbox_group" "controller" {
     etcd_image_tag    = "v${var.tectonic_versions["etcd"]}"
     kubelet_image_url = "${replace(var.tectonic_container_images["hyperkube"],var.tectonic_image_re,"$1")}"
     kubelet_image_tag = "${replace(var.tectonic_container_images["hyperkube"],var.tectonic_image_re,"$2")}"
+
+    # custom pause container image
+    pod_infra_image = "${var.tectonic_container_images["pod_infra_image"]}"
   }
 }
 
@@ -75,5 +78,8 @@ resource "matchbox_group" "worker" {
     kubelet_image_url  = "${replace(var.tectonic_container_images["hyperkube"],var.tectonic_image_re,"$1")}"
     kubelet_image_tag  = "${replace(var.tectonic_container_images["hyperkube"],var.tectonic_image_re,"$2")}"
     kube_version_image = "${var.tectonic_container_images["kube_version"]}"
+
+    # custom pause container image
+    pod_infra_image = "${var.tectonic_container_images["pod_infra_image"]}"
   }
 }

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -77,6 +77,8 @@ module "tectonic" {
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${length(var.tectonic_metal_controller_names)}"
   stats_url         = "${var.tectonic_stats_url}"
+
+  image_re = "${var.tectonic_image_re}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -76,6 +76,8 @@ module "tectonic" {
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
+
+  image_re = "${var.tectonic_image_re}"
 }
 
 module "etcd" {

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -77,6 +77,8 @@ module "tectonic" {
 
   master_count = "${var.tectonic_master_count}"
   stats_url    = "${var.tectonic_stats_url}"
+
+  image_re = "${var.tectonic_image_re}"
 }
 
 data "null_data_source" "local" {

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -71,6 +71,8 @@ module "tectonic" {
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
+
+  image_re = "${var.tectonic_image_re}"
 }
 
 data "archive_file" "assets" {


### PR DESCRIPTION
From work in the field on offline installs, we've found these four images were not configurable via terraform.

\cc @alekssaul @coresolve 