### PR TITLE
tests/smoke/aws: simplify updating test policy

### DIFF
--- a/tests/smoke/aws/README.md
+++ b/tests/smoke/aws/README.md
@@ -1,0 +1,56 @@
+# Tectonic Smoke Tests on AWS
+
+This README documents how to run Tectonic smoke tests on AWS. This directory has the following configuration:
+```
+aws
+├── smoke.sh           # Utility script for planning and creating clusters and running tests
+└── vars               # Terraform tfvars files for AWS smoke tests
+    ├── aws-exp.tfvars # Default Tectonic configuration + experimental features enabled
+    ├── aws.tfvars     # Default Tectonic configuration
+    └── ...
+```
+
+All Tectonic smoke tests on AWS are run using the `smoke.sh` script found in this directory. For help using this tool, run:
+```sh
+./smoke.sh help
+```
+
+## Assume Role
+Smoke tests should be run with a role with limited privileges to ensure that the Tectonic Installer is as locked-down as possible.
+The following steps create or update a role with restricted access and assume that role for testing purposes.
+To begin, verify that the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables are set in the current shell.
+Now, edit the trust policy located at `Documentation/files/aws-sts-trust-policy.json` to include the ARN for the AWS user to be used for testing.
+Then, define a role name, e.g. `tectonic-installer`, and use the `smoke.sh` script to create a role or update an existing one:
+```sh
+export ROLE_NAME=tectonic-installer
+./smoke.sh set-role $ROLE_NAME ../../../Documentation/files/aws-policy.json ../../../Documentation/files/aws-sts-trust-policy.json
+```
+
+*Note*: the same command can be used to update the policies associated with an existing role.
+Now that the role exists, assume the role:
+```sh
+eval "$(./smoke.sh assume-role "$ROLE_NAME")"
+```
+
+## Create and Test Cluster
+Once the role has been assumed, select a Tectonic configuration to test, e.g. `aws-exp.tfvars` and plan a cluster:
+```sh
+export TEST_VARS=vars/aws-exp.tfvars
+./smoke.sh plan $TEST_VARS
+```
+
+Continue by actually creating the cluster:
+```sh
+./smoke.sh create $TEST_VARS
+```
+
+Finally, test the cluster:
+```sh
+./smoke.sh test $TEST_VARS
+```
+
+## Cleanup
+Once all testing has concluded, clean up the AWS resources that were created:
+```sh
+./smoke.sh destroy $TEST_VARS
+```

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -19,6 +19,19 @@ assume_role() {
     echo "AWS_SESSION_TOKEN=$(echo "$CREDENTIALS" | jq -r '.SessionToken'); export AWS_SESSION_TOKEN"
 }
 
+set_role() {
+    ROLE_NAME=$1
+    ROLE_POLICY=$2
+    TRUST_POLICY=$3
+    # If the role exists, then update the trust policy. Otherwise, create a new role.
+    if aws iam get-role --role-name="$ROLE_NAME" > /dev/null 2>&1 ; then
+        aws iam update-assume-role-policy --role-name="$ROLE_NAME" --policy-document=file://"$TRUST_POLICY"
+    else
+        aws iam create-role --role-name="$ROLE_NAME" --assume-role-policy-document=file://"$TRUST_POLICY"
+    fi
+    aws iam put-role-policy --role-name="$ROLE_NAME" --policy-name="$ROLE_NAME" --policy-document=file://"$ROLE_POLICY"
+}
+
 common() {
     DIR="$( cd "$( dirname "$0" )" && pwd )"
     # make core utils accessible to make
@@ -98,11 +111,13 @@ usage() {
     printf "%s is a tool for running Tectonic smoke tests on AWS.\n\n" "$(basename "$0")"
     printf "Usage:\n\n \t %s command [arguments]\n\n" "$(basename "$0")"
     printf "The commands are:\n\n"
-    printf "\t assume-role <role-name> \tassume the role specified by <role-name>\n"
-    printf "\t create <tfvars>         \tcreate a Tectonic cluster parameterized by <tfvars>\n"
-    printf "\t destroy <tfvars>        \tdestroy the Tectonic cluster parameterized by <tfvars>\n"
-    printf "\t plan <tfvars>           \tplan a Tectonic cluster parameterized by <tfvars>\n"
-    printf "\t test <tfvars>           \ttest a Tectonic cluster parameterized by <tfvars>\n"
+    printf "\t assume-role <role-name>                      assume the role specified by <role-name>\n"
+    printf "\t create <tfvars>                              create a Tectonic cluster parameterized by <tfvars>\n"
+    printf "\t destroy <tfvars>                             destroy the Tectonic cluster parameterized by <tfvars>\n"
+    printf "\t plan <tfvars>                                plan a Tectonic cluster parameterized by <tfvars>\n"
+    printf "\t set-role <role-name> <policy> <trust-policy> create or update the <role-name> role with policy at file\n"
+    printf "\t                                              path <policy> and trust policy at file path <trust-policy>\n"
+    printf "\t test <tfvars>                                test a Tectonic cluster parameterized by <tfvars>\n"
     printf "\n"
 }
 
@@ -123,6 +138,8 @@ main () {
             destroy "$@";;
         plan)
             plan "$@";;
+        set-role)
+            set_role "$@";;
         test)
             test_cluster "$@";;
         *)

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -ex
 set -o pipefail
 shopt -s expand_aliases
+DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE=${WORKSPACE:-"$(cd "$DIR"/../../.. && pwd)"}
 # Alias filter for convenience
 # shellcheck disable=SC2139
 alias filter="$WORKSPACE"/installer/scripts/filter.sh
@@ -33,7 +35,6 @@ set_role() {
 }
 
 common() {
-    DIR="$( cd "$( dirname "$0" )" && pwd )"
     # make core utils accessible to make
     export PATH=/bin:$PATH
     export PLATFORM=aws
@@ -147,4 +148,6 @@ main () {
     esac
 }
 
+pushd "$WORKSPACE" > /dev/null
 main "$@"
+popd > /dev/null


### PR DESCRIPTION
Now that smoke tests are run with a limited role, we need to simplify
how we update the policies for that role in the event that the
privileges needed to run the Tectonic installer grow or shrink. This
commit introduces a `set-role` command in the `smoke.sh` script for that
purpose and documents the use of the tool in a README.

fixes: #1001 

cc @sym3tri @ggreer 