### PR TITLE
Make detect-master.sh more robust.

### DIFF
--- a/modules/aws/ignition/resources/detect-master.sh
+++ b/modules/aws/ignition/resources/detect-master.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-REGION=$(wget -q -O - http://169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/[a-zA-Z]$//')
-INSTANCE_ID=$(wget -qO- http://169.254.169.254/latest/meta-data/instance-id)
-ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region="$REGION" --instance-ids="$INSTANCE_ID" | jq -r ".AutoScalingInstances[0] .AutoScalingGroupName")
-
 # Wait for the ASG to run at the expected scale.
 while true; do
+  REGION=$(wget -q -O - http://169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/[a-zA-Z]$//')
+  INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
+  ASG_NAME=$(aws autoscaling describe-auto-scaling-instances --region="$REGION" --instance-ids="$INSTANCE_ID" | jq -r ".AutoScalingInstances[0] .AutoScalingGroupName")
   ASG_DESCRIPTION=$(aws autoscaling describe-auto-scaling-groups --region="$REGION" --auto-scaling-group-names="$ASG_NAME")
-  ASG_DESIRED_CAP=$(echo $ASG_DESCRIPTION | jq ".AutoScalingGroups[0] .DesiredCapacity")
-  ASG_INSTANCE_IDS=$(echo $ASG_DESCRIPTION | jq -r ".AutoScalingGroups[0] .Instances | sort_by(.InstanceId) | .[].InstanceId")
+  # shellcheck disable=SC2181
+  if [ $? -ne 0 ]; then
+    sleep 15
+    continue
+  fi
+  ASG_DESIRED_CAP=$(echo "$ASG_DESCRIPTION" | jq ".AutoScalingGroups[0] .DesiredCapacity")
+  ASG_INSTANCE_IDS=$(echo "$ASG_DESCRIPTION" | jq -r ".AutoScalingGroups[0] .Instances | sort_by(.InstanceId) | .[].InstanceId")
   ASG_CURRENT_CAP=$(echo -e "$ASG_INSTANCE_IDS" | wc -l)
 
   if [ "$ASG_CURRENT_CAP" == "$ASG_DESIRED_CAP" ]; then


### PR DESCRIPTION
- Retry fetching region & instance ID.
- Avoid false positive comparisons that could potentially cause a node to think it's the first master when it isn't.
- Wrap some fields in quotes to prevent potential issues with globbing.