### PR TITLE
Add support for cloud provider config on azure

### DIFF
--- a/Documentation/variables/azure.md
+++ b/Documentation/variables/azure.md
@@ -6,6 +6,9 @@ This document gives an overview of variables used in the Azure platform of the T
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
+| tectonic_azure_client_id | The client ID to use. | string | - |
+| tectonic_azure_client_secret | The client secret to use. | string | - |
+| tectonic_azure_cloud_environment | (optional) Azure cloud environment to use. See https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13 for available environments. | string | `AZUREPUBLICCLOUD` |
 | tectonic_azure_config_version | (internal) This declares the version of the Azure configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
 | tectonic_azure_create_dns_zone | If set to true, create an Azure DNS zone | string | `true` |
 | tectonic_azure_dns_resource_group |  | string | `tectonic-dns-group` |
@@ -28,6 +31,8 @@ This document gives an overview of variables used in the Azure platform of the T
 | tectonic_azure_ssh_key | Name of an Azure ssh key to use joe-sfo | string | - |
 | tectonic_azure_ssh_network_external | (optional) Network (external) to allow SSH access from. Maps to `source_address_prefix` in Azure. Defaults to `*`. Can be external to Azure environment. Allowed values: [network CIDR (i.e., 10.0.0.0/16) | `VirtualNetwork` | `Internet` | `*` ] | string | `*` |
 | tectonic_azure_ssh_network_internal | Network (internal) to allow SSH access from. Maps to `source_address_prefix` in Azure. Defaults to `VirtualNetwork`. Should be internal to Azure environment. Allowed values: [network CIDR (i.e., 10.0.0.0/16) | `VirtualNetwork` | `Internet` | `*` ] | string | `VirtualNetwork` |
