### PR TITLE
modules/aws: Configure ASG minimum size = desired instance count

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -26,7 +26,7 @@ resource "aws_autoscaling_group" "masters" {
   name                 = "${var.cluster_name}-masters"
   desired_capacity     = "${var.instance_count}"
   max_size             = "${var.instance_count * 3}"
-  min_size             = "1"
+  min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.master_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -51,7 +51,7 @@ resource "aws_autoscaling_group" "workers" {
   name                 = "${var.cluster_name}-workers"
   desired_capacity     = "${var.instance_count}"
   max_size             = "${var.instance_count * 3}"
-  min_size             = "1"
+  min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.worker_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 


### PR DESCRIPTION
The Auto Scaling groups defined for masters and workers on AWS correctly configure the desired capacity based on `instance_count` but leave the minimum size = `1`. This can result in far less capacity than is desired in the event of losing an instance.