### PR TITLE
Provide masters access to s3:HeadObject and s3:ListBucket

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -142,7 +142,8 @@ resource "aws_iam_role_policy" "master_policy" {
     {
       "Action" : [
         "s3:GetObject",
-        "s3:HeadObject"
+        "s3:HeadObject",
+        "s3:ListBucket"
       ],
       "Resource": "arn:aws:s3:::*",
       "Effect": "Allow"

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -141,7 +141,8 @@ resource "aws_iam_role_policy" "master_policy" {
     },
     {
       "Action" : [
-        "s3:GetObject"
+        "s3:GetObject",
+        "s3:HeadObject"
       ],
       "Resource": "arn:aws:s3:::*",
       "Effect": "Allow"


### PR DESCRIPTION
Give masters access to s3:HeadObject to avoid 403 when key doesn't exist
within bucket (due to s3 propagation delays, details below).

Reasons for this are: @diegs and I were troubleshooting his cluster not coming up. We found the masters had a failed `init-assets.service`, logs gave us a 403 Permission Denied error on `aws s3 cp` for `HeadObject`. It turns out you get a 403 if a object's key (which is a file or directory) doesn't exist, and you don't have permissions to ListBucket/HeadObject, as mentioned in  mentioned in https://github.com/aws/aws-cli/issues/1689 and documented in https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html#rest-object-head-permissions

It's pretty hard to reproduce, as it seems to be due to the eventual consistency model in S3. This specific case is mentioned here here: https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyModel

I believe this is the relevant case:

> A process writes a new object to Amazon S3 and immediately lists keys within its bucket. Until the change is fully propagated, the object might not appear in the list.

We were able to restart the service and it downloaded all the assets fine.