### PR TITLE
platforms/openstack: Don’t create console DNS on vanilla

### DIFF
--- a/platforms/openstack/neutron/dns.tf
+++ b/platforms/openstack/neutron/dns.tf
@@ -13,6 +13,7 @@ resource "aws_route53_record" "tectonic-api" {
 }
 
 resource "aws_route53_record" "tectonic-console" {
+  count   = "${var.tectonic_vanilla_k8s ? 0 : 1}"
   zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
   name    = "${var.tectonic_cluster_name}"
   type    = "A"

--- a/platforms/openstack/nova/dns.tf
+++ b/platforms/openstack/nova/dns.tf
@@ -13,6 +13,7 @@ resource "aws_route53_record" "tectonic-api" {
 }
 
 resource "aws_route53_record" "tectonic-console" {
+  count   = "${var.tectonic_vanilla_k8s ? 0 : 1}"
   zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
   name    = "${var.tectonic_cluster_name}"
   type    = "A"


### PR DESCRIPTION
Only create a DNS record for the Tectonic console if
tectonic_vanilla_k8s=false.