### PR TITLE
Jenkinsfile: test experimental features

### DIFF
--- a/test/aws-exp.tfvars
+++ b/test/aws-exp.tfvars
@@ -1,0 +1,29 @@
+tectonic_worker_count = "2"
+
+tectonic_master_count = "1"
+
+tectonic_base_domain = "tectonic.dev.coreos.systems"
+
+tectonic_cl_channel = "stable"
+
+tectonic_admin_email = "example@coreos.com"
+
+tectonic_admin_password_hash = "$2a$12$k9wa31uE/4uD9aVtT/vNtOZwxXyEJ/9DwXXEYB/eUpb9fvEPsH/kO" # PASSWORD
+
+tectonic_ca_cert = ""
+
+tectonic_ca_key = ""
+
+tectonic_aws_ssh_key = "jenkins"
+
+tectonic_aws_master_ec2_type = "m4.large"
+
+tectonic_aws_worker_ec2_type = "m4.large"
+
+tectonic_aws_etcd_ec2_type = "m4.large"
+
+tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
+
+tectonic_aws_external_vpc_id = ""
+
+tectonic_experimental = true

--- a/test/scripts/aws-destroy.sh
+++ b/test/scripts/aws-destroy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+set -o pipefail
+shopt -s expand_aliases
+
+# Set the specified vars file
+TF_VARS_FILE=$1
+TEST_NAME=$(echo ${TF_VARS_FILE} | cut -d "." -f 1)
+
+# Set required configuration
+export PLATFORM=aws
+export CLUSTER="${TEST_NAME}-${BRANCH_NAME}-${BUILD_ID}"
+
+# s3 buckets require lowercase names
+export TF_VAR_tectonic_cluster_name=$(echo ${CLUSTER} | awk '{print tolower($0)}')
+
+# randomly select region
+REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
+export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
+i=$(( ${CHANGE_ID} % ${#REGIONS[@]} ))
+export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
+export AWS_REGION="${REGIONS[$i]}"
+echo "selected region: ${TF_VAR_tectonic_aws_region}"
+
+echo "Destroying ${CLUSTER}..."
+make destroy

--- a/test/scripts/aws.sh
+++ b/test/scripts/aws.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -ex
+set -o pipefail
+shopt -s expand_aliases
+
+# Set the specified vars file
+TF_VARS_FILE=$1
+TEST_NAME=$(echo ${TF_VARS_FILE} | cut -d "." -f 1)
+
+# Set required configuration
+export PLATFORM=aws
+export CLUSTER="${TEST_NAME}-${BRANCH_NAME}-${BUILD_ID}"
+
+# s3 buckets require lowercase names
+export TF_VAR_tectonic_cluster_name=$(echo ${CLUSTER} | awk '{print tolower($0)}')
+
+# randomly select region
+REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
+export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
+i=$(( ${CHANGE_ID} % ${#REGIONS[@]} ))
+export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
+export AWS_REGION="${REGIONS[$i]}"
+echo "selected region: ${TF_VAR_tectonic_aws_region}"
+# make core utils accessible to make
+export PATH=/bin:${PATH}
+
+# Create local config
+make localconfig
+
+# Use smoke test configuration for deployment
+ln -sf ${WORKSPACE}/test/${TF_VARS_FILE} ${WORKSPACE}/build/${CLUSTER}/terraform.tfvars
+
+alias filter=${WORKSPACE}/installer/scripts/filter.sh
+
+make plan | filter
+if [ "$ONLY_PLAN" = true ]; then
+    exit 0
+fi
+make apply | filter
+
+# TODO: replace in Go
+CONFIG=${WORKSPACE}/build/${CLUSTER}/terraform.tfvars
+MASTER_COUNT=$(grep tectonic_master_count ${CONFIG} | awk -F "=" '{gsub(/"/, "", $2); print $2}')
+WORKER_COUNT=$(grep tectonic_worker_count ${CONFIG} | awk -F "=" '{gsub(/"/, "", $2); print $2}')
+
+export NODE_COUNT=$(( ${MASTER_COUNT} + ${WORKER_COUNT} ))
+
+export TEST_KUBECONFIG=${WORKSPACE}/build/${CLUSTER}/generated/auth/kubeconfig
+installer/bin/sanity -test.v -test.parallel=1


### PR DESCRIPTION
Our smoke tests failed to catch a regression with one of the
experimental features because the smoke tests do not enable
`tectonic_experimental`. This PR does two things:
1. it adds a parallel step to the tests that runs with the experimental features enabled.
2. it moves the inline jenkins test code to its own file.