### PR TITLE
Calculate root_block_device.iops for gp2 volumes

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "etcd_node" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : var.root_volume_type == "gp2" ? min(10000, max(100, 3 * var.root_volume_size)) : 0}"
   }
 
   volume_tags = "${merge(map(


### PR DESCRIPTION
This fixes an idempotency issue where even though the `iops` parameter is not used when the volume type is anything other than `io1`, Terraform will report a diff forcing recreation of the instance(s) because the reported `iops` parameter does not match the value specified in the module.

The calculation comes from the AWS docs at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html, specifically:

>Between a minimum of 100 IOPS (at 33.33 GiB and below) and a maximum of 10,000 IOPS (at 3,334 GiB and above), baseline performance scales linearly at 3 IOPS per GiB of volume size.

Related to / supersedes #896