### PR TITLE
Makefile: allow injecting extra arguments to plan / apply / destroy 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ localconfig:
 	cp examples/*$(subst /,-,$(PLATFORM)) $(BUILD_DIR)/terraform.tfvars
 
 terraform-get:
-	cd $(BUILD_DIR) && $(TF_CMD) get $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && $(TF_CMD) get $(TF_GET_OPTIONS) $(TOP_DIR)/platforms/$(PLATFORM)
 
 plan: installer-env terraform-get
-	cd $(BUILD_DIR) && $(TF_CMD) plan $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && $(TF_CMD) plan $(TF_PLAN_OPTIONS) $(TOP_DIR)/platforms/$(PLATFORM)
 
 apply: installer-env terraform-get
-	cd $(BUILD_DIR) && $(TF_CMD) apply $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && $(TF_CMD) apply $(TF_APPLY_OPTIONS) $(TOP_DIR)/platforms/$(PLATFORM)
 
 destroy: installer-env terraform-get
-	cd $(BUILD_DIR) && $(TF_CMD) destroy -force $(TOP_DIR)/platforms/$(PLATFORM)
+	cd $(BUILD_DIR) && $(TF_CMD) destroy $(TF_DESTROY_OPTIONS) -force $(TOP_DIR)/platforms/$(PLATFORM)
 
 payload:
 	@${TOP_DIR}/modules/update-payload/make-update-payload.sh > /dev/null


### PR DESCRIPTION
This change allows users to inject arguments to the terraform commands invoked by make.

To use this feature, one would set environment variables like in this example:
```
export TF_GET_OPTIONS="-no-color -update=false"
export TF_PLAN_OPTIONS="-no-color -out=./plan-file"
export TF_APPLY_OPTIONS="-no-color -parallelism=20"
export TF_DESTROY_OPTIONS="-no-color -refresh=flase"
```

Our immediate use case for this feature is to be able to pass "-no-color" when running in Jenkins, thus cleaning up the log files of unreadable ANSI color codes.