### PR TITLE
platforms/*: Use tectonic_vanilla_k8s flag

### DIFF
--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -85,7 +85,7 @@ resource "null_resource" "tectonic" {
       "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",
       "sudo mv /home/core/tectonic /opt/",
-      "sudo systemctl start tectonic",
+      "sudo systemctl start ${var.tectonic_vanilla_k8s ? "bootkube.service" : "tectonic.service"}",
     ]
   }
 }

--- a/platforms/vmware/remote.tf
+++ b/platforms/vmware/remote.tf
@@ -18,7 +18,7 @@ resource "null_resource" "bootstrap" {
       "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",
       "sudo mv /home/core/tectonic /opt/",
-      "sudo systemctl start tectonic",
+      "sudo systemctl start ${var.tectonic_vanilla_k8s ? "bootkube.service" : "tectonic.service"}",
     ]
   }
 }


### PR DESCRIPTION
The tectonic_vanilla_k8s flag was previously defined, but not
actually used. Conditionally deploy Tectonic assets based
on the value of this flag.

Related: #637 
Fixes: #960 