### PR TITLE
Append the base domain to the VPC name

### DIFF
--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -14,6 +14,10 @@ variable "cluster_id" {
   type = "string"
 }
 
+variable "base_domain" {
+  type = "string"
+}
+
 variable "cluster_name" {
   type = "string"
 }

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "new_vpc" {
   enable_dns_support   = true
 
   tags = "${merge(map(
-      "Name", "${var.cluster_name}-vpc",
+      "Name", "${var.cluster_name}.${var.base_domain}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
       "tectonicClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -8,6 +8,7 @@ module "vpc" {
   source = "../../modules/aws/vpc"
 
   cidr_block   = "${var.tectonic_aws_vpc_cidr_block}"
+  base_domain  = "${var.tectonic_base_domain}"
   cluster_name = "${var.tectonic_cluster_name}"
 
   external_vpc_id         = "${var.tectonic_aws_external_vpc_id}"


### PR DESCRIPTION
Proposing a change - this maintains the same naming convention as the previous Tectonic installer.