### PR TITLE
Update TCO version to 0.3.3

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -23,7 +23,7 @@ variable "tectonic_container_images" {
     identity                        = "quay.io/coreos/dex:v2.4.1"
     container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.0"
     kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.6.2"
-    tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.3.2"
+    tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.3.3"
     node_agent                      = "quay.io/coreos/node-agent:787844277099e8c10d617c3c807244fc9f873e46"
     prometheus_operator             = "quay.io/coreos/prometheus-operator:v0.9.1"
     tectonic_prometheus_operator    = "quay.io/coreos/tectonic-prometheus-operator:v1.2.0"


### PR DESCRIPTION
Enforces signing of payloads, see:

https://github.com/coreos-inc/tectonic-channel-operator/releases/tag/0.3.3

cc @marineam @yifan-gu @aaronlevy @derekparker 

Fixes #831