### PR TITLE
Implement BYO node IAM roles

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -22,6 +22,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_master_custom_subnets | (optional) This configures master availability zones and their corresponding subnet CIDRs directly.<br><br>Example: `{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }` | map | `<map>` |
 | tectonic_aws_master_ec2_type | Instance size for the master node(s). Example: `t2.medium`. | string | `t2.medium` |
 | tectonic_aws_master_extra_sg_ids | (optional) List of additional security group IDs for master nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
+| tectonic_aws_master_iam_role_name | (optional) Name of IAM role to use for the instance profiles of master nodes. The name is also the last part of a role's ARN.<br><br>Example:  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer  * Role Name = tectonic-installer | string | `` |
 | tectonic_aws_master_root_volume_iops | The amount of provisioned IOPS for the root block device of master nodes. | string | `100` |
 | tectonic_aws_master_root_volume_size | The size of the volume in gigabytes for the root block device of master nodes. | string | `30` |
 | tectonic_aws_master_root_volume_type | The type of volume for the root block device of master nodes. | string | `gp2` |
@@ -31,6 +32,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_worker_custom_subnets | (optional) This configures worker availability zones and their corresponding subnet CIDRs directly.<br><br>Example: `{ eu-west-1a = "10.0.64.0/20", eu-west-1b = "10.0.80.0/20" }` | map | `<map>` |
 | tectonic_aws_worker_ec2_type | Instance size for the worker node(s). Example: `t2.medium`. | string | `t2.medium` |
 | tectonic_aws_worker_extra_sg_ids | (optional) List of additional security group IDs for worker nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
+| tectonic_aws_worker_iam_role_name | (optional) Name of IAM role to use for the instance profiles of worker nodes. The name is also the last part of a role's ARN.<br><br>Example:  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer  * Role Name = tectonic-installer | string | `` |
 | tectonic_aws_worker_root_volume_iops | The amount of provisioned IOPS for the root block device of worker nodes. | string | `100` |
 | tectonic_aws_worker_root_volume_size | The size of the volume in gigabytes for the root block device of worker nodes. | string | `30` |
 | tectonic_aws_worker_root_volume_type | The type of volume for the root block device of worker nodes. | string | `gp2` |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -79,6 +79,14 @@ tectonic_aws_master_ec2_type = "t2.medium"
 // Example: `["sg-51530134", "sg-b253d7cc"]`
 // tectonic_aws_master_extra_sg_ids = ""
 
+// (optional) Name of IAM role to use for the instance profiles of master nodes.
+// The name is also the last part of a role's ARN.
+// 
+// Example:
+//  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
+//  * Role Name = tectonic-installer
+// tectonic_aws_master_iam_role_name = ""
+
 // The amount of provisioned IOPS for the root block device of master nodes.
 tectonic_aws_master_root_volume_iops = "100"
 
@@ -110,6 +118,14 @@ tectonic_aws_worker_ec2_type = "t2.medium"
 // 
 // Example: `["sg-51530134", "sg-b253d7cc"]`
 // tectonic_aws_worker_extra_sg_ids = ""
