### PR TITLE
Change many components to run as user 'nobody'.

### DIFF
--- a/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
+++ b/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
@@ -26,6 +26,9 @@ spec:
           name: etcd-operator
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       tolerations:
       - key: node-role.kubernetes.io/master
         operator: Exists

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -58,14 +58,17 @@ spec:
         - name: ssl-host
           mountPath: /etc/ssl/certs
           readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       volumes:
       - name: secrets
         secret:

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -45,11 +45,14 @@ spec:
             port: 10251  # Note: Using default port. Update if --port option is set differently.
           initialDelaySeconds: 15
           timeoutSeconds: 15
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"
-      nodeSelector:
-        node-role.kubernetes.io/master: ""

--- a/modules/tectonic/resources/manifests/identity/deployment.yaml
+++ b/modules/tectonic/resources/manifests/identity/deployment.yaml
@@ -66,3 +66,6 @@ spec:
       # private registry.
       imagePullSecrets:
       - name: coreos-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-operator.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-operator.yaml
@@ -28,3 +28,6 @@ spec:
            limits:
              cpu: 200m
              memory: 300Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/modules/tectonic/resources/manifests/stats-emitter.yaml
+++ b/modules/tectonic/resources/manifests/stats-emitter.yaml
@@ -133,3 +133,6 @@ spec:
         emptyDir: {}
       imagePullSecrets:
       - name: coreos-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/modules/tectonic/resources/manifests/updater/kube-version-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/kube-version-operator.yaml
@@ -22,3 +22,6 @@ spec:
         image: ${kube_version_operator_image}
       imagePullSecrets:
       - name: coreos-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534

--- a/modules/tectonic/resources/manifests/updater/tectonic-channel-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-channel-operator.yaml
@@ -39,6 +39,9 @@ spec:
       restartPolicy: Always
       imagePullSecrets:
       - name: coreos-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       volumes:
       - name: certs
         hostPath:

--- a/modules/tectonic/resources/manifests/updater/tectonic-prometheus-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-prometheus-operator.yaml
@@ -31,6 +31,9 @@ spec:
             cpu: 20m
             memory: 50Mi
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       terminationGracePeriodSeconds: 30
       imagePullSecrets:
       - name: coreos-pull-secret


### PR DESCRIPTION
Affected components:
- Controller Manager
- Scheduler
- Stats
- KVO
- TCO
- Tectonic Prometheus Operator

Not updated:
- DNS
- Prometheus
- Tectonic etcd Operator
- CLUO (Operator, not agent)

Partially addresses #749.