### PR TITLE
Remove flock timeout from apiserver.

### DIFF
--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -9,8 +9,6 @@ spec:
     image: ${hyperkube_image}
     command:
     - /usr/bin/flock
-    - --exclusive
-    - --timeout=30
     - /var/lock/api-server.lock
     - /hyperkube
     - apiserver

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -25,8 +25,6 @@ spec:
         image: ${hyperkube_image}
         command:
         - /usr/bin/flock
-        - --exclusive
-        - --timeout=30
         - /var/lock/api-server.lock
         - /hyperkube
         - apiserver


### PR DESCRIPTION
It doesn't contribute anything and leads to unnecessary apiserver
restarts during the bootstrap process.