+
+// (optional) Name of IAM role to use for the instance profiles of worker nodes.
+// The name is also the last part of a role's ARN.
+// 
+// Example:
+//  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
+//  * Role Name = tectonic-installer
+// tectonic_aws_worker_iam_role_name = ""
 
 // The amount of provisioned IOPS for the root block device of worker nodes.
 tectonic_aws_worker_root_volume_iops = "100"

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -99,3 +99,9 @@ variable "root_volume_iops" {
   default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
+
+variable "master_iam_role" {
+  type        = "string"
+  default     = ""
+  description = "IAM role to use for the instance profiles of master nodes."
+}

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -67,3 +67,9 @@ variable "root_volume_iops" {
   default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
+
+variable "worker_iam_role" {
+  type        = "string"
+  default     = ""
+  description = "IAM role to use for the instance profiles of worker nodes."
+}

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -81,12 +81,22 @@ resource "aws_autoscaling_group" "workers" {
 
 resource "aws_iam_instance_profile" "worker_profile" {
   name = "${var.cluster_name}-worker-profile"
-  role = "${aws_iam_role.worker_role.name}"
+
+  role = "${var.worker_iam_role == "" ? 
+    join("|", aws_iam_role.worker_role.*.name) : 
+    join("|", data.aws_iam_role.worker_role.*.role_name)
+  }"
+}
+
+data "aws_iam_role" "worker_role" {
+  count     = "${var.worker_iam_role == "" ? 0 : 1}"
+  role_name = "${var.worker_iam_role}"
 }
 
 resource "aws_iam_role" "worker_role" {
-  name = "${var.cluster_name}-worker-role"
-  path = "/"
+  count = "${var.worker_iam_role == "" ? 1 : 0}"
+  name  = "${var.cluster_name}-worker-role"
+  path  = "/"
 
   assume_role_policy = <<EOF
 {
@@ -106,8 +116,9 @@ EOF
 }
 
 resource "aws_iam_role_policy" "worker_policy" {
-  name = "${var.cluster_name}_worker_policy"
-  role = "${aws_iam_role.worker_role.id}"
+  count = "${var.worker_iam_role == "" ? 1 : 0}"
+  name  = "${var.cluster_name}_worker_policy"
+  role  = "${aws_iam_role.worker_role.id}"
 
   policy = <<EOF
 {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -99,7 +99,7 @@ module "masters" {
   instance_count  = "${var.tectonic_master_count}"
   ec2_type        = "${var.tectonic_aws_master_ec2_type}"
   cluster_name    = "${var.tectonic_cluster_name}"
-  master_iam_role = "${var.tectonic_aws_master_iam_role}"
+  master_iam_role = "${var.tectonic_aws_master_iam_role_name}"
 
   subnet_ids = ["${module.vpc.master_subnet_ids}"]
 
@@ -145,7 +145,7 @@ module "workers" {
   instance_count  = "${var.tectonic_worker_count}"
   ec2_type        = "${var.tectonic_aws_worker_ec2_type}"
   cluster_name    = "${var.tectonic_cluster_name}"
-  worker_iam_role = "${var.tectonic_aws_worker_iam_role}"
+  worker_iam_role = "${var.tectonic_aws_worker_iam_role_name}"
 
   vpc_id     = "${module.vpc.vpc_id}"
   subnet_ids = ["${module.vpc.worker_subnet_ids}"]

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -96,9 +96,10 @@ module "ignition-masters" {
 module "masters" {
   source = "../../modules/aws/master-asg"
 
-  instance_count = "${var.tectonic_master_count}"
-  ec2_type       = "${var.tectonic_aws_master_ec2_type}"
-  cluster_name   = "${var.tectonic_cluster_name}"
+  instance_count  = "${var.tectonic_master_count}"
+  ec2_type        = "${var.tectonic_aws_master_ec2_type}"
+  cluster_name    = "${var.tectonic_cluster_name}"
+  master_iam_role = "${var.tectonic_aws_master_iam_role}"
 
   subnet_ids = ["${module.vpc.master_subnet_ids}"]
 
@@ -141,9 +142,10 @@ module "ignition-workers" {
 module "workers" {
   source = "../../modules/aws/worker-asg"
 
-  instance_count = "${var.tectonic_worker_count}"
-  ec2_type       = "${var.tectonic_aws_worker_ec2_type}"
-  cluster_name   = "${var.tectonic_cluster_name}"
+  instance_count  = "${var.tectonic_worker_count}"
+  ec2_type        = "${var.tectonic_aws_worker_ec2_type}"
+  cluster_name    = "${var.tectonic_cluster_name}"
+  worker_iam_role = "${var.tectonic_aws_worker_iam_role}"
 
   vpc_id     = "${module.vpc.vpc_id}"
   subnet_ids = ["${module.vpc.worker_subnet_ids}"]

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -239,3 +239,15 @@ variable "tectonic_aws_region" {
   default     = "eu-west-1"
   description = "The target AWS region for the cluster."
 }
+
+variable "tectonic_aws_master_iam_role" {
+  type        = "string"
+  default     = ""
+  description = "IAM role to use for the instance profiles of master nodes."
+}
+
+variable "tectonic_aws_worker_iam_role" {
+  type        = "string"
+  default     = ""
+  description = "IAM role to use for the instance profiles of worker nodes."
+}

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -240,14 +240,30 @@ variable "tectonic_aws_region" {
   description = "The target AWS region for the cluster."
 }
 
-variable "tectonic_aws_master_iam_role" {
-  type        = "string"
-  default     = ""
-  description = "IAM role to use for the instance profiles of master nodes."
+variable "tectonic_aws_master_iam_role_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(optional) Name of IAM role to use for the instance profiles of master nodes.
+The name is also the last part of a role's ARN.
+
+Example:
+ * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
+ * Role Name = tectonic-installer
+EOF
 }
 
-variable "tectonic_aws_worker_iam_role" {
-  type        = "string"
-  default     = ""
-  description = "IAM role to use for the instance profiles of worker nodes."
+variable "tectonic_aws_worker_iam_role_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(optional) Name of IAM role to use for the instance profiles of worker nodes.
+The name is also the last part of a role's ARN.
+
+Example:
+ * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
+ * Role Name = tectonic-installer
+EOF
 }


### PR DESCRIPTION
This change allows users to specify their own external IAM role names for use as instance profiles on master and worker nodes.

Fixes #666 

/cc: @robszumski 