### PR TITLE
modules/tectonic: don't exit on failure in wait_for_tpr

### DIFF
--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -43,6 +43,7 @@ function kubectl() {
 }
 
 function wait_for_tpr() {
+  set +e
   local i=0
 
   echo "Waiting for TPR $2"
@@ -51,6 +52,7 @@ function wait_for_tpr() {
     echo "TPR $2 not available yet, retrying in 5 seconds ($i)"
     sleep 5
   done
+  set -e
 }
 
 function wait_for_pods() {


### PR DESCRIPTION
Currently, if wait_for_tpr fails, whole `tectonic.sh` fails. This fixes
it.