### PR TITLE
*/openstack/nova: Add support for self-hosted etcd

### DIFF
--- a/modules/openstack/etcd/ignition.tf
+++ b/modules/openstack/etcd/ignition.tf
@@ -1,4 +1,6 @@
 data "ignition_config" "etcd" {
+  count = "${var.tectonic_experimental ? 0 : 1}"
+
   users = [
     "${data.ignition_user.core.id}",
   ]

--- a/modules/openstack/etcd/secgroup.tf
+++ b/modules/openstack/etcd/secgroup.tf
@@ -1,6 +1,7 @@
 resource "openstack_compute_secgroup_v2" "etcd" {
   name        = "${var.cluster_name}_etcd_group"
   description = "security group for etcd: SSH and etcd client / cluster"
+  count       = "${var.tectonic_experimental ? 0 : 1}"
 
   rule {
     from_port   = 22

--- a/modules/openstack/etcd/variables.tf
+++ b/modules/openstack/etcd/variables.tf
@@ -18,3 +18,7 @@ variable "container_image" {
 variable core_public_keys {
   type = "list"
 }
+
+variable "tectonic_experimental" {
+  default = false
+}

--- a/modules/openstack/nodes/output.tf
+++ b/modules/openstack/nodes/output.tf
@@ -2,10 +2,26 @@ output "user_data" {
   value = ["${data.ignition_config.node.*.rendered}"]
 }
 
-output "secgroup_name" {
+output "secgroup_master_name" {
+  value = "${openstack_compute_secgroup_v2.master.name}"
+}
+
+output "secgroup_master_id" {
+  value = "${openstack_compute_secgroup_v2.master.id}"
+}
+
+output "secgroup_node_name" {
   value = "${openstack_compute_secgroup_v2.node.name}"
 }
 
-output "secgroup_id" {
+output "secgroup_node_id" {
   value = "${openstack_compute_secgroup_v2.node.id}"
+}
+
+output "secgroup_self_hosted_etcd_name" {
+  value = "${openstack_compute_secgroup_v2.self_hosted_etcd.name}"
+}
+
+output "secgroup_self_hosted_etcd_id" {
+  value = "${openstack_compute_secgroup_v2.self_hosted_etcd.id}"
 }

--- a/modules/openstack/nodes/secgroup.tf
+++ b/modules/openstack/nodes/secgroup.tf
@@ -1,21 +1,9 @@
-resource "openstack_compute_secgroup_v2" "node" {
+resource "openstack_compute_secgroup_v2" "master" {
   name        = "${var.cluster_name}_${var.hostname_infix}"
-  description = "security group for k8s nodes: SSH and https"
+  description = "security group for k8s masters"
+  count       = "${var.hostname_infix == "master" ? 1 : 0}"
 
-  rule {
-    from_port   = 22
-    to_port     = 22
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 443
-    to_port     = 443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
+  // icmp
   rule {
     from_port   = -1
     to_port     = -1
@@ -23,6 +11,85 @@ resource "openstack_compute_secgroup_v2" "node" {
     cidr        = "0.0.0.0/0"
   }
 
+  // SSH
+  rule {
+    from_port   = 22
+    to_port     = 22
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // k8s API
+  rule {
+    from_port   = 443
+    to_port     = 443
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // cAdvisor
+  rule {
+    from_port   = 4194
+    to_port     = 4194
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // flannel overlay vxlan
+  rule {
+    from_port   = 8472
+    to_port     = 8472
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // kubelet API
+  rule {
+    from_port   = 10250
+    to_port     = 10250
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+}
+
+resource "openstack_compute_secgroup_v2" "node" {
+  name        = "${var.cluster_name}_${var.hostname_infix}"
+  description = "security group for k8s nodes"
+  count       = "${var.hostname_infix == "worker" ? 1 : 0}"
+
+  // ICMP
+  rule {
+    from_port   = -1
+    to_port     = -1
+    ip_protocol = "icmp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // SSH
+  rule {
+    from_port   = 22
+    to_port     = 22
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // k8s API
+  rule {
+    from_port   = 443
+    to_port     = 443
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // cAdvisor
+  rule {
+    from_port   = 4194
+    to_port     = 4194
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // flannel
   rule {
     from_port   = 4789
     to_port     = 4789
@@ -30,9 +97,49 @@ resource "openstack_compute_secgroup_v2" "node" {
     cidr        = "0.0.0.0/0"
   }
 
+  // flannel overlay vxlan
+  rule {
+    from_port   = 8472
+    to_port     = 8472
+    ip_protocol = "udp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // kubelet API
   rule {
     from_port   = 10250
     to_port     = 10250
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // External services
+  rule {
+    from_port   = 30000
+    to_port     = 32767
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+}
+
+resource "openstack_compute_secgroup_v2" "self_hosted_etcd" {
+  name        = "${var.cluster_name}_${var.hostname_infix}_self_hosted_etcd"
+  description = "security group for self hosted etcd"
+
+  count = "${var.tectonic_experimental ? 1 : 0}"
+
+  // etcd
+  rule {
+    from_port   = 2379
+    to_port     = 2380
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  // bootstrap etcd
+  rule {
+    from_port   = 12379
+    to_port     = 12380
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }

--- a/modules/openstack/nodes/variables.tf
+++ b/modules/openstack/nodes/variables.tf
@@ -57,3 +57,7 @@ variable "bootkube_service" {
 variable "tectonic_service" {
   type = "string"
 }
+
+variable "tectonic_experimental" {
+  default = false
+}

--- a/platforms/openstack/nova/dns.tf
+++ b/platforms/openstack/nova/dns.tf
@@ -44,6 +44,7 @@ resource "aws_route53_record" "worker_nodes" {
 
 resource "aws_route53_record" "etcd_srv_discover" {
   name    = "_etcd-server._tcp"
+  count   = "${var.tectonic_experimental ? 0 : 1}"
   type    = "SRV"
   records = ["${formatlist("0 0 2380 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
   ttl     = "300"
@@ -52,6 +53,7 @@ resource "aws_route53_record" "etcd_srv_discover" {
 
 resource "aws_route53_record" "etcd_srv_client" {
   name    = "_etcd-client._tcp"
+  count   = "${var.tectonic_experimental ? 0 : 1}"
   type    = "SRV"
   records = ["${formatlist("0 0 2379 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
   ttl     = "60"
@@ -59,7 +61,7 @@ resource "aws_route53_record" "etcd_srv_client" {
 }
 
 resource "aws_route53_record" "etc_a_nodes" {
-  count   = "${var.tectonic_etcd_count}"
+  count   = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
   type    = "A"
   ttl     = "60"
   name    = "${var.tectonic_cluster_name}-etcd-${count.index}"

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -23,6 +23,8 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
+  experimental_enabled = "${var.tectonic_experimental}"
+
   etcd_endpoints   = ["${openstack_compute_instance_v2.etcd_node.*.access_ip_v4}"]
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
@@ -79,10 +81,11 @@ nameserver 8.8.8.8
 nameserver 8.8.4.4
 EOF
 
-  base_domain      = "${var.tectonic_base_domain}"
-  cluster_name     = "${var.tectonic_cluster_name}"
-  container_image  = "${var.tectonic_container_images["etcd"]}"
-  core_public_keys = ["${module.secrets.core_public_key_openssh}"]
+  base_domain           = "${var.tectonic_base_domain}"
+  cluster_name          = "${var.tectonic_cluster_name}"
+  container_image       = "${var.tectonic_container_images["etcd"]}"
+  core_public_keys      = ["${module.secrets.core_public_key_openssh}"]
+  tectonic_experimental = "${var.tectonic_experimental}"
 }
 
 module "master_nodes" {
@@ -103,6 +106,7 @@ EOF
   core_public_keys             = ["${module.secrets.core_public_key_openssh}"]
   bootkube_service             = "${module.bootkube.systemd_service}"
   tectonic_service             = "${module.tectonic.systemd_service}"
+  tectonic_experimental        = "${var.tectonic_experimental}"
   hostname_infix               = "master"
   node_labels                  = "node-role.kubernetes.io/master"
   node_taints                  = "node-role.kubernetes.io/master=:NoSchedule"

--- a/platforms/openstack/nova/nodes.tf
+++ b/platforms/openstack/nova/nodes.tf
@@ -1,9 +1,13 @@
 resource "openstack_compute_instance_v2" "master_node" {
-  count           = "${var.tectonic_master_count}"
-  name            = "${var.tectonic_cluster_name}_master_node_${count.index}"
-  image_id        = "${var.tectonic_openstack_image_id}"
-  flavor_id       = "${var.tectonic_openstack_flavor_id}"
-  security_groups = ["${module.master_nodes.secgroup_name}"]
+  count     = "${var.tectonic_master_count}"
+  name      = "${var.tectonic_cluster_name}_master_node_${count.index}"
+  image_id  = "${var.tectonic_openstack_image_id}"
+  flavor_id = "${var.tectonic_openstack_flavor_id}"
+
+  security_groups = [
+    "${module.master_nodes.secgroup_master_name}",
+    "${module.master_nodes.secgroup_self_hosted_etcd_name}",
+  ]
 
   network {
     name = "${var.tectonic_openstack_network_name}"
@@ -22,7 +26,7 @@ resource "openstack_compute_instance_v2" "worker_node" {
   name            = "${var.tectonic_cluster_name}_worker_node_${count.index}"
   image_id        = "${var.tectonic_openstack_image_id}"
   flavor_id       = "${var.tectonic_openstack_flavor_id}"
-  security_groups = ["${module.worker_nodes.secgroup_name}"]
+  security_groups = ["${module.worker_nodes.secgroup_node_name}"]
 
   network {
     name = "${var.tectonic_openstack_network_name}"
@@ -37,7 +41,7 @@ resource "openstack_compute_instance_v2" "worker_node" {
 }
 
 resource "openstack_compute_instance_v2" "etcd_node" {
-  count           = "${var.tectonic_etcd_count}"
+  count           = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
   name            = "${var.tectonic_cluster_name}_etcd_node_${count.index}"
   image_id        = "${var.tectonic_openstack_image_id}"
   flavor_id       = "${var.tectonic_openstack_flavor_id}"


### PR DESCRIPTION
- Plumb tectonic_experimental flag through to openstack/nova
to conditionally enable self-hosted etcd
- Update security groups with conditional logic for self-hosted
and external etcd clusters
- Conditionally disable etcd DNS entries for self-hosted mode

/cc @s-urbaniak 