### PR TITLE
Bump bootkube v0.4.4 & hyperkube v1.6.4_coreos.0

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -18,7 +18,7 @@ variable "tectonic_container_images" {
   default = {
     hyperkube                       = "quay.io/coreos/hyperkube:v1.6.2_coreos.0"
     pod_checkpointer                = "quay.io/coreos/pod-checkpointer:2cad4cac4186611a79de1969e3ea4924f02f459e"
-    bootkube                        = "quay.io/coreos/bootkube:v0.4.2"
+    bootkube                        = "quay.io/coreos/bootkube:v0.4.4"
     console                         = "quay.io/coreos/tectonic-console:v1.5.6"
     identity                        = "quay.io/coreos/dex:v2.4.1"
     container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.0"

--- a/config.tf
+++ b/config.tf
@@ -16,7 +16,7 @@ variable "tectonic_container_images" {
   type        = "map"
 
   default = {
-    hyperkube                       = "quay.io/coreos/hyperkube:v1.6.2_coreos.0"
+    hyperkube                       = "quay.io/coreos/hyperkube:v1.6.4_coreos.0"
     pod_checkpointer                = "quay.io/coreos/pod-checkpointer:2cad4cac4186611a79de1969e3ea4924f02f459e"
     bootkube                        = "quay.io/coreos/bootkube:v0.4.4"
     console                         = "quay.io/coreos/tectonic-console:v1.5.6"

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -8,6 +8,7 @@ mkdir -p /etc/kubernetes/manifests/
 
 # Move optional experimental manifests into bootkube friendly locations
 [ -d /opt/tectonic/experimental ] && mv /opt/tectonic/experimental/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/experimental
+[ -d /opt/tectonic/etcd-experimental ] && mv /opt/tectonic/etcd-experimental /opt/tectonic/etcd
 [ -d /opt/tectonic/bootstrap-experimental ] && mv /opt/tectonic/bootstrap-experimental/* /opt/tectonic/bootstrap-manifests/ && rm -r /opt/tectonic/bootstrap-experimental
 
 /usr/bin/rkt run \

--- a/modules/bootkube/resources/experimental/bootstrap-manifests/bootstrap-etcd.yaml
+++ b/modules/bootkube/resources/experimental/bootstrap-manifests/bootstrap-etcd.yaml
@@ -14,16 +14,11 @@ spec:
     - --name=boot-etcd
     - --listen-client-urls=http://0.0.0.0:12379
     - --listen-peer-urls=http://0.0.0.0:12380
-    - --advertise-client-urls=http://$(MY_POD_IP):12379
-    - --initial-advertise-peer-urls=http://$(MY_POD_IP):12380
-    - --initial-cluster=boot-etcd=http://$(MY_POD_IP):12380
+    - --advertise-client-urls=http://${bootstrap_etcd_service_ip}:12379
+    - --initial-advertise-peer-urls=http://${bootstrap_etcd_service_ip}:12380
+    - --initial-cluster=boot-etcd=http://${bootstrap_etcd_service_ip}:12380
     - --initial-cluster-token=bootkube
     - --initial-cluster-state=new
     - --data-dir=/var/etcd/data
-    env:
-      - name: MY_POD_IP
-        valueFrom:
-          fieldRef:
-            fieldPath: status.podIP
   hostNetwork: true
   restartPolicy: Never

--- a/modules/bootkube/resources/experimental/etcd/bootstrap-etcd-service.json
+++ b/modules/bootkube/resources/experimental/etcd/bootstrap-etcd-service.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "name": "bootstrap-etcd-service",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "selector": {
+      "k8s-app": "boot-etcd"
+    },
+    "clusterIP": "${bootstrap_etcd_service_ip}",
+    "ports": [
+      {
+        "name": "client",
+        "port": 12379,
+        "protocol": "TCP"
+      },
+      {
+        "name": "peers",
+        "port": 12380,
+        "protocol": "TCP"
+      }
+    ]
+  }
+}

--- a/modules/bootkube/resources/experimental/etcd/migrate-etcd-cluster.json
+++ b/modules/bootkube/resources/experimental/etcd/migrate-etcd-cluster.json
@@ -1,0 +1,27 @@
+{
+  "apiVersion": "etcd.coreos.com/v1beta1",
+  "kind": "Cluster",
+  "metadata": {
+    "name": "kube-etcd",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "size": 1,
+    "version": "v${etcd_version}",
+    "pod": {
+      "nodeSelector": {
+        "node-role.kubernetes.io/master": ""
+      },
+      "tolerations": [
+        {
+          "key": "node-role.kubernetes.io/master",
+          "operator": "Exists",
+          "effect": "NoSchedule"
+        }
+      ]
+    },
+    "selfHosted": {
+      "bootMemberClientEndpoint": "http://${bootstrap_etcd_service_ip}:12379"
+    }
+  }
+}

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -8,6 +8,10 @@ variable "kube_apiserver_url" {
   type        = "string"
 }
 
+variable "etcd_version" {
+  type = "string"
+}
+
 variable "etcd_endpoints" {
   description = "List of etcd endpoints to connect with (hostnames/IPs only)"
   type        = "list"

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -26,6 +26,7 @@ module "bootkube" {
   etcd_ca_cert         = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert     = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key      = "${var.tectonic_etcd_client_key_path}"
+  etcd_version         = "${var.tectonic_versions["etcd"]}"
   experimental_enabled = "${var.tectonic_experimental}"
 }
 


### PR DESCRIPTION
There was a change in bootkube where it now generates additional self-hosted etcd assets as part of the rendering step - so those assets have also been added here.