### PR TITLE
Makefile: automatically create tfvars file for specified platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ installer-env: $(INSTALLER_BIN) terraformrc.example
 
 localconfig:
 	mkdir -p $(BUILD_DIR)
+	cp examples/*$(subst /,-,$(PLATFORM)) $(BUILD_DIR)/terraform.tfvars
 
 terraform-get:
 	cd $(BUILD_DIR) && $(TF_CMD) get $(TOP_DIR)/platforms/$(PLATFORM)

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -62,7 +62,7 @@ common() {
     # Create local config
     make localconfig
     # Use smoke test configuration for deployment
-    ln -sf "$DIR/$TF_VARS_FILE" "$WORKSPACE/build/$CLUSTER/terraform.tfvars"
+    cp "$DIR/$TF_VARS_FILE" "$WORKSPACE/build/$CLUSTER/terraform.tfvars"
 }
 
 create() {


### PR DESCRIPTION
Example tfvars for each platform are located in the examples
folder. Automatically copy and rename this file matching the
specified platform for `make localconfig`

Fixes #923 