### PR TITLE
Documentation: Reference matchbox v0.6.1 release

### DIFF
--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -49,15 +49,15 @@ Matchbox is an open-source service for on-premise environments that matches bare
 Download a Matchbox v0.6+ [release](https://github.com/coreos/matchbox/releases).
 
 ```sh
-$ wget https://github.com/coreos/matchbox/releases/download/v0.6.0/matchbox-v0.6.0-linux-amd64.tar.gz
-$ wget https://github.com/coreos/matchbox/releases/download/v0.6.0/matchbox-v0.6.0-linux-amd64.tar.gz.asc
+$ wget https://github.com/coreos/matchbox/releases/download/v0.6.1/matchbox-v0.6.1-linux-amd64.tar.gz
+$ wget https://github.com/coreos/matchbox/releases/download/v0.6.1/matchbox-v0.6.1-linux-amd64.tar.gz.asc
 ```
 
 Untar the release.
 
 ```sh
-$ tar xzvf matchbox-v0.6.0-linux-amd64.tar.gz
-$ cd matchbox-v0.6.0-linux-amd64
+$ tar xzvf matchbox-v0.6.1-linux-amd64.tar.gz
+$ cd matchbox-v0.6.1-linux-amd64
 ```
 
 [Install Matchbox](https://github.com/coreos/matchbox/blob/master/Documentation/deployment.md) on a server or Kubernetes cluster that your bare-metal machines can reach using the guides:

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -4,7 +4,7 @@ Following this guide will deploy a Tectonic cluster on virtual or physical hardw
 
 ## Prerequsities
 
-* Matchbox [v0.6.0](https://github.com/coreos/matchbox/releases) installation with the gRPC API enabled. See [installation](https://coreos.com/matchbox/docs/latest/deployment.html).
+* Matchbox [v0.6+](https://github.com/coreos/matchbox/releases) installation with the gRPC API enabled. See [installation](https://coreos.com/matchbox/docs/latest/deployment.html).
 * Matchbox TLS client credentials
 * PXE network boot environment with DHCP, TFTP, and DNS services. See [network-setup](https://coreos.com/matchbox/docs/latest/network-setup.html).
 * DNS records for the Kubernetes controller(s) and Tectonic Ingress worker(s). See [DNS](https://coreos.com/tectonic/docs/latest/install/bare-metal#networking).


### PR DESCRIPTION
Point release bump. Nothing urgent if you want to bump for this release or the next one.
https://github.com/coreos/matchbox/releases/tag/v0.6.1