### PR TITLE
Revert "Remove flock timeout from apiserver."

### DIFF
--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -9,6 +9,8 @@ spec:
     image: ${hyperkube_image}
     command:
     - /usr/bin/flock
+    - --exclusive
+    - --timeout=30
     - /var/lock/api-server.lock
     - /hyperkube
     - apiserver

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -25,6 +25,8 @@ spec:
         image: ${hyperkube_image}
         command:
         - /usr/bin/flock
+        - --exclusive
+        - --timeout=30
         - /var/lock/api-server.lock
         - /hyperkube
         - apiserver


### PR DESCRIPTION
Reverts coreos/tectonic-installer#915

As per discussion in https://github.com/coreos/tectonic-installer/pull/915#issuecomment-304720940 this was supposed to get in post-1.6.4.