### PR TITLE
Jenkinsfile: add `TECTONIC_INSTALLER_ROLE` to smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,9 @@ pipeline {
     }
 
     stage("Smoke Tests") {
+      environment {
+        TECTONIC_INSTALLER_ROLE = 'tectonic-installer'
+      }
       steps {
         parallel (
           "TerraForm: AWS": {


### PR DESCRIPTION
```
20:25:09 [TerraForm: AWS] + main assume-role ''
20:25:09 [TerraForm: AWS] + COMMAND=assume-role
20:25:09 [TerraForm: AWS] + '[' 2 -eq 0 ']'
20:25:09 [TerraForm: AWS] + shift
20:25:09 [TerraForm: AWS] + case $COMMAND in
20:25:09 [TerraForm: AWS] + assume_role ''
20:25:09 [TerraForm: AWS] + set +x
20:25:09 [TerraForm: AWS] 
20:25:09 [TerraForm: AWS] Parameter validation failed:
20:25:09 [TerraForm: AWS] Invalid length for parameter RoleName, value: 0, valid range: 1-inf
```