### PR TITLE
openstack: Fix flannel security groups

### DIFF
--- a/modules/openstack/nodes/secgroup.tf
+++ b/modules/openstack/nodes/secgroup.tf
@@ -35,10 +35,10 @@ resource "openstack_compute_secgroup_v2" "master" {
     cidr        = "0.0.0.0/0"
   }
 
-  // flannel overlay vxlan
+  // flannel
   rule {
-    from_port   = 8472
-    to_port     = 8472
+    from_port   = 4789
+    to_port     = 4789
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }
@@ -93,14 +93,6 @@ resource "openstack_compute_secgroup_v2" "node" {
   rule {
     from_port   = 4789
     to_port     = 4789
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // flannel overlay vxlan
-  rule {
-    from_port   = 8472
-    to_port     = 8472
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }


### PR DESCRIPTION
Flannel is configured to use UDP 4789 for vxlan overlay (https://github.com/coreos/tectonic-installer/blob/4ea97a0/modules/bootkube/resources/manifests/kube-flannel.yaml#L23) so we don't need 8472 open on any nodes. Instead, we need to also open 4789 open on controllers.