### PR TITLE
examples: note max k8s service cidr size

### DIFF
--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -207,6 +207,7 @@ tectonic_master_count = "1"
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+// Note: The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -145,6 +145,7 @@ tectonic_master_count = "1"
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+// Note: The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
 // 

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -193,6 +193,7 @@ tectonic_metal_worker_names = ""
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+// Note: The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
 // SSH public key to use as an authorized key.

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -115,6 +115,7 @@ tectonic_openstack_subnet_cidr = "192.168.1.0/24"
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+// Note: The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.

--- a/examples/terraform.tfvars.openstack-nova
+++ b/examples/terraform.tfvars.openstack-nova
@@ -105,6 +105,7 @@ tectonic_openstack_network_name = "public"
 tectonic_pull_secret_path = ""
 
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+// Note: The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.


### PR DESCRIPTION
Came up during a customer install. Haven't been able to find this limit in upstream docs, but validation snippet is [here](https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/validation.go#L29-L32)