### PR TITLE
modules/aws/master-asg: switch ELBs’ health checks to using SSL targets

### DIFF
--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -17,7 +17,7 @@ resource "aws_elb" "api-internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:443"
+    target              = "SSL:443"
     interval            = 5
   }
 
@@ -67,7 +67,7 @@ resource "aws_elb" "api-external" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     timeout             = 3
-    target              = "TCP:443"
+    target              = "SSL:443"
     interval            = 5
   }
 


### PR DESCRIPTION
This avoids having the API servers’ logs being hammered with:

```
http: TLS handshake error from 10.0.44.6:28942: EOF
```

Fixes https://github.com/coreos/tectonic-installer/issues/893.