### PR TITLE
Replace all occurences of path.cwd

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -16,7 +16,7 @@ data "null_data_source" "etcd" {
 resource "template_dir" "experimental" {
   count           = "${var.experimental_enabled ? 1 : 0}"
   source_dir      = "${path.module}/resources/experimental/manifests"
-  destination_dir = "${path.cwd}/generated/experimental"
+  destination_dir = "./generated/experimental"
 
   vars {
     etcd_operator_image = "${var.container_images["etcd_operator"]}"
@@ -27,7 +27,7 @@ resource "template_dir" "experimental" {
 resource "template_dir" "bootstrap-experimental" {
   count           = "${var.experimental_enabled ? 1 : 0}"
   source_dir      = "${path.module}/resources/experimental/bootstrap-manifests"
-  destination_dir = "${path.cwd}/generated/bootstrap-experimental"
+  destination_dir = "./generated/bootstrap-experimental"
 
   vars {
     etcd_image                = "${var.container_images["etcd"]}"
@@ -39,7 +39,7 @@ resource "template_dir" "bootstrap-experimental" {
 resource "template_dir" "etcd-experimental" {
   count           = "${var.experimental_enabled ? 1 : 0}"
   source_dir      = "${path.module}/resources/experimental/etcd"
-  destination_dir = "${path.cwd}/generated/etcd"
+  destination_dir = "./generated/etcd"
 
   vars {
     etcd_version              = "${var.versions["etcd"]}"
@@ -50,7 +50,7 @@ resource "template_dir" "etcd-experimental" {
 # Self-hosted manifests (resources/generated/manifests/)
 resource "template_dir" "bootkube" {
   source_dir      = "${path.module}/resources/manifests"
-  destination_dir = "${path.cwd}/generated/manifests"
+  destination_dir = "./generated/manifests"
 
   vars {
     hyperkube_image        = "${var.container_images["hyperkube"]}"
@@ -112,7 +112,7 @@ resource "template_dir" "bootkube" {
 # Self-hosted bootstrapping manifests (resources/generated/manifests-bootstrap/)
 resource "template_dir" "bootkube-bootstrap" {
   source_dir      = "${path.module}/resources/bootstrap-manifests"
-  destination_dir = "${path.cwd}/generated/bootstrap-manifests"
+  destination_dir = "./generated/bootstrap-manifests"
 
   vars {
     hyperkube_image = "${var.container_images["hyperkube"]}"
@@ -141,19 +141,19 @@ resource "template_dir" "bootkube-bootstrap" {
 resource "local_file" "etcd_ca_crt" {
   count    = "${var.etcd_ca_cert == "" ? 0 : 1}"
   content  = "${file(var.etcd_ca_cert)}"
-  filename = "${path.cwd}/generated/tls/etcd-ca.crt"
+  filename = "./generated/tls/etcd-ca.crt"
 }
 
 resource "local_file" "etcd_client_crt" {
   count    = "${var.etcd_client_cert == "" ? 0 : 1}"
   content  = "${file(var.etcd_client_cert)}"
-  filename = "${path.cwd}/generated/tls/etcd-client.crt"
+  filename = "./generated/tls/etcd-client.crt"
 }
 
 resource "local_file" "etcd_client_key" {
   count    = "${var.etcd_client_key == "" ? 0 : 1}"
   content  = "${file(var.etcd_client_key)}"
-  filename = "${path.cwd}/generated/tls/etcd-client.key"
+  filename = "./generated/tls/etcd-client.key"
 }
 
 # kubeconfig (resources/generated/auth/kubeconfig)
@@ -170,7 +170,7 @@ data "template_file" "kubeconfig" {
 
 resource "local_file" "kubeconfig" {
   content  = "${data.template_file.kubeconfig.rendered}"
-  filename = "${path.cwd}/generated/auth/kubeconfig"
+  filename = "./generated/auth/kubeconfig"
 }
 
 # bootkube.sh (resources/generated/bootkube.sh)
@@ -184,7 +184,7 @@ data "template_file" "bootkube-sh" {
 
 resource "local_file" "bootkube-sh" {
   content  = "${data.template_file.bootkube-sh.rendered}"
-  filename = "${path.cwd}/generated/bootkube.sh"
+  filename = "./generated/bootkube.sh"
 }
 
 # bootkube.service (available as output variable)

--- a/modules/bootkube/assets_tls.tf
+++ b/modules/bootkube/assets_tls.tf
@@ -42,12 +42,12 @@ resource "tls_self_signed_cert" "kube-ca" {
 
 resource "local_file" "kube-ca-key" {
   content  = "${var.ca_cert == "" ? join(" ", tls_private_key.kube-ca.*.private_key_pem) : var.ca_key}"
-  filename = "${path.cwd}/generated/tls/ca.key"
+  filename = "./generated/tls/ca.key"
 }
 
 resource "local_file" "kube-ca-crt" {
   content  = "${var.ca_cert == "" ? join(" ", tls_self_signed_cert.kube-ca.*.cert_pem) : var.ca_cert}"
-  filename = "${path.cwd}/generated/tls/ca.crt"
+  filename = "./generated/tls/ca.crt"
 }
 
 # Kubernetes API Server (resources/generated/tls/{apiserver.key,apiserver.crt})
@@ -97,12 +97,12 @@ resource "tls_locally_signed_cert" "apiserver" {
 
 resource "local_file" "apiserver-key" {
   content  = "${tls_private_key.apiserver.private_key_pem}"
-  filename = "${path.cwd}/generated/tls/apiserver.key"
+  filename = "./generated/tls/apiserver.key"
 }
 
 resource "local_file" "apiserver-crt" {
   content  = "${tls_locally_signed_cert.apiserver.cert_pem}"
-  filename = "${path.cwd}/generated/tls/apiserver.crt"
+  filename = "./generated/tls/apiserver.crt"
 }
 
 # Kubernete's Service Account (resources/generated/tls/{service-account.key,service-account.pub})
@@ -113,12 +113,12 @@ resource "tls_private_key" "service-account" {
 
 resource "local_file" "service-account-key" {
   content  = "${tls_private_key.service-account.private_key_pem}"
-  filename = "${path.cwd}/generated/tls/service-account.key"
+  filename = "./generated/tls/service-account.key"
 }
 
 resource "local_file" "service-account-crt" {
   content  = "${tls_private_key.service-account.public_key_pem}"
-  filename = "${path.cwd}/generated/tls/service-account.pub"
+  filename = "./generated/tls/service-account.pub"
 }
 
 # Kubelet
@@ -156,10 +156,10 @@ resource "tls_locally_signed_cert" "kubelet" {
 
 resource "local_file" "kubelet-key" {
   content  = "${tls_private_key.kubelet.private_key_pem}"
-  filename = "${path.cwd}/generated/tls/kubelet.key"
+  filename = "./generated/tls/kubelet.key"
 }
 
 resource "local_file" "kubelet-crt" {
   content  = "${tls_locally_signed_cert.kubelet.cert_pem}"
-  filename = "${path.cwd}/generated/tls/kubelet.crt"
+  filename = "./generated/tls/kubelet.crt"
 }

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -6,7 +6,7 @@ resource "random_id" "cluster_id" {
 # Kubernetes Manifests (resources/generated/manifests/)
 resource "template_dir" "tectonic" {
   source_dir      = "${path.module}/resources/manifests"
-  destination_dir = "${path.cwd}/generated/tectonic"
+  destination_dir = "./generated/tectonic"
 
   vars {
     addon_resizer_image                   = "${var.container_images["addon_resizer"]}"
@@ -88,7 +88,7 @@ data "template_file" "tectonic" {
 
 resource "local_file" "tectonic" {
   content  = "${data.template_file.tectonic.rendered}"
-  filename = "${path.cwd}/generated/tectonic.sh"
+  filename = "./generated/tectonic.sh"
 }
 
 # tectonic.sh (resources/generated/tectonic-rkt.sh)
@@ -103,7 +103,7 @@ data "template_file" "tectonic-rkt" {
 
 resource "local_file" "tectonic-rkt" {
   content  = "${data.template_file.tectonic-rkt.rendered}"
-  filename = "${path.cwd}/generated/tectonic-rkt.sh"
+  filename = "./generated/tectonic-rkt.sh"
 }
 
 # tectonic.service (available as output variable)

--- a/modules/update-payload/assets.tf
+++ b/modules/update-payload/assets.tf
@@ -1,7 +1,7 @@
 # Kubernetes Deployments and AppVersions TPR used in the payload
 resource "template_dir" "upload_payload" {
   source_dir      = "../tectonic/resources/manifests/updater/"
-  destination_dir = "${path.cwd}/generated"
+  destination_dir = "./generated"
 
   vars {
     # Used variables for generating the payload,

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -65,7 +65,7 @@ module "tectonic" {
 
 data "archive_file" "assets" {
   type       = "zip"
-  source_dir = "${path.cwd}/generated/"
+  source_dir = "./generated/"
 
   # Because the archive_file provider is a data source, depends_on can't be
   # used to guarantee that the tectonic/bootkube modules have generated
@@ -77,5 +77,5 @@ data "archive_file" "assets" {
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
   # folder, we write it in the TerraForm managed hidden folder `.terraform`.
-  output_path = "${path.cwd}/.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id}")}.zip"
+  output_path = "./.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id}")}.zip"
 }

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -76,7 +76,7 @@ resource "null_resource" "tectonic" {
   }
 
   provisioner "file" {
-    source      = "${path.cwd}/generated"
+    source      = "./generated"
     destination = "$HOME/tectonic"
   }
 

--- a/platforms/metal/remote.tf
+++ b/platforms/metal/remote.tf
@@ -35,7 +35,7 @@ resource "null_resource" "bootstrap" {
   }
 
   provisioner "file" {
-    source      = "${path.cwd}/generated"
+    source      = "./generated"
     destination = "$HOME/tectonic"
   }
 

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -70,7 +70,7 @@ module "tectonic" {
 
 data "archive_file" "assets" {
   type       = "zip"
-  source_dir = "${path.cwd}/generated/"
+  source_dir = "./generated/"
 
   # Because the archive_file provider is a data source, depends_on can't be
   # used to guarantee that the tectonic/bootkube modules have generated
@@ -82,5 +82,5 @@ data "archive_file" "assets" {
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
   # folder, we write it in the TerraForm managed hidden folder `.terraform`.
-  output_path = "${path.cwd}/.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id}")}.zip"
+  output_path = "./.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id}")}.zip"
 }

--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -91,7 +91,7 @@ resource "null_resource" "tectonic" {
   }
 
   provisioner "file" {
-    source      = "${path.cwd}/generated"
+    source      = "./generated"
     destination = "$HOME/tectonic"
   }
 

--- a/platforms/openstack/nova/nodes.tf
+++ b/platforms/openstack/nova/nodes.tf
@@ -65,7 +65,7 @@ resource "null_resource" "tectonic" {
   }
 
   provisioner "file" {
-    source      = "${path.cwd}/generated"
+    source      = "./generated"
     destination = "$HOME/tectonic"
   }
 


### PR DESCRIPTION
The use of the `path.cwd` everywhere results in local paths being stored
in the state.  This causes noisy, false, diffs when working in a team
setting or via an automated deployment system.  Just using `.` should
have the same effect while keeping the paths in the state relative.