### PR TITLE
modules/aws: add dep from aws_eip.nat_eip to aws_internet_gateway.igw

### DIFF
--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -57,6 +57,11 @@ resource "aws_route_table_association" "route_net" {
 resource "aws_eip" "nat_eip" {
   count = "${var.external_vpc_id == "" ? min(var.master_az_count, var.worker_az_count) : 0}"
   vpc   = true
+
+  # Terraform does not declare an explicit dependency towards the internet gateway.
+  # this can cause the internet gateway to be deleted/detached before the EIPs.
+  # https://github.com/coreos/tectonic-installer/issues/1017#issuecomment-307780549
+  depends_on = ["aws_internet_gateway.igw"]
 }
 
 resource "aws_nat_gateway" "nat_gw" {

--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -68,7 +68,4 @@ resource "aws_nat_gateway" "nat_gw" {
   count         = "${var.external_vpc_id == "" ? min(var.master_az_count, var.worker_az_count) : 0}"
   allocation_id = "${aws_eip.nat_eip.*.id[count.index]}"
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
-
-  # TODO (sym3tri): Trying to prevent test flakes related to the `allocation_id` line above. May not be required.
-  depends_on = ["aws_eip.nat_eip"]
 }


### PR DESCRIPTION
This prevents the internet gateway to be deleted before Elastic IPs which
can cause destroy failure.

Fixes #1017