### PR TITLE
vmware: add tectonic_vmware_ssh_private_key variable

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -26,6 +26,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_node_dns | DNS Server to be useddd by Virtual Machine(s) | string | - |
 | tectonic_vmware_server | vCenter Server IP/FQDN | string | - |
 | tectonic_vmware_ssh_authorized_key | SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."` | string | - |
+| tectonic_vmware_ssh_private_key_path | SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used. | string | `` |
 | tectonic_vmware_sslselfsigned | Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"` | string | - |
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -177,6 +177,9 @@ tectonic_vmware_server = ""
 // SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."`
 tectonic_vmware_ssh_authorized_key = ""
 
+// SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used.
+tectonic_vmware_ssh_private_key_path = ""
+
 // Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"`
 tectonic_vmware_sslselfsigned = ""
 

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -24,8 +24,9 @@ resource "vsphere_virtual_machine" "node" {
   }
 
   connection {
-    type = "ssh"
-    user = "core"
+    type        = "ssh"
+    user        = "core"
+    private_key = "${file(var.tectonic_vmware_ssh_private_key_path != "" ? pathexpand(var.tectonic_vmware_ssh_private_key_path) : "/dev/null")}"
   }
 
   provisioner "file" {

--- a/platforms/vmware/remote.tf
+++ b/platforms/vmware/remote.tf
@@ -2,10 +2,11 @@ resource "null_resource" "bootstrap" {
   # Without depends_on, this remote-exec may start before the kubeconfig copy.  # Terraform only does one task at a time, so it would try to bootstrap  # Kubernetes and Tectonic while no Kubelets are running. Ensure all nodes  # receive a kubeconfig before proceeding with bootkube and tectonic.  #depends_on = ["null_resource.kubeconfig-masters"]
 
   connection {
-    type    = "ssh"
-    host    = "${module.masters.ip_address[0]}"
-    user    = "core"
-    timeout = "60m"
+    type        = "ssh"
+    host        = "${module.masters.ip_address[0]}"
+    user        = "core"
+    timeout     = "60m"
+    private_key = "${file(var.tectonic_vmware_ssh_private_key_path != "" ? pathexpand(var.tectonic_vmware_ssh_private_key_path) : "/dev/null")}"
   }
 
   provisioner "file" {

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -52,6 +52,12 @@ variable "tectonic_vmware_ssh_authorized_key" {
   description = "SSH public key to use as an authorized key. Example: `\"ssh-rsa AAAB3N...\"`"
 }
 
+variable "tectonic_vmware_ssh_private_key_path" {
+  type        = "string"
+  description = "SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used."
+  default     = ""
+}
+
 variable "tectonic_vmware_node_dns" {
   type        = "string"
   description = "DNS Server to be useddd by Virtual Machine(s)"


### PR DESCRIPTION
Follow up on https://github.com/coreos/tectonic-installer/pull/625 for VMware platform.

Allow users to specify the SSH private key via a variable in cases where
ssh-agent isn't available or configured.