### PR TITLE
Test with a max length cluster name.

### DIFF
--- a/test/scripts/aws-common.sh
+++ b/test/scripts/aws-common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+set -o pipefail
+shopt -s expand_aliases
+
+# Set the specified vars file
+export TF_VARS_FILE=$1
+TEST_NAME=$(echo "${TF_VARS_FILE}" | cut -d "." -f 1)
+
+# Set required configuration
+export PLATFORM=aws
+CLUSTER="${TEST_NAME}-${BRANCH_NAME}-${BUILD_ID}"
+MAX_LENGTH=19
+
+LENGTH=${#CLUSTER}
+if [ "$LENGTH" -gt "$MAX_LENGTH" ]
+then
+  CLUSTER="${CLUSTER:0:MAX_LENGTH}"
+  echo "Cluster name too long. Truncated to $CLUSTER"
+elif [ "$LENGTH" -lt "$MAX_LENGTH" ]
+then
+  APPEND=$(( MAX_LENGTH - LENGTH ))
+  APPEND_STR="01234567890123456789123456789"
+  CLUSTER="${CLUSTER}${APPEND_STR:0:APPEND}"
+  echo "Cluster name too short. Appended to $CLUSTER"
+fi
+
+CLUSTER=$(echo "${CLUSTER}" | awk '{print tolower($0)}')
+export CLUSTER
+export TF_VAR_tectonic_cluster_name=$CLUSTER
+
+# randomly select region
+REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
+export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
+i=$(( CHANGE_ID % ${#REGIONS[@]} ))
+export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
+export AWS_REGION="${REGIONS[$i]}"
+echo "selected region: ${TF_VAR_tectonic_aws_region}"
+echo "cluster name: ${CLUSTER}"

--- a/test/scripts/aws-destroy.sh
+++ b/test/scripts/aws-destroy.sh
@@ -2,24 +2,9 @@
 set -o pipefail
 shopt -s expand_aliases
 
-# Set the specified vars file
-TF_VARS_FILE=$1
-TEST_NAME=$(echo ${TF_VARS_FILE} | cut -d "." -f 1)
-
-# Set required configuration
-export PLATFORM=aws
-export CLUSTER="${TEST_NAME}-${BRANCH_NAME}-${BUILD_ID}"
-
-# s3 buckets require lowercase names
-export TF_VAR_tectonic_cluster_name=$(echo ${CLUSTER} | awk '{print tolower($0)}')
-
-# randomly select region
-REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
-export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
-i=$(( ${CHANGE_ID} % ${#REGIONS[@]} ))
-export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
-export AWS_REGION="${REGIONS[$i]}"
-echo "selected region: ${TF_VAR_tectonic_aws_region}"
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+# shellcheck disable=SC1090
+source "$DIR/aws-common.sh"
 
 echo "Destroying ${CLUSTER}..."
 make destroy

--- a/test/scripts/aws.sh
+++ b/test/scripts/aws.sh
@@ -2,24 +2,10 @@
 set -o pipefail
 shopt -s expand_aliases
 
-# Set the specified vars file
-TF_VARS_FILE=$1
-TEST_NAME=$(echo ${TF_VARS_FILE} | cut -d "." -f 1)
+DIR="$( cd "$( dirname "$0" )" && pwd )"
+# shellcheck disable=SC1090
+source "$DIR/aws-common.sh"
 
-# Set required configuration
-export PLATFORM=aws
-export CLUSTER="${TEST_NAME}-${BRANCH_NAME}-${BUILD_ID}"
-
-# s3 buckets require lowercase names
-export TF_VAR_tectonic_cluster_name=$(echo ${CLUSTER} | awk '{print tolower($0)}')
-
-# randomly select region
-REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
-export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
-i=$(( ${CHANGE_ID} % ${#REGIONS[@]} ))
-export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
-export AWS_REGION="${REGIONS[$i]}"
-echo "selected region: ${TF_VAR_tectonic_aws_region}"
 # make core utils accessible to make
 export PATH=/bin:${PATH}
 
@@ -27,9 +13,10 @@ export PATH=/bin:${PATH}
 make localconfig
 
 # Use smoke test configuration for deployment
-ln -sf ${WORKSPACE}/test/${TF_VARS_FILE} ${WORKSPACE}/build/${CLUSTER}/terraform.tfvars
+ln -sf "${WORKSPACE}/test/${TF_VARS_FILE}" "${WORKSPACE}/build/${CLUSTER}/terraform.tfvars"
 
-alias filter=${WORKSPACE}/installer/scripts/filter.sh
+# shellcheck disable=SC2139
+alias filter="${WORKSPACE}/installer/scripts/filter.sh"
 
 make plan | filter
 if [ "$ONLY_PLAN" = true ]; then


### PR DESCRIPTION
- Reduce duplicated code by moving common stuff to aws-common.sh
- Truncate or append to cluster name if name is too short or too long
- Set max cluster name length to 19 chars (max length that currently works)

We need this to prevent regressions, because people keep appending characters to the cluster name when creating other aws resources (elbs, s3 buckets, etc).