### PR TITLE
Idempotency fix: don't set IOPS value unless device type is IO1

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -48,6 +48,6 @@ resource "aws_instance" "etcd_node" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_iops}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
   }
 }

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -78,7 +78,7 @@ resource "aws_launch_configuration" "master_conf" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_iops}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
   }
 }
 

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -43,7 +43,7 @@ resource "aws_launch_configuration" "worker_conf" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_iops}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
   }
 }
 


### PR DESCRIPTION
I noticed that after successfully applying the templates from master, any subsequent `plan` operation will show that changes are required to update the value of the IOPS attribute in the block device mapping of the ASG launch configuration.
The reason for this is that during a previous apply, for a device type other than IO1 setting IOPS will just ignore the value. When doing a plan later on, the previously set value will not be returned by the AWS API, and so Terraform assumes that it has diverged and attempts to update it.

With this change we only attempt to set the actual IOPS value on volumes of type IO1, while for everything else we pass 0, which is the neutral value for this attribute. This avoids the perceived divergence and will not signal required changes later on.