### PR TITLE
DO NOT MERGE - GlusterFS Setup - Do not merge

### DIFF
--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -2,6 +2,7 @@ data "ignition_config" "main" {
   files = [
     "${data.ignition_file.max-user-watches.id}",
     "${data.ignition_file.s3-puller.id}",
+    "${data.ignition_file.dm_thin_pool.id}",
     "${data.ignition_file.init-assets.id}",
     "${data.ignition_file.detect-master.id}",
   ]
@@ -93,6 +94,16 @@ data "ignition_file" "s3-puller" {
 
   content {
     content = "${data.template_file.s3-puller.rendered}"
+  }
+}
+
+data "ignition_file" "dm_thin_pool" {
+  filesystem = "root"
+  path       = "/etc/modules-load.d/dm_thin_pool.conf"
+  mode       = "555"
+
+  content {
+    content = "${file("${path.module}/resources/dm_thin_pool.conf")}"
   }
 }
 

--- a/modules/aws/ignition/resources/dm_thin_pool.conf
+++ b/modules/aws/ignition/resources/dm_thin_pool.conf
@@ -1,0 +1,2 @@
+# Load dm_thin_pool.ko at boot for LVM
+dm_thin_pool

--- a/modules/aws/vpc/sg-master.tf
+++ b/modules/aws/vpc/sg-master.tf
@@ -38,6 +38,26 @@ resource "aws_security_group_rule" "master_ingress_ssh" {
   to_port     = 22
 }
 
+resource "aws_security_group_rule" "master_ingress_gluster_mgt" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 24007
+  to_port     = 24008
+}
+
+resource "aws_security_group_rule" "master_ingress_gluster_bricks" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 49152
+  to_port     = 49251
+}
+
 resource "aws_security_group_rule" "master_ingress_http" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"

--- a/modules/aws/vpc/sg-worker.tf
+++ b/modules/aws/vpc/sg-worker.tf
@@ -28,6 +28,26 @@ resource "aws_security_group_rule" "worker_ingress_icmp" {
   to_port     = 0
 }
 
+resource "aws_security_group_rule" "worker_ingress_gluster_mgt" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.worker.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 24007
+  to_port     = 24008
+}
+
+resource "aws_security_group_rule" "worker_ingress_gluster_bricks" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.worker.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 49152
+  to_port     = 49251
+}
+
 resource "aws_security_group_rule" "worker_ingress_ssh" {
   type              = "ingress"
   security_group_id = "${aws_security_group.worker.id}"

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -45,6 +45,27 @@ resource "aws_launch_configuration" "worker_conf" {
     volume_size = "${var.root_volume_size}"
     iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
   }
+
+  ebs_block_device {
+    device_name = "/dev/xvdc"
+    volume_type = "gp2"
+    volume_size = "256"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
+  }
+
+  ebs_block_device {
+    device_name = "/dev/xvdd"
+    volume_type = "gp2"
+    volume_size = "256"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
+  }
+
+  ebs_block_device {
+    device_name = "/dev/xvde"
+    volume_type = "gp2"
+    volume_size = "256"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
+  }
 }
 
 resource "aws_autoscaling_group" "workers" {


### PR DESCRIPTION
This is a proof of concept of setting up the nodes for GlusterFS. The setup does the following:

* Creates three disks per node
* Opens ports for Gluster node-node communication
* Sets up dm_thin_pool