+| tectonic_azure_subscription_id | The subscription ID to use. | string | - |
+| tectonic_azure_tenant_id | The tenant ID to use. | string | - |
 | tectonic_azure_use_custom_fqdn | (optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure. | string | `false` |
 | tectonic_azure_vnet_cidr_block | Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute. | string | `10.0.0.0/16` |
 | tectonic_azure_worker_storage_account_type | Storage account type for the worker node(s). Example: Premium_LRS. | string | `Premium_LRS` |

--- a/Documentation/variables/azure.md
+++ b/Documentation/variables/azure.md
@@ -6,7 +6,6 @@ This document gives an overview of variables used in the Azure platform of the T
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
-| tectonic_azure_client_id | The client ID to use. | string | - |
 | tectonic_azure_client_secret | The client secret to use. | string | - |
 | tectonic_azure_cloud_environment | (optional) Azure cloud environment to use. See https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13 for available environments. | string | `AZUREPUBLICCLOUD` |
 | tectonic_azure_config_version | (internal) This declares the version of the Azure configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
@@ -31,8 +30,6 @@ This document gives an overview of variables used in the Azure platform of the T
 | tectonic_azure_ssh_key | Name of an Azure ssh key to use joe-sfo | string | - |
 | tectonic_azure_ssh_network_external | (optional) Network (external) to allow SSH access from. Maps to `source_address_prefix` in Azure. Defaults to `*`. Can be external to Azure environment. Allowed values: [network CIDR (i.e., 10.0.0.0/16) | `VirtualNetwork` | `Internet` | `*` ] | string | `*` |
 | tectonic_azure_ssh_network_internal | Network (internal) to allow SSH access from. Maps to `source_address_prefix` in Azure. Defaults to `VirtualNetwork`. Should be internal to Azure environment. Allowed values: [network CIDR (i.e., 10.0.0.0/16) | `VirtualNetwork` | `Internet` | `*` ] | string | `VirtualNetwork` |
-| tectonic_azure_subscription_id | The subscription ID to use. | string | - |
-| tectonic_azure_tenant_id | The tenant ID to use. | string | - |
 | tectonic_azure_use_custom_fqdn | (optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure. | string | `false` |
 | tectonic_azure_vnet_cidr_block | Block of IP addresses used by the Resource Group. This should not overlap with any other networks, such as a private datacenter connected via ExpressRoute. | string | `10.0.0.0/16` |
 | tectonic_azure_worker_storage_account_type | Storage account type for the worker node(s). Example: Premium_LRS. | string | `Premium_LRS` |

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -10,6 +10,17 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
+// The client ID to use.
+tectonic_azure_client_id = ""
+
+// The client secret to use.
+tectonic_azure_client_secret = ""
+
+// (optional) Azure cloud environment to use. See
+// https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
+// for available environments.
+// tectonic_azure_cloud_environment = "AZUREPUBLICCLOUD"
+
 // If set to true, create an Azure DNS zone
 tectonic_azure_create_dns_zone = true
 
@@ -89,6 +100,12 @@ tectonic_azure_ssh_key = ""
 // Defaults to `VirtualNetwork`. Should be internal to Azure environment.
 // Allowed values: [network CIDR (i.e., 10.0.0.0/16) | `VirtualNetwork` | `Internet` | `*` ]
 tectonic_azure_ssh_network_internal = "VirtualNetwork"
+
+// The subscription ID to use.
+tectonic_azure_subscription_id = ""
+
+// The tenant ID to use.
+tectonic_azure_tenant_id = ""
 
 // (optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure.
 // tectonic_azure_use_custom_fqdn = false

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -10,9 +10,6 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
-// The client ID to use.
-tectonic_azure_client_id = ""
-
 // The client secret to use.
 tectonic_azure_client_secret = ""
 
@@ -100,12 +97,6 @@ tectonic_azure_ssh_key = ""
 // Defaults to `VirtualNetwork`. Should be internal to Azure environment.
 // Allowed values: [network CIDR (i.e., 10.0.0.0/16) | `VirtualNetwork` | `Internet` | `*` ]
 tectonic_azure_ssh_network_internal = "VirtualNetwork"
-
-// The subscription ID to use.
-tectonic_azure_subscription_id = ""
-
-// The tenant ID to use.
-tectonic_azure_tenant_id = ""
 
 // (optional) If set to true, assemble the FQDN from the configuration. Otherwise, use the FQDN set up by Azure.
 // tectonic_azure_use_custom_fqdn = false

--- a/modules/azure/master-as/ignition-master.tf
+++ b/modules/azure/master-as/ignition-master.tf
@@ -3,6 +3,7 @@ data "ignition_config" "master" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
+    "${data.ignition_file.cloud-provider-config.id}"
   ]
 
   systemd = [
@@ -90,6 +91,16 @@ data "ignition_file" "max-user-watches" {
 
   content {
     content = "fs.inotify.max_user_watches=16184"
+  }
+}
+
+data "ignition_file" "cloud-provider-config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+
+  content {
+    content = "${var.cloud_provider_config}"
   }
 }
 

--- a/modules/azure/master-as/ignition-master.tf
+++ b/modules/azure/master-as/ignition-master.tf
@@ -3,7 +3,7 @@ data "ignition_config" "master" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
-    "${data.ignition_file.cloud-provider-config.id}"
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [

--- a/modules/azure/master-as/resources/master-kubelet.service
+++ b/modules/azure/master-as/resources/master-kubelet.service
@@ -33,8 +33,9 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_domain=cluster.local \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
-  --cloud-provider="${cloud_provider}"
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+  --cloud-provider="${cloud_provider}" \
+  --cloud-config=/etc/kubernetes/cloud/config
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always
 RestartSec=10
 

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -71,6 +71,11 @@ variable "cloud_provider" {
   default = "azure"
 }
 
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+}
+
 variable "kubelet_node_label" {
   type = "string"
 }

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -54,7 +54,3 @@ output "etcd_private_ips" {
 output "etcd_public_ip" {
   value = "${azurerm_public_ip.etcd_publicip.ip_address}"
 }
-
-output "default_security_group" {
-  value = "${azurerm_network_security_group.cluster_default.id}"
-}

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -54,3 +54,7 @@ output "etcd_private_ips" {
 output "etcd_public_ip" {
   value = "${azurerm_public_ip.etcd_publicip.ip_address}"
 }
+
+output "default_security_group" {
+  value = "${azurerm_network_security_group.cluster_default.id}"
+}

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -50,3 +50,7 @@ output "etcd_private_ips" {
 output "etcd_public_ip" {
   value = "${azurerm_public_ip.etcd_publicip.ip_address}"
 }
+
+output "default_security_group" {
+  value = "${azurerm_network_security_group.cluster_default.id}"
+}

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -10,6 +10,10 @@ output "worker_subnet" {
   value = "${var.external_vnet_name == "" ?  join(" ", azurerm_subnet.worker_subnet.*.id) : var.external_worker_subnet_id }"
 }
 
+output "worker_subnet_name" {
+  value = "${var.external_vnet_name == "" ?  join(" ", azurerm_subnet.worker_subnet.*.id) : var.external_vnet_name }"
+}
+
 # TODO: Allow user to provide their own network
 output "etcd_cidr" {
   value = "${azurerm_subnet.master_subnet.address_prefix}"
@@ -49,8 +53,4 @@ output "etcd_private_ips" {
 
 output "etcd_public_ip" {
   value = "${azurerm_public_ip.etcd_publicip.ip_address}"
-}
-
-output "default_security_group" {
-  value = "${azurerm_network_security_group.cluster_default.id}"
 }

--- a/modules/azure/worker-as/ignition-worker.tf
+++ b/modules/azure/worker-as/ignition-worker.tf
@@ -3,6 +3,7 @@ data "ignition_config" "worker" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
+    "${data.ignition_file.cloud-provider-config.id}"
   ]
 
   systemd = [

--- a/modules/azure/worker-as/ignition-worker.tf
+++ b/modules/azure/worker-as/ignition-worker.tf
@@ -82,6 +82,16 @@ data "ignition_file" "max-user-watches" {
   }
 }
 
+data "ignition_file" "cloud-provider-config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+
+  content {
+    content = "${var.cloud_provider_config}"
+  }
+}
+
 data "ignition_systemd_unit" "tectonic" {
   name   = "tectonic.service"
   enable = true

--- a/modules/azure/worker-as/ignition-worker.tf
+++ b/modules/azure/worker-as/ignition-worker.tf
@@ -3,7 +3,7 @@ data "ignition_config" "worker" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
-    "${data.ignition_file.cloud-provider-config.id}"
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [

--- a/modules/azure/worker-as/output.tf
+++ b/modules/azure/worker-as/output.tf
@@ -1,0 +1,3 @@
+output "availability_set_name" {
+  value = "${azurerm_availability_set.tectonic_workers.name}"
+}

--- a/modules/azure/worker-as/resources/worker-kubelet.service
+++ b/modules/azure/worker-as/resources/worker-kubelet.service
@@ -32,8 +32,9 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_domain=cluster.local \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
-  --cloud-provider="${cloud_provider}"
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+  --cloud-provider="${cloud_provider}" \
+  --cloud-config=/etc/kubernetes/cloud/config
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always
 RestartSec=10
 

--- a/modules/azure/worker-as/variables.tf
+++ b/modules/azure/worker-as/variables.tf
@@ -72,6 +72,11 @@ variable "cloud_provider" {
   default = "azure"
 }
 
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+}
+
 variable "kubelet_node_label" {
   type = "string"
 }

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -91,4 +91,8 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   tags {
     environment = "staging"
   }
+
+  lifecycle {
+    ignore_changes = [ "storage_data_disk" ]
+  }
 }

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -93,6 +93,6 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   }
 
   lifecycle {
-    ignore_changes = [ "storage_data_disk" ]
+    ignore_changes = ["storage_data_disk"]
   }
 }

--- a/modules/azure/worker-ss/ignition-worker.tf
+++ b/modules/azure/worker-ss/ignition-worker.tf
@@ -3,6 +3,7 @@ data "ignition_config" "worker" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
+    "${data.ignition_file.cloud-provider-config.id}"
   ]
 
   systemd = [

--- a/modules/azure/worker-ss/ignition-worker.tf
+++ b/modules/azure/worker-ss/ignition-worker.tf
@@ -3,7 +3,7 @@ data "ignition_config" "worker" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
-    "${data.ignition_file.cloud-provider-config.id}"
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -83,7 +83,8 @@ resource "template_dir" "bootkube" {
     etcd_service_ip           = "${cidrhost(var.service_cidr, 15)}"
     bootstrap_etcd_service_ip = "${cidrhost(var.service_cidr, 20)}"
 
-    cloud_provider = "${var.cloud_provider}"
+    cloud_provider        = "${var.cloud_provider}"
+    cloud_provider_config = "${var.cloud_provider_config}"
 
     cluster_cidr        = "${var.cluster_cidr}"
     service_cidr        = "${var.service_cidr}"

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -41,8 +41,8 @@ spec:
     - mountPath: /etc/kubernetes/secrets
       name: secrets
       readOnly: true
-    - mountPath: /etc/kubernetes
-      name: etc-kubernetes
+    - mountPath: /etc/kubernetes/cloud
+      name: etc-kubernetes-cloud
       readOnly: true
     - mountPath: /var/lock
       name: var-lock
@@ -54,7 +54,7 @@ spec:
       path: /etc/kubernetes/bootstrap-secrets
   - name: etc-kubernetes-cloud
     hostPath:
-      path: /etc/kubernetes-cloud
+      path: /etc/kubernetes/cloud
   - name: ssl-certs-host
     hostPath:
       path: /usr/share/ca-certificates

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -18,6 +18,7 @@ spec:
     - --bind-address=0.0.0.0
     - --client-ca-file=/etc/kubernetes/secrets/ca.crt
     - --cloud-provider=${cloud_provider}
+    - --cloud-config=/etc/kubernetes/cloud/config
     - --etcd-servers=${etcd_servers}
     ${etcd_ca_flag}
     ${etcd_cert_flag}
@@ -40,6 +41,9 @@ spec:
     - mountPath: /etc/kubernetes/secrets
       name: secrets
       readOnly: true
+    - mountPath: /etc/kubernetes
+      name: etc-kubernetes
+      readOnly: true
     - mountPath: /var/lock
       name: var-lock
       readOnly: false
@@ -48,6 +52,9 @@ spec:
   - name: secrets
     hostPath:
       path: /etc/kubernetes/bootstrap-secrets
+  - name: etc-kubernetes-cloud
+    hostPath:
+      path: /etc/kubernetes-cloud
   - name: ssl-certs-host
     hostPath:
       path: /usr/share/ca-certificates

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -13,6 +13,7 @@ spec:
     - --allocate-node-cidrs=true
     - --cluster-cidr=${cluster_cidr}
     - --cloud-provider=${cloud_provider}
+    - --cloud-config=/etc/kubernetes/cloud/config
     - --configure-cloud-routes=false
     - --leader-elect=true
     - --kubeconfig=/etc/kubernetes/kubeconfig

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -56,6 +56,7 @@ spec:
         - --oidc-groups-claim=${oidc_groups_claim}
         - --oidc-ca-file=/etc/kubernetes/secrets/ca.crt
         - --cloud-provider=${cloud_provider}
+        - --cloud-config=/etc/kubernetes/cloud/config
         - --audit-log-path=/var/log/kubernetes/kube-apiserver-audit.log
         - --audit-log-maxage=30
         - --audit-log-maxbackup=3
@@ -66,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes/secrets
           name: secrets
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
           readOnly: true
         - mountPath: /var/lock
           name: var-lock
@@ -89,6 +93,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-apiserver
+      - name: cloud-config
+        configMap:
+          name: kube-cloud-cfg
       - name: var-lock
         hostPath:
           path: /var/lock

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -94,8 +94,8 @@ spec:
         secret:
           secretName: kube-apiserver
       - name: cloud-config
-        configMap:
-          name: kube-cloud-cfg
+        secret:
+          secretName: kube-cloud-cfg
       - name: var-lock
         hostPath:
           path: /var/lock

--- a/modules/bootkube/resources/manifests/kube-cloud-config.yaml
+++ b/modules/bootkube/resources/manifests/kube-cloud-config.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: kube-cloud-cfg
   namespace: kube-system
+type: Opaque
 data:
-  config: |
-    ${cloud_provider_config}
+  config: ${base64encode(cloud_provider_config)}

--- a/modules/bootkube/resources/manifests/kube-cloud-config.yaml
+++ b/modules/bootkube/resources/manifests/kube-cloud-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-cloud-cfg
+  namespace: kube-system
+data:
+  config: ${base64encode(cloud_provider_config)}

--- a/modules/bootkube/resources/manifests/kube-cloud-config.yaml
+++ b/modules/bootkube/resources/manifests/kube-cloud-config.yaml
@@ -4,4 +4,5 @@ metadata:
   name: kube-cloud-cfg
   namespace: kube-system
 data:
-  config: ${base64encode(cloud_provider_config)}
+  config: |
+    ${cloud_provider_config}

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -78,8 +78,8 @@ spec:
         secret:
           secretName: kube-controller-manager
       - name: cloud-config
-        configMap:
-          name: kube-cloud-cfg
+        secret:
+          secretName: kube-cloud-cfg
       - name: ssl-host
         hostPath:
           path: /usr/share/ca-certificates

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -45,6 +45,7 @@ spec:
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
         - --leader-elect=true
         - --cloud-provider=${cloud_provider}
+        - --cloud-config=/etc/kubernetes/cloud/config
         livenessProbe:
           httpGet:
             path: /healthz
@@ -54,6 +55,9 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /etc/kubernetes/secrets
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
           readOnly: true
         - name: ssl-host
           mountPath: /etc/ssl/certs
@@ -73,6 +77,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-controller-manager
+      - name: cloud-config
+        configMap:
+          name: kube-cloud-cfg
       - name: ssl-host
         hostPath:
           path: /usr/share/ca-certificates

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -40,6 +40,11 @@ variable "cloud_provider" {
   type        = "string"
 }
 
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+}
+
 variable "service_cidr" {
   description = "A CIDR notation IP range from which to assign service cluster IPs"
   type        = "string"

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -43,6 +43,7 @@ variable "cloud_provider" {
 variable "cloud_provider_config" {
   description = "Content of cloud provider config"
   type        = "string"
+  default     = ""
 }
 
 variable "service_cidr" {

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -67,6 +67,7 @@ data "null_data_source" "cloud-provider" {
     "resourceGroup"     = "${module.resource_group.name}"
     "location"          = "${var.tectonic_azure_location}"
     "subnetName"        = "${module.vnet.worker_subnet_name}"
+    "securityGroupName" = "${module.vnet.worker_nsg_name}"
     "vnetName"          = "${module.vnet.vnet_id}"
   }
 }

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -1,9 +1,9 @@
 provider "azurerm" {
-  subscription_id = "${var.tectonic_azure_subscription_id}"
-  client_id       = "${var.tectonic_azure_client_id}"
-  client_secret   = "${var.tectonic_azure_client_secret}"
-  tenant_id       = "${var.tectonic_azure_tenant_id}"
+  environment   = "${var.tectonic_azure_cloud_environment}"
+  client_secret = "${var.tectonic_azure_client_secret}"
 }
+
+data "azurerm_client_config" "current" {}
 
 module "resource_group" {
   source = "../../modules/azure/resource-group"
@@ -60,9 +60,9 @@ module "etcd" {
 data "null_data_source" "cloud-provider" {
   inputs = {
     "cloud"                      = "${var.tectonic_azure_cloud_environment}"
-    "tenantId"                   = "${var.tectonic_azure_tenant_id}"
-    "subscriptionId"             = "${var.tectonic_azure_subscription_id}"
-    "aadClientId"                = "${var.tectonic_azure_client_id}"
+    "tenantId"                   = "${data.azurerm_client_config.current.tenant_id}"
+    "subscriptionId"             = "${data.azurerm_client_config.current.subscription_id}"
+    "aadClientId"                = "${data.azurerm_client_config.current.client_id}"
     "aadClientSecret"            = "${var.tectonic_azure_client_secret}"
     "resourceGroup"              = "${module.resource_group.name}"
     "location"                   = "${var.tectonic_azure_location}"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -59,16 +59,17 @@ module "etcd" {
 # Workaround for https://github.com/hashicorp/terraform/issues/4084
 data "null_data_source" "cloud-provider" {
   inputs = {
-    "cloud"             = "${var.tectonic_azure_cloud_environment}"
-    "tenantId"          = "${var.tectonic_azure_tenant_id}"
-    "subscriptionId"    = "${var.tectonic_azure_subscription_id}"
-    "aadClientId"       = "${var.tectonic_azure_client_id}"
-    "aadClientSecret"   = "${var.tectonic_azure_client_secret}"
-    "resourceGroup"     = "${module.resource_group.name}"
-    "location"          = "${var.tectonic_azure_location}"
-    "subnetName"        = "${module.vnet.worker_subnet_name}"
-    "securityGroupName" = "${module.vnet.worker_nsg_name}"
-    "vnetName"          = "${module.vnet.vnet_id}"
+    "cloud"                      = "${var.tectonic_azure_cloud_environment}"
+    "tenantId"                   = "${var.tectonic_azure_tenant_id}"
+    "subscriptionId"             = "${var.tectonic_azure_subscription_id}"
+    "aadClientId"                = "${var.tectonic_azure_client_id}"
+    "aadClientSecret"            = "${var.tectonic_azure_client_secret}"
+    "resourceGroup"              = "${module.resource_group.name}"
+    "location"                   = "${var.tectonic_azure_location}"
+    "subnetName"                 = "${module.vnet.worker_subnet_name}"
+    "securityGroupName"          = "${module.vnet.worker_nsg_name}"
+    "vnetName"                   = "${module.vnet.vnet_id}"
+    "primaryAvailabilitySetName" = "${module.workers.availability_set_name}"
   }
 }
 

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -66,8 +66,7 @@ data "null_data_source" "cloud-provider" {
     "aadClientSecret"   = "${var.tectonic_azure_client_secret}"
     "resourceGroup"     = "${module.resource_group.name}"
     "location"          = "${var.tectonic_azure_location}"
-    "subnetName"        = "${module.vnet.master_subnet}"
-    "securityGroupName" = "${module.vnet.default_security_group}"
+    "subnetName"        = "${module.vnet.worker_subnet_name}"
     "vnetName"          = "${module.vnet.vnet_id}"
   }
 }

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -1,6 +1,8 @@
 module "bootkube" {
-  source         = "../../modules/bootkube"
-  cloud_provider = ""
+  source = "../../modules/bootkube"
+
+  cloud_provider        = "azure"
+  cloud_provider_config = "${jsonencode(data.null_data_source.cloud-provider.inputs)}"
 
   kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"
   oidc_issuer_url    = "https://${module.masters.ingress_internal_fqdn}/identity"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -65,7 +65,7 @@ module "tectonic" {
 }
 
 resource "null_resource" "tectonic" {
-  depends_on = ["module.tectonic", "module.masters"]
+  depends_on = ["module.etcd", "module.tectonic", "module.masters"]
 
   triggers {
     api-endpoint = "${module.masters.api_external_fqdn}"

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -228,24 +228,6 @@ EOF
   default = "AZUREPUBLICCLOUD"
 }
 
-variable "tectonic_azure_tenant_id" {
-  type = "string"
-
-  description = "The tenant ID to use."
-}
-
-variable "tectonic_azure_subscription_id" {
-  type = "string"
-
-  description = "The subscription ID to use."
-}
-
-variable "tectonic_azure_client_id" {
-  type = "string"
-
-  description = "The client ID to use."
-}
-
 variable "tectonic_azure_client_secret" {
   type = "string"
 

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -215,3 +215,39 @@ EOF
 
   default = ""
 }
+
+variable "tectonic_azure_cloud_environment" {
+  type = "string"
+
+  description = <<EOF
+(optional) Azure cloud environment to use. See
+https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
+for available environments.
+EOF
+
+  default = "AZUREPUBLICCLOUD"
+}
+
+variable "tectonic_azure_tenant_id" {
+  type = "string"
+
+  description = "The tenant ID to use."
+}
+
+variable "tectonic_azure_subscription_id" {
+  type = "string"
+
+  description = "The subscription ID to use."
+}
+
+variable "tectonic_azure_client_id" {
+  type = "string"
+
+  description = "The client ID to use."
+}
+
+variable "tectonic_azure_client_secret" {
+  type = "string"
+
+  description = "The client secret to use."
+}


### PR DESCRIPTION
This is WIP, I just wanted to share this early for feedback.

This closes #84 and should be fairly self-explanatory. One change in behaviour is that now you have to specify the provider config as tf variables instead of env variables so we can render the cloud provider config which include these.

I'm also not sure if the cloud config should be a config map or secret. It contains secrets but it's called cloud config, so dunno.. Probably better to use a secret.

Will update PR once I've tested everything in Azure.