### PR TITLE
Fix the pod-checkpointer container name.

### DIFF
--- a/modules/bootkube/resources/manifests/pod-checkpointer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpointer.yaml
@@ -20,7 +20,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       containers:
-      - name: checkpoint
+      - name: pod-checkpointer
         image: ${pod_checkpointer_image}
         command:
         - /checkpoint


### PR DESCRIPTION
By convention it should match the name of the daemonset.

Fixes #848