### PR TITLE
Fix incorrect file modes.

### DIFF
--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -71,7 +71,7 @@ data "ignition_systemd_unit" "kubelet-env" {
 data "ignition_file" "max-user-watches" {
   filesystem = "root"
   path       = "/etc/sysctl.d/max-user-watches.conf"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "fs.inotify.max_user_watches=16184"
@@ -81,7 +81,7 @@ data "ignition_file" "max-user-watches" {
 data "ignition_file" "s3-puller" {
   filesystem = "root"
   path       = "/opt/s3-puller.sh"
-  mode       = "555"
+  mode       = 0755
 
   content {
     content = "${file("${path.module}/resources/s3-puller.sh")}"
@@ -91,7 +91,7 @@ data "ignition_file" "s3-puller" {
 data "ignition_file" "detect-master" {
   filesystem = "root"
   path       = "/opt/detect-master.sh"
-  mode       = "555"
+  mode       = 0755
 
   content {
     content = "${file("${path.module}/resources/detect-master.sh")}"
@@ -113,7 +113,7 @@ data "template_file" "init-assets" {
 data "ignition_file" "init-assets" {
   filesystem = "root"
   path       = "/opt/tectonic/init-assets.sh"
-  mode       = "555"
+  mode       = 0755
 
   content {
     content = "${data.template_file.init-assets.rendered}"

--- a/modules/azure/master/ignition-master.tf
+++ b/modules/azure/master/ignition-master.tf
@@ -63,7 +63,7 @@ data "ignition_systemd_unit" "kubelet-master" {
 data "ignition_file" "kubeconfig" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubeconfig"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "${var.kubeconfig_content}"
@@ -73,7 +73,7 @@ data "ignition_file" "kubeconfig" {
 data "ignition_file" "kubelet-env" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubelet.env"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = <<EOF
@@ -86,7 +86,7 @@ EOF
 data "ignition_file" "max-user-watches" {
   filesystem = "root"
   path       = "/etc/sysctl.d/max-user-watches.conf"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "fs.inotify.max_user_watches=16184"

--- a/modules/azure/worker/ignition-worker.tf
+++ b/modules/azure/worker/ignition-worker.tf
@@ -52,7 +52,7 @@ data "ignition_systemd_unit" "kubelet-worker" {
 data "ignition_file" "kubeconfig" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubeconfig"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "${var.kubeconfig_content}"
@@ -62,7 +62,7 @@ data "ignition_file" "kubeconfig" {
 data "ignition_file" "kubelet-env" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubelet.env"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = <<EOF
@@ -75,7 +75,7 @@ EOF
 data "ignition_file" "max-user-watches" {
   filesystem = "root"
   path       = "/etc/sysctl.d/max-user-watches.conf"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "fs.inotify.max_user_watches=16184"

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -86,7 +86,7 @@ data "ignition_systemd_unit" "kubelet" {
 data "ignition_file" "kubeconfig" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubeconfig"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "${var.kubeconfig_content}"
@@ -96,7 +96,7 @@ data "ignition_file" "kubeconfig" {
 data "ignition_file" "kubelet-env" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubelet.env"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = <<EOF
@@ -109,7 +109,7 @@ EOF
 data "ignition_file" "max-user-watches" {
   filesystem = "root"
   path       = "/etc/sysctl.d/max-user-watches.conf"
-  mode       = "420"
+  mode       = 0644
 
   content {
     content = "fs.inotify.max_user_watches=16184"


### PR DESCRIPTION
- 555 should be 755.
- 420 translates to 644.
- If octal is being used it should be prefixed by 0.
- Quotes are unnecessary.