### PR TITLE
Enable timestamps for Jenkins output

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
 
   options {
     timeout(time:45, unit:'MINUTES')
+    timestamps()
     buildDiscarder(logRotator(numToKeepStr:'20'))
   }
 


### PR DESCRIPTION
This should give us more insight about where time is spent when bringing up & testing a cluster.