### PR TITLE
modules/bootkube: fix etcd-operator startup with S3 backups and nobody

### DIFF
--- a/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
+++ b/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
@@ -22,6 +22,8 @@ spec:
               valueFrom: 
                 fieldRef: 
                   fieldPath: metadata.name
+            - name: HOME
+              value: /tmp
           image: ${etcd_operator_image}
           name: etcd-operator
       nodeSelector:


### PR DESCRIPTION
Fixes https://github.com/coreos/tectonic-installer/issues/959.
See issue for details.