### PR TITLE
azure: restore create_dns_zone and make use_custom_fqdn optional

### DIFF
--- a/Documentation/variables/azure.md
+++ b/Documentation/variables/azure.md
@@ -18,7 +18,7 @@ This document gives an overview of variables used in the Azure platform of the T
 | tectonic_azure_location |  | string | - |
 | tectonic_azure_master_vm_size | Instance size for the master node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |
 | tectonic_azure_ssh_key | Name of an Azure ssh key to use joe-sfo | string | - |
-| tectonic_azure_use_custom_fqdn | If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure. | string | `true` |
+| tectonic_azure_use_custom_fqdn | (optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure. | string | `false` |
 | tectonic_azure_vnet_cidr_block | Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute. | string | `10.0.0.0/16` |
 | tectonic_azure_worker_vm_size | Instance size for the worker node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |
 | tectonic_ssh_key |  | string | `` |

--- a/Documentation/variables/azure.md
+++ b/Documentation/variables/azure.md
@@ -7,6 +7,7 @@ This document gives an overview of variables used in the Azure platform of the T
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
 | tectonic_azure_config_version | (internal) This declares the version of the Azure configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
+| tectonic_azure_create_dns_zone | If set to true, create an Azure DNS zone | string | `true` |
 | tectonic_azure_dns_resource_group |  | string | `tectonic-dns-group` |
 | tectonic_azure_etcd_vm_size | Instance size for the etcd node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |
 | tectonic_azure_external_master_subnet_id | (optional) Subnet ID within an existing VNet to deploy master nodes into. Required to use an existing VNet.<br><br>Example: the subnet ID starts with `"/subscriptions/{subscriptionId}"` or `"/providers/{resourceProviderNamespace}"`. | string | `` |

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -10,6 +10,9 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
+// If set to true, create an Azure DNS zone
+tectonic_azure_create_dns_zone = true
+
 // 
 tectonic_azure_dns_resource_group = "tectonic-dns-group"
 

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -49,8 +49,8 @@ tectonic_azure_master_vm_size = "Standard_DS2_v2"
 // 
 tectonic_azure_ssh_key = ""
 
-// If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure.
-tectonic_azure_use_custom_fqdn = true
+// (optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure.
+// tectonic_azure_use_custom_fqdn = false
 
 // Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute.
 tectonic_azure_vnet_cidr_block = "10.0.0.0/16"

--- a/modules/azure/dns/etcd.tf
+++ b/modules/azure/dns/etcd.tf
@@ -6,5 +6,5 @@ resource "azurerm_dns_a_record" "etcd" {
   ttl     = "60"
   records = ["${var.etcd_ip_addresses}"]
 
-  count = "${var.use_custom_fqdn ? 1 : 0}"
+  count = "${var.create_dns_zone ? 1 : 0}"
 }

--- a/modules/azure/dns/main.tf
+++ b/modules/azure/dns/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_dns_zone" "tectonic_azure_dns_zone" {
   name                = "${var.base_domain}"
   resource_group_name = "${var.resource_group_name}"
-  count               = "${var.use_custom_fqdn ? 1 : 0}"
+  count               = "${var.create_dns_zone ? 1 : 0}"
 }

--- a/modules/azure/dns/master.tf
+++ b/modules/azure/dns/master.tf
@@ -6,7 +6,7 @@ resource "azurerm_dns_a_record" "tectonic-api" {
   ttl     = "60"
   records = ["${var.master_ip_addresses}"]
 
-  count = "${var.use_custom_fqdn ? 1 : 0}"
+  count = "${var.create_dns_zone ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "tectonic-console" {
@@ -17,7 +17,7 @@ resource "azurerm_dns_a_record" "tectonic-console" {
   ttl     = "60"
   records = ["${var.console_ip_address}"]
 
-  count = "${var.use_custom_fqdn ? 1 : 0}"
+  count = "${var.create_dns_zone ? 1 : 0}"
 }
 
 resource "azurerm_dns_a_record" "master_nodes" {
@@ -28,5 +28,5 @@ resource "azurerm_dns_a_record" "master_nodes" {
   ttl     = "59"
   records = ["${var.master_ip_addresses}"]
 
-  count = "${var.use_custom_fqdn ? 1 : 0}"
+  count = "${var.create_dns_zone ? 1 : 0}"
 }

--- a/modules/azure/dns/variables.tf
+++ b/modules/azure/dns/variables.tf
@@ -30,6 +30,6 @@ variable "etcd_ip_addresses" {
   type = "list"
 }
 
-variable "use_custom_fqdn" {
+variable "create_dns_zone" {
   default = true
 }

--- a/modules/azure/master/variables.tf
+++ b/modules/azure/master/variables.tf
@@ -90,5 +90,5 @@ variable "tectonic_service_disabled" {
 }
 
 variable "use_custom_fqdn" {
-  default = true
+  default = false
 }

--- a/platforms/azure/dns-todo/worker.tf
+++ b/platforms/azure/dns-todo/worker.tf
@@ -6,5 +6,5 @@ resource "azurerm_dns_a_record" "worker_nodes" {
   name    = "${var.tectonic_cluster_name}-worker-${count.index}"
   ttl     = "59"
   records = ["${azurerm_public_ip.worker_node.ip_address[count.index]}"]
-  count   = "${var.use_custom_fqdn ? 1 : 0}"
+  count   = "${var.create_dns_zone ? 1 : 0}"
 }

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -97,7 +97,7 @@ module "dns" {
   location            = "${var.tectonic_azure_location}"
   resource_group_name = "${var.tectonic_azure_dns_resource_group}"
 
-  use_custom_fqdn = "${var.tectonic_azure_use_custom_fqdn}"
+  create_dns_zone = "${var.tectonic_azure_create_dns_zone}"
 
   // TODO etcd list
   // TODO worker list

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -86,6 +86,11 @@ variable "tectonic_azure_external_vnet_name" {
   description = "Pre-existing virtual network to create cluster into."
 }
 
+variable "tectonic_azure_create_dns_zone" {
+  description = "If set to true, create an Azure DNS zone"
+  default     = true
+}
+
 variable "tectonic_azure_use_custom_fqdn" {
   description = "(optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure."
   default     = false

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -87,8 +87,8 @@ variable "tectonic_azure_external_vnet_name" {
 }
 
 variable "tectonic_azure_use_custom_fqdn" {
-  description = "If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure."
-  default     = true
+  description = "(optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure."
+  default     = false
 }
 
 variable "tectonic_azure_external_master_subnet_id" {


### PR DESCRIPTION
This PR fixes the following issues introduced in https://github.com/coreos/tectonic-installer/pull/417 and https://github.com/coreos/tectonic-installer/pull/602, which replaced `create_dns_zone` with `use_custom_fqdn` and changed the default value of `use_custom_fqdn`:

- If `use_custom_fqdn` was `false` a DNS Zone would not be created
- If `user_custom_fqdn` was `true`, which was the default, it would destroy an existing DNS zone whether the user intended it or not, as it took the place of `create_dns_zone` in the logic of the DNS module.

This PR restores `create_dns_zone` and limits its use to the DNS module, and limits `use_custom_fqdn` to the Master module, creating the ability to configure both if desired, and separating the use cases out as independent variables. 