### PR TITLE
frontend: Default to 3 nodes for AWS masters & workers.

### DIFF
--- a/installer/frontend/components/make-node-form.jsx
+++ b/installer/frontend/components/make-node-form.jsx
@@ -25,7 +25,7 @@ export const makeNodeForm = (name, instanceValidator=validate.int({min: 1, max: 
   const fields = [
     new Field(toKey(name, NUMBER_OF_INSTANCES), {
       validator: instanceValidator,
-      default: 1,
+      default: 3,
       name: NUMBER_OF_INSTANCES,
     }),
     new Field(toKey(name, INSTANCE_TYPE), {


### PR DESCRIPTION
Default to booting a HA cluster with 3 masters, 3 workers, and (unless experimental) 3 etcds.

Fixes #457.
