### PR TITLE
monitoring: add cpu usage recording rules

### DIFF
--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-rules.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-rules.yaml
@@ -14,6 +14,9 @@ data:
     pod_name:container_spec_cpu_shares:sum = sum by(pod_name) (
       container_spec_cpu_shares{container_name!="POD",pod_name!=""}
     )
+    pod_name:container_cpu_usage:sum = sum by(pod_name) (
+      rate (container_cpu_usage_seconds_total{container_name!="POD",pod_name!=""}[5m])
+    )
     pod_name:container_fs_usage_bytes:sum = sum by(pod_name) (
       container_fs_usage_bytes{container_name!="POD",pod_name!=""}
     )
@@ -22,6 +25,9 @@ data:
     )
     namespace:container_spec_cpu_shares:sum = sum by(namespace) (
       container_spec_cpu_shares{container_name!=""}
+    )
+    namespace:container_cpu_usage:sum = sum by(namespace) (
+      rate (container_cpu_usage_seconds_total{container_name!="POD"}[5m])
     )
     instance:node_cpu:rate:sum = sum by(instance) (
       rate(node_cpu{mode!="idle",mode!="iowait",mode!~"guest.*"}[1m])


### PR DESCRIPTION
This is syncing the changes from https://github.com/coreos-inc/tectonic-prometheus-operator/pull/58 this repo. For the sake of comprehensibility I'll quote the description from there here:

On @rithujohn191's request we are adding recording rules for the container CPU usage in addition to the already existing CPU requests/spec recording rule.

While these recording rules are not strictly necessary for console to query this data it will improve the performance when querying, as recording rules pre-calculate and store the calculated values in an extra time-series.

These added recording rules return CPU usage in its base units, so 1.0 is using one entire core. It is best practice in Prometheus to use base units, so note that when using this metric you may need to query something like the following:

```
pod_name:container_cpu_usage:sum{pod_name="prometheus-k8s-0"} * 1000
```

To get the equivalent of what people typically use in the containers' resource requests (eg. `100m`).

@fabxc @mxinden @alexsomesan @s-urbaniak 

/cc @rithujohn191 @robszumski @sym3tri