### PR TITLE
Revert "Fix the pod-checkpointer container name. (#844)"

### DIFF
--- a/modules/bootkube/resources/manifests/pod-checkpointer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpointer.yaml
@@ -20,7 +20,7 @@ spec:
         checkpointer.alpha.coreos.com/checkpoint: "true"
     spec:
       containers:
-      - name: pod-checkpointer
+      - name: checkpoint
         image: ${pod_checkpointer_image}
         command:
         - /checkpoint


### PR DESCRIPTION
This change is causing daemonset upgrade problems that we need to debug
further. It may be a kubelet issue. Since this change is not strictly
required we should back it out completely for now.

See #848 for more details.