### PR TITLE
Only build installer for PLATFORM=metal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,12 @@ all: apply
 $(INSTALLER_BIN):
 	make build -C $(TOP_DIR)/installer
 
-installer-env: $(INSTALLER_BIN) terraformrc.example
+
+ifeq ($(PLATFORM),metal)
+ INSTALLER_DEP=$(INSTALLER_BIN)
+endif
+installer-env: $(INSTALLER_DEP) terraformrc.example
+	@echo $(INSTALLER_DEP)
 	sed "s|<PATH_TO_INSTALLER>|$(INSTALLER_BIN)|g" terraformrc.example > .terraformrc
 
 localconfig:


### PR DESCRIPTION
This closes #961

@Quentin-M I'm not sure if that works for all other use cases but this will only build the installer on plan/apply/destroy if PLATFORM=metal.