### PR TITLE
frontend: split-dns-copy

### DIFF
--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -92,8 +92,8 @@ export const LICENSING = 'licensing';
 export const SPLIT_DNS_ON = "on";
 export const SPLIT_DNS_OFF = "off";
 export const SPLIT_DNS_OPTIONS = {
-  [SPLIT_DNS_ON]: "Use both a public and private zone (default).",
-  [SPLIT_DNS_OFF]: "Only use a public zone.",
+  [SPLIT_DNS_ON]: "Create an additional Route 53 private zone (default).",
+  [SPLIT_DNS_OFF]: "Do not create a private zone.",
 };
 
 export const toVPCSubnet = (region, subnets, deselected) => {

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -357,19 +357,13 @@ class AWS_VPCComponent extends React.Component {
       </div>
       { !privateZone &&
         <div className="row form-group">
-          <div className="col-xs-3">
-            <label>
-              Split DNS
-            </label>
-          </div>
-          <div className="col-xs-9">
+          <div className="col-xs-offset-3 col-xs-9">
             <Connect field={AWS_SPLIT_DNS}>
               <Select>
                 {_.map(SPLIT_DNS_OPTIONS, ((k, v) => <option value={v} key={k}>{k}</option>))}
               </Select>
             </Connect>
             <p className="text-muted wiz-help-text">
-              By default, a private zone is used for internal traffic.
               See AWS <a href="http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html"
                 target="_blank">Split-View DNS documentation&nbsp;<i className="fa fa-external-link" /></a>
             </p>


### PR DESCRIPTION
Some copy and styling changes for the tectonic_aws_external_private_zone switch.  Please suggest changes.

![screen shot 2017-05-23 at 6 40 29 pm](https://cloud.githubusercontent.com/assets/986627/26383394/527043bc-3fe7-11e7-9439-ea9a4a874d5f.png)
