### PR TITLE
Jenkins cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,17 @@
 1. Stages should simply invoke a make target or a self-contained script. Do not write testing logic in this Jenkinsfile.
 3. CoreOS does not ship with `make`, so Docker builds still have to use small scripts.
 */
+
+def creds = [
+  file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_license_path'),
+  file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_pull_secret_path'), [
+    $class: 'UsernamePasswordMultiBinding',
+    credentialsId: 'tectonic-aws',
+    usernameVariable: 'AWS_ACCESS_KEY_ID',
+    passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+  ]
+]
+
 pipeline {
   agent {
     docker {
@@ -12,7 +23,7 @@ pipeline {
   }
 
   options {
-    timeout(time:45, unit:'MINUTES')
+    timeout(time:60, unit:'MINUTES')
     timestamps()
     buildDiscarder(logRotator(numToKeepStr:'20'))
   }
@@ -35,9 +46,9 @@ pipeline {
       steps {
         sh """#!/bin/bash -ex
 
-        # Prevent "fatal: You don't exist. Go away!" git error
-        git config --global user.name "jenkins tectonic installer"
-        git config --global user.email "jenkins-tectonic-installer@coreos.com"
+        # Prevent fatal: You don't exist. Go away! git error
+        git config --global user.name 'jenkins tectonic installer'
+        git config --global user.email 'jenkins-tectonic-installer@coreos.com'
         go get github.com/segmentio/terraform-docs
 
         make docs
@@ -50,9 +61,9 @@ pipeline {
       steps {
         sh """#!/bin/bash -ex
 
-        # Prevent "fatal: You don't exist. Go away!" git error
-        git config --global user.name "jenkins tectonic installer"
-        git config --global user.email "jenkins-tectonic-installer@coreos.com"
+        # Prevent fatal: You don't exist. Go away! git error
+        git config --global user.name 'jenkins tectonic installer'
+        git config --global user.email 'jenkins-tectonic-installer@coreos.com'
         go get github.com/s-urbaniak/terraform-examples
 
         make examples
@@ -78,67 +89,51 @@ pipeline {
         """
         stash name: 'installer', includes: 'installer/bin/linux/installer'
         stash name: 'sanity', includes: 'installer/bin/sanity'
-        }
       }
-      stage("Smoke Tests") {
+    }
+
+    stage("Smoke Tests") {
       steps {
         parallel (
           "TerraForm: AWS": {
-            withCredentials([file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_pull_secret_path'),
-                             file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_license_path'),
-                             [
-                               $class: 'UsernamePasswordMultiBinding',
-                               credentialsId: 'tectonic-aws',
-                               usernameVariable: 'AWS_ACCESS_KEY_ID',
-                               passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                             ]
-                             ]) {
-              unstash 'installer'
-              unstash 'sanity'
+            unstash 'installer'
+            unstash 'sanity'
+            withCredentials(creds) {
               timeout(30) {
                 sh '${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws.tfvars'
                 sh '${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws.tfvars'
                 sh '${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws.tfvars'
               }
+              timeout(10) {
+                sh '${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars'
+              }
             }
           },
           "TerraForm: AWS-experimental": {
-            withCredentials([file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_pull_secret_path'),
-                             file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_license_path'),
-                             [
-                               $class: 'UsernamePasswordMultiBinding',
-                               credentialsId: 'tectonic-aws',
-                               usernameVariable: 'AWS_ACCESS_KEY_ID',
-                               passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                             ]
-                             ]) {
             unstash 'installer'
             unstash 'sanity'
-            sh '${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-exp.tfvars'
+            withCredentials(creds) {
+              timeout(5) {
+                sh '${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-exp.tfvars'
+              }
             }
           }
         )
+      }
+      post {
+        failure {
+          unstash 'installer'
+          withCredentials(creds) {
+            timeout(10) {
+              sh '${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars'
+            }
+          }
+        }
       }
     }
   }
   post {
     always {
-      checkout scm
-
-      withCredentials([file(credentialsId: 'tectonic-license', variable: 'TF_VAR_tectonic_pull_secret_path'),
-                       file(credentialsId: 'tectonic-pull', variable: 'TF_VAR_tectonic_license_path'),
-                       [
-                         $class: 'UsernamePasswordMultiBinding',
-                         credentialsId: 'tectonic-aws',
-                         usernameVariable: 'AWS_ACCESS_KEY_ID',
-                         passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                       ]
-                       ]) {
-        unstash 'installer'
-        timeout(10) {
-          sh '${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars'
-        }
-      }
       // Cleanup workspace
       deleteDir()
     }


### PR DESCRIPTION
Paired with @kans.

- Don't repeat withCredentials args three times, [one of which was incorrect](https://github.com/coreos/tectonic-installer/commit/ff3c92ba79e2b5c10d05b6b89a98acf936bf4bd3#commitcomment-22354809).
- TF Destroy is part of blue ocean console output. (Previously, it was hidden.)
- Don't re-run tf destroy if build or lint fails.
- Set more fine-grained timeouts for various steps.
- Don't needlessly checkout scm again when destroying.
- Lastly: fix indentation.
