### PR TITLE
Test with long cluster names (28 chars)

### DIFF
--- a/installer/frontend/fields.js
+++ b/installer/frontend/fields.js
@@ -13,8 +13,8 @@ FIELDS[CLUSTER_NAME] = new Field(CLUSTER_NAME, {
     case AWS_TF:
       // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html
       // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-loadbalancer.html#cfn-elasticloadbalancingv2-loadbalancer-name
-      if (s.length === 0 || s.length > 19) {
-        return 'Value must be between 1 and 19 characters';
+      if (s.length === 0 || s.length > 28) {
+        return 'Value must be between 1 and 28 characters';
       }
       if (s.toLowerCase() !== s) {
         return 'Value must be lower case.';

--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "api-internal" {
-  name            = "${var.cluster_name}-api-internal"
+  name            = "${var.cluster_name}-int"
   subnets         = ["${var.subnet_ids}"]
   internal        = true
   security_groups = ["${var.api_sg_ids}"]
@@ -42,7 +42,7 @@ resource "aws_route53_record" "api-internal" {
 
 resource "aws_elb" "api-external" {
   count           = "${var.public_vpc}"
-  name            = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-api-external"
+  name            = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-ext"
   subnets         = ["${var.subnet_ids}"]
   internal        = false
   security_groups = ["${var.api_sg_ids}"]
@@ -92,7 +92,7 @@ resource "aws_route53_record" "api-external" {
 }
 
 resource "aws_elb" "console" {
-  name            = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-console"
+  name            = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-con"
   subnets         = ["${var.subnet_ids}"]
   internal        = "${var.public_vpc ? false : true}"
   security_groups = ["${var.console_sg_ids}"]

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -17,7 +17,7 @@ common() {
     
     # Set required configuration
     CLUSTER="$TEST_NAME-$BRANCH_NAME-$BUILD_ID"
-    MAX_LENGTH=19
+    MAX_LENGTH=28
     
     LENGTH=${#CLUSTER}
     if [ "$LENGTH" -gt "$MAX_LENGTH" ]


### PR DESCRIPTION
Commit on top of #914.

Once this test passes, https://github.com/coreos/tectonic-installer/issues/413 will be fixed.
