### PR TITLE
Build docker image

### DIFF
--- a/images/tectonic-installer/Dockerfile
+++ b/images/tectonic-installer/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.8-stretch
+
+ENV TERRAFORM_VERSION="0.9.6"
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y -q \
+    unzip
+
+# Install Terraform
+RUN curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
+
+ENV PROJECT_DIR /go/src/github.com/coreos/tectonic-installer
+
+ADD Makefile $PROJECT_DIR/
+ADD config.tf $PROJECT_DIR/
+ADD installer/bin/linux/installer $PROJECT_DIR/installer/bin/linux/
+ADD platforms $PROJECT_DIR/platforms
+ADD modules $PROJECT_DIR/modules
+ADD terraformrc.example $PROJECT_DIR/
+

--- a/images/tectonic-installer/README.md
+++ b/images/tectonic-installer/README.md
@@ -1,0 +1,7 @@
+# tectonic-installer
+
+[![Container Repository on Quay](https://quay.io/repository/coreos/tectonic-installer/status "Container Repository on Quay")](https://quay.io/repository/coreos/tectonic-installer)
+
+This container image contains the environment and the compiled installer binary
+required to use the Tectonic Installer. It aims at facilitating the usage of the
+Tectonic Installer in different CI/CD pipelines.


### PR DESCRIPTION
Add stage to build docker image containing compiled binaries.

> We are already compiling the installer in the CI pipeline of the
Tectonic installer. I would propose building a Docker image with
terraform and the compiled binaries as a step of the pipeline so anyone
can just go ahead and start her cluster without any dependencies by
using the quay.io/coreos/tectonic-installer-dev:master image.

In addition, this specifies a Docker image per stage, and not per entire pipeline.

Fixes #689 