### PR TITLE
modules/tectonic/resources: add security context to ingress controller

### DIFF
--- a/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
+++ b/modules/tectonic/resources/manifests/ingress/hostport/daemonset.yaml
@@ -69,4 +69,10 @@ spec:
         node-role.kubernetes.io/node: ""
       dnsPolicy: ClusterFirst
       restartPolicy: Always
+      securityContext:
+        capabilities:
+          add:
+          - NET_BIND_SERVICE
+        runAsNonRoot: true
+        runAsUser: 65534
       terminationGracePeriodSeconds: 60

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -54,6 +54,13 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
+          securityContext:
+            capabilities:
+              add:
+              - NET_BIND_SERVICE
       dnsPolicy: ClusterFirst
       restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
Ensure ingress controller runs as non-root. This is trickier than some other pods in Tectonic since we cannot make ingress controller run on ports other than 80 and 443 because these values are hardcoded into the ingress controller source [0] [1]. This means that we cannot make ingress controller run as non-root without adding additional CAPs to allow it to listen on privileged ports.

[0] https://github.com/kubernetes/ingress/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go#L94
[1] https://github.com/kubernetes/ingress/blob/master/controllers/nginx/pkg/cmd/controller/nginx.go#L210
