### PR TITLE
[WIP] tectonic/terraform: Enable custom cluster names & enforce cluster name string length

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -168,6 +168,12 @@ This applies only to cloud platforms.
 EOF
 }
 
+variable "tectonic_cluster_prefix" {
+  type = "string"
+  description = ""
+  default = ""
+}
+
 variable "tectonic_cluster_name" {
   type = "string"
 

--- a/modules/azure/master/lb.tf
+++ b/modules/azure/master/lb.tf
@@ -1,5 +1,5 @@
 resource "azurerm_lb" "tectonic_lb" {
-  name                = "api-lb"
+  name                = "${var.cluster_name}-api-lb"
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 

--- a/modules/azure/master/master.tf
+++ b/modules/azure/master/master.tf
@@ -66,7 +66,7 @@ resource "azurerm_virtual_machine_scale_set" "tectonic_masters" {
   }
 
   os_profile {
-    computer_name_prefix = "tectonic-master-"
+    computer_name_prefix = "${var.cluster_name}-master-"
     admin_username       = "core"
     admin_password       = ""
 

--- a/modules/azure/resource-group/rsg.tf
+++ b/modules/azure/resource-group/rsg.tf
@@ -14,7 +14,7 @@ variable "tectonic_cluster_name" {
 resource "azurerm_resource_group" "tectonic_cluster" {
   count    = "${var.external_rsg_name == "" ? 1 : 0}"
   location = "${var.tectonic_azure_location}"
-  name     = "tectonic-cluster-${var.tectonic_cluster_name}"
+  name     = "${var.tectonic_cluster_name}"
 }
 
 output "name" {

--- a/modules/azure/worker/workers.tf
+++ b/modules/azure/worker/workers.tf
@@ -70,7 +70,7 @@ resource "azurerm_virtual_machine_scale_set" "tectonic_workers" {
   }
 
   os_profile {
-    computer_name_prefix = "tectonic-worker-"
+    computer_name_prefix = "${var.cluster_name}-worker-"
     admin_username       = "core"
     admin_password       = ""
     custom_data          = "${base64encode("${data.ignition_config.worker.rendered}")}"

--- a/modules/tectonic/output.tf
+++ b/modules/tectonic/output.tf
@@ -15,6 +15,10 @@
 # the content of the resources on disk. Because this output is computed from the
 # combination of all the resources' IDs, it can't be guessed and can only be
 # interpolated once the assets have all been created.
+output "name" {
+  value = "${var.cluster_prefix != "" ? "${var.cluster_prefix}-${var.cluster_name}" : var.cluster_name}"
+}
+
 output "id" {
   value = "${sha1("${template_dir.tectonic.id} ${local_file.tectonic.id}")}"
 }

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -1,3 +1,11 @@
+variable "cluster_prefix" {
+  type = "string"
+}
+
+variable "cluster_name" {
+  type = "string"
+}
+
 variable "container_images" {
   description = "Container images to use. Leave blank for defaults."
   type        = "map"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -3,7 +3,7 @@ module "resource_group" {
 
   external_rsg_name       = "${var.tectonic_azure_external_rsg_name}"
   tectonic_azure_location = "${var.tectonic_azure_location}"
-  tectonic_cluster_name   = "${var.tectonic_cluster_name}"
+  tectonic_cluster_name   = "${module.tectonic.name}"
 }
 
 module "vnet" {
@@ -11,7 +11,7 @@ module "vnet" {
 
   location                  = "${var.tectonic_azure_location}"
   resource_group_name       = "${module.resource_group.name}"
-  tectonic_cluster_name     = "${var.tectonic_cluster_name}"
+  tectonic_cluster_name     = "${module.tectonic.name}"
   vnet_cidr_block           = "${var.tectonic_azure_vnet_cidr_block}"
   external_vnet_name        = "${var.tectonic_azure_external_vnet_name}"
   external_master_subnet_id = "${var.tectonic_azure_external_master_subnet_id}"
@@ -28,7 +28,7 @@ module "etcd" {
 
   etcd_count      = "${var.tectonic_etcd_count}"
   base_domain     = "${var.tectonic_base_domain}"
-  cluster_name    = "${var.tectonic_cluster_name}"
+  cluster_name    = "${module.tectonic.name}"
   public_ssh_key  = "${var.tectonic_azure_ssh_key}"
   virtual_network = "${module.vnet.vnet_id}"
   subnet          = "${module.vnet.master_subnet}"
@@ -44,7 +44,7 @@ module "masters" {
 
   master_count                 = "${var.tectonic_master_count}"
   base_domain                  = "${var.tectonic_base_domain}"
-  cluster_name                 = "${var.tectonic_cluster_name}"
+  cluster_name                 = "${module.tectonic.name}"
   public_ssh_key               = "${var.tectonic_azure_ssh_key}"
   virtual_network              = "${module.vnet.vnet_id}"
   subnet                       = "${module.vnet.master_subnet}"
@@ -72,7 +72,7 @@ module "workers" {
 
   worker_count                 = "${var.tectonic_worker_count}"
   base_domain                  = "${var.tectonic_base_domain}"
-  cluster_name                 = "${var.tectonic_cluster_name}"
+  cluster_name                 = "${module.tectonic.name}"
   public_ssh_key               = "${var.tectonic_azure_ssh_key}"
   virtual_network              = "${module.vnet.vnet_id}"
   subnet                       = "${module.vnet.worker_subnet}"
@@ -92,7 +92,7 @@ module "dns" {
   etcd_ip_addresses   = "${module.etcd.ip_address}"
 
   base_domain  = "${var.tectonic_base_domain}"
-  cluster_name = "${var.tectonic_cluster_name}"
+  cluster_name = "${module.tectonic.name}"
 
   location            = "${var.tectonic_azure_location}"
   resource_group_name = "${var.tectonic_azure_dns_resource_group}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -33,6 +33,9 @@ module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "azure"
 
+  cluster_prefix = "${var.tectonic_cluster_prefix}"
+  cluster_name = "${var.tectonic_cluster_name}"
+
   base_address       = "${module.masters.ingress_internal_fqdn}"
   kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"
 


### PR DESCRIPTION
WIP - DO NOT MERGE

Adds `tectonic_cluster_prefix`, which allows for a prefix to the cluster name.
Customer request.

Some more things need to be done here, namely:
- [ ] Extend to support all platforms
- [ ] Update resources to use shorter names
- [ ] Enforce `tectonic_cluster_prefix` and `tectonic_cluster_name` string lengths
- [ ] Update variable descriptions
- [ ] Merge in #865 and change references from `"tectonic-cluster-${var.tectonic_cluster_name}"` to `"${var.tectonic_cluster_name}"`
- [ ] fixup (regenerate docs & `terraform fmt`)