### PR TITLE
contrib,tests: add private vpc smoke test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def quay_creds = [
   )
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.13'
+def builder_image = 'quay.io/coreos/tectonic-builder:v1.15'
 
 pipeline {
   agent none

--- a/contrib/internal-cluster/README.md
+++ b/contrib/internal-cluster/README.md
@@ -1,0 +1,82 @@
+# Internal Cluster
+
+This directory contains Terraform configuration that provisions a VPC with a VPN connection in AWS. This setup is designed to emulate a customer-like deployment in order to end-to-end test deploying Tectonic as a private "Internal Cluster" to an "Existing VPC.
+
+This Terraform configuration provisions the following AWS resources by default:
+* 1 VPC with name configured by `TF_VAR_vpc_name`
+* 4 subnets in the VPC with count configured by `TF_VAR_subnet_count`
+* 1 public subnet containing an internet gateway and NAT gateway
+* 1 private Route 53 zone for `tectonic.dev.coreos.systems` configured by `TF_VAR_base_domain`
+* 1 t2.micro EC2 instance in the public subnet running [OpenVPN Access Server](https://aws.amazon.com/marketplace/pp/B00MI40CAE/ref=mkt_wir_openvpn_byol)
+* 1 VPN gateway and VPN connection
+
+## Usage
+
+### Install Terraform
+
+[Download the Terraform binary](https://www.terraform.io/downloads.html) and install it.
+
+
+### Configure Credentials
+
+Any existing credentials available in the `~/.aws/credentials` file will automatically be used. Otherwise, make the AWS credentials available by exporting the following environment variables:
+
+```
+export AWS_ACCESS_KEY_ID=<aws-key-id>
+export AWS_SECRET_ACCESS_KEY=<aws-key-secret>
+```
+
+### Additional Variables
+
+Terraform will prompt for any unset required variables. These variables can be manually entered at every run, exported as environment variables, or configured with a [terraform.tfvars](https://www.terraform.io/docs/configuration/variables.html#variable-files) file that will be ignored by git and used for every run. Simply create a `terraform.tfvars` file and set any required variables or overrides
+
+### Running
+
+Validate the configuration and plan the run with:
+
+```
+terraform plan
+```
+
+Provision the infrastructure with:
+
+```
+terraform apply
+```
+
+### Connect to the VPN
+
+Once the infrastructure is ready, Terraform will output an `ovpn_url` variable containing the URL of the OpenVPN Access Server. In order to connect to the VPN, take the following steps:
+
+1. Navigate to `ovpn_url` and login to the Access Server with the username `openvpn` and the password provided when running Terraform.
+2. Download the OpenVPN configuration file from the Access Server.
+3. Follow the instructions for the appropriate OS to setup a VPN connection using the configuration file.
+4. When establishing the VPN connection, use the same credentials used when connecting to the Access Server. If prompted, do not provide a private key password.
+
+### Manual DNS configuration
+
+Terraform does not support changing SOA TTLs in Route 53. As a result, in order to make use of the private zone immediately, the TTLs must be manually modified in the AWS console.
+
+### Tectonic Installation
+
+Once all the infrastructure is provisioned and the VPN connection is available, a Tectonic clusyou can be installed the VPC. When running the Tectonic installer, be sure to:
+
+* Select the provisioned private DNS Zone using the GUI or by setting the `TF_VAR_tectonic_aws_external_private_zone` environment variable.
+* Install Tectonic in the provisioned VPC by selecting the "Existing VPC" option and selecting the appropriate VPC ID in the GUI or by setting the `TF_VAR_tectonic_aws_external_vpc_id` environment variable.
+
+
+### Tear Down
+
+To tear down the infrastructure or to restart the process, run:
+
+```
+terraform destroy
+```
+
+### Troubleshooting
+
+If `terraform apply` fails, Terraform will not automatically roll back the created resources. Before attempting to create the infrastructure again, the resources must be destroyed manually by running:
+
+```
+terraform destroy
+```

--- a/contrib/internal-cluster/main.tf
+++ b/contrib/internal-cluster/main.tf
@@ -1,0 +1,118 @@
+provider "aws" {
+  region = "${var.vpc_aws_region}"
+}
+
+# Declare the data source
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "vpc" {
+  cidr_block           = "${var.vpc_cidr}"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "${var.vpc_name}"
+  }
+}
+
+# Private DNS zone
+resource "aws_route53_zone" "priv_zone" {
+  name    = "${var.base_domain}"
+  vpc_id  = "${aws_vpc.vpc.id}"
+  comment = "Managed by Terraform"
+
+  tags {
+    Name = "${var.vpc_name}"
+  }
+}
+
+# IGW
+resource "aws_internet_gateway" "igw" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  tags {
+    Name = "${var.vpc_name}-igw"
+  }
+}
+
+# NAT Gateway
+resource "aws_eip" "natgw" {
+  vpc = true
+}
+
+resource "aws_nat_gateway" "natgw" {
+  allocation_id = "${aws_eip.natgw.id}"
+  subnet_id     = "${aws_subnet.pub_subnet_generic.id}"
+  depends_on    = ["aws_internet_gateway.igw"]
+}
+
+# General purpose public subnet. used for OVPN access and IGW/NAT attachment.
+resource "aws_subnet" "pub_subnet_generic" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  # 1st available AZ
+  availability_zone       = "${data.aws_availability_zones.available.names[0]}"
+  cidr_block              = "10.0.255.0/24"
+  map_public_ip_on_launch = true
+
+  tags {
+    Name = "${var.vpc_name}-vpn"
+  }
+}
+
+resource "aws_route_table_association" "pub_subnet_generic" {
+  subnet_id      = "${aws_subnet.pub_subnet_generic.id}"
+  route_table_id = "${aws_route_table.pub_rt.id}"
+}
+
+# public subnet route table
+resource "aws_route_table" "pub_rt" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.igw.id}"
+  }
+
+  tags {
+    Name = "${var.vpc_name}-public"
+  }
+}
+
+# private subnets
+resource "aws_subnet" "priv_subnet" {
+  count             = "${var.subnet_count}"
+  vpc_id            = "${aws_vpc.vpc.id}"
+  availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+  cidr_block        = "${cidrsubnet(var.vpc_cidr, 8, count.index + 100)}"
+
+  tags {
+    Name = "${var.vpc_name}-${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "priv_subnet" {
+  count          = "${var.subnet_count}"
+  subnet_id      = "${aws_subnet.priv_subnet.*.id[count.index]}"
+  route_table_id = "${aws_route_table.priv_rt.id}"
+}
+
+# private subnet route table
+resource "aws_route_table" "priv_rt" {
+  vpc_id           = "${aws_vpc.vpc.id}"
+  propagating_vgws = ["${aws_vpn_gateway.vpg.id}"]
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = "${aws_nat_gateway.natgw.id}"
+  }
+
+  route {
+    cidr_block = "${var.local_network_cidr}"
+    gateway_id = "${aws_vpn_gateway.vpg.id}"
+  }
+
+  tags {
+    Name = "${var.vpc_name}-private"
+  }
+}

--- a/contrib/internal-cluster/vars.tf
+++ b/contrib/internal-cluster/vars.tf
@@ -1,0 +1,79 @@
+# placeholders for access_key / secret_key
+# should be fed through env var or variable file
+# https://www.terraform.io/docs/configuration/variables.html
+
+variable vpc_name {
+  description = "The name of the VPC to identify created resources."
+}
+
+variable base_domain {
+  default     = "tectonic.dev.coreos.systems"
+  description = "The base domain for this cluster's FQDN"
+}
+
+variable vpc_aws_region {
+  description = "The target AWS region for the cluster"
+}
+
+variable vpc_cidr {
+  default     = "10.0.0.0/16"
+  description = "The CIDR range used for your entire VPC"
+}
+
+variable subnet_count {
+  default     = 4
+  description = "Number of private subnets to pre-create"
+}
+
+variable local_network_cidr {
+  default     = "10.7.0.0/16"
+  description = "IP range in the network your laptop is on (dosn't actually matter unless your instances need to connect to the local network your laptop is on)"
+}
+
+variable ovpn_password {
+  default     = "PASSWORD"
+  description = "password to use when connecting"
+}
+
+variable ovpn_ami_ids {
+  # For details see: https://docs.openvpn.net/how-to-tutorialsguides/virtual-platforms/amazon-ec2-appliance-ami-quick-start-guide/
+  description = "AMI IDs of the OVPN appliance images per region."
+  type        = "map"
+
+  default = {
+    us-west-1      = "ami-4a02492a"
+    us-west-2      = "ami-d3e743b3"
+    us-east-1      = "ami-bc3566ab"
+    us-east-2      = "ami-10306a75"
+    eu-west-1      = "ami-f53d7386"
+    eu-central-1   = "ami-ad1fe6c2"
+    ap-southeast-1 = "ami-a859ffcb"
+    ap-northeast-1 = "ap-northeast-1"
+    ap-southeast-2 = "ami-89477aea"
+    sa-east-1      = "ami-0c069b60kj"
+  }
+}
+
+output "ovpn_url" {
+  value = "https://${aws_eip.ovpn_eip.public_ip}:443"
+}
+
+output "base_domain" {
+  value = "${var.base_domain}"
+}
+
+output "private_zone_id" {
+  value = "${aws_route53_zone.priv_zone.id}"
+}
+
+output "vpc_id" {
+  value = "${aws_vpc.vpc.id}"
+}
+
+output "vpc_dns" {
+  value = "${cidrhost(var.vpc_cidr, 2)}"
+}
+
+output "subnets" {
+  value = "${aws_subnet.priv_subnet.*.id}"
+}

--- a/contrib/internal-cluster/vpn.tf
+++ b/contrib/internal-cluster/vpn.tf
@@ -1,0 +1,117 @@
+resource "aws_vpn_gateway" "vpg" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  # 1st available AZ
+  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+
+  tags {
+    Name = "${var.vpc_name}-vpg"
+  }
+}
+
+resource "aws_instance" "ovpn" {
+  # 1st available AZ
+  availability_zone      = "${data.aws_availability_zones.available.names[0]}"
+  ami                    = "${lookup(var.ovpn_ami_ids, var.vpc_aws_region)}"
+  instance_type          = "t2.micro"
+  subnet_id              = "${aws_subnet.pub_subnet_generic.id}"
+  vpc_security_group_ids = ["${aws_security_group.vpn_sg.id}"]
+
+  user_data = <<EOF
+public_hostname=${aws_eip.ovpn_eip.public_ip}
+admin_user=openvpn
+admin_pw=${var.ovpn_password}
+reroute_gw=1
+reroute_dns=1
+EOF
+
+  depends_on = ["aws_eip.ovpn_eip"]
+
+  tags {
+    Name = "${var.vpc_name}-ovpn-server"
+  }
+}
+
+resource "aws_eip" "ovpn_eip" {
+  vpc = true
+}
+
+resource "aws_eip_association" "vpn_eip_assoc" {
+  instance_id   = "${aws_instance.ovpn.id}"
+  allocation_id = "${aws_eip.ovpn_eip.id}"
+}
+
+resource "aws_security_group" "vpn_sg" {
+  name        = "ovpn-server-sg"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${aws_vpc.vpc.id}"
+
+  ingress {
+    from_port   = 943
+    to_port     = 943
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 943
+    to_port     = 943
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 1194
+    to_port     = 1194
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+
+    # all
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.vpc_name}-ovpn-sg"
+  }
+}
+
+resource "aws_customer_gateway" "customer_gateway" {
+  bgp_asn    = 65000
+  ip_address = "${aws_eip.ovpn_eip.public_ip}"
+  type       = "ipsec.1"
+
+  tags {
+    Name = "${var.vpc_name}-customer-gateway"
+  }
+}
+
+resource "aws_vpn_connection" "main" {
+  vpn_gateway_id      = "${aws_vpn_gateway.vpg.id}"
+  customer_gateway_id = "${aws_customer_gateway.customer_gateway.id}"
+  type                = "ipsec.1"
+  static_routes_only  = true
+
+  tags {
+    Name = "${var.vpc_name}-vpn-conn"
+  }
+}

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -30,7 +30,7 @@ RUN chmod 777 -R ${HOME}
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y -q \
-    build-essential sudo curl wget git autoconf automake unzip libtool jq shellcheck awscli gnupg1
+    build-essential sudo curl wget git autoconf automake unzip libtool jq shellcheck awscli gnupg1 openvpn
 
 # install terraform
 RUN curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-set -ex -o pipefail
+set -exuo pipefail
 shopt -s expand_aliases
-DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Allow smoke.sh to work off jenkins.
 WORKSPACE=${WORKSPACE:-"$(cd "$DIR"/../../.. && pwd)"}
+BUILD_ID=${BUILD_ID:-1}
+BRANCH_NAME=${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}
+
 # Alias filter for convenience
 # shellcheck disable=SC2139
 alias filter="$WORKSPACE"/installer/scripts/filter.sh
@@ -35,6 +39,15 @@ set_role() {
     aws iam put-role-policy --role-name="$ROLE_NAME" --policy-name="$ROLE_NAME" --policy-document=file://"$ROLE_POLICY"
 }
 
+random_region() {
+    # randomly select region
+    REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
+    export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
+    i=$(( CHANGE_ID % ${#REGIONS[@]} ))
+    export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
+    export AWS_REGION="${REGIONS[$i]}"
+}
+
 common() {
     # make core utils accessible to make
     export PATH=/bin:$PATH
@@ -61,16 +74,11 @@ common() {
         echo "Cluster name too short. Appended to $CLUSTER"
     fi
     
+    random_region
     CLUSTER=$(echo "${CLUSTER}" | awk '{print tolower($0)}')
     export CLUSTER
     export TF_VAR_tectonic_cluster_name=$CLUSTER
     
-    # randomly select region
-    REGIONS=(us-east-1 us-east-2 us-west-1 us-west-2)
-    export CHANGE_ID=${CHANGE_ID:-${BUILD_ID}}
-    i=$(( CHANGE_ID % ${#REGIONS[@]} ))
-    export TF_VAR_tectonic_aws_region="${REGIONS[$i]}"
-    export AWS_REGION="${REGIONS[$i]}"
     echo "selected region: $TF_VAR_tectonic_aws_region"
     echo "cluster name: $CLUSTER"
 
@@ -83,6 +91,72 @@ common() {
 create() {
     common "$1"
     make apply | filter
+}
+
+common_vpc() {
+    random_region
+    export TF_VAR_vpc_aws_region="$TF_VAR_tectonic_aws_region"
+    # shellcheck disable=SC2155
+    export TF_VAR_vpc_name="$(echo "vpc-$BRANCH_NAME-$BUILD_ID" | awk '{print tolower($0)}')"
+}
+
+create_vpc() {
+    common_vpc
+    pushd "$WORKSPACE/contrib/internal-cluster"
+    set +x
+    # shellcheck disable=SC2155
+    export TF_VAR_ovpn_password="$(tr -cd '[:alnum:]' < /dev/urandom | head -c 32 ; echo)"
+    set -x
+    # Create the vpc.
+    terraform apply
+    # Get the VPN details.
+    # shellcheck disable=SC2155
+    local vpn_url="$(terraform output -json | jq -r '.ovpn_url.value')"
+    until curl -k -L --silent "$vpn_url" > /dev/null; do
+        echo "waiting for vpn access server to become available"
+        sleep 5
+    done
+    set +x
+    curl -k -L -u "openvpn:$TF_VAR_ovpn_password" --silent --fail "$(terraform output -json | jq -r '.ovpn_url.value')"/rest/GetUserlogin > vpn.conf
+    printf "openvpn\n%s\n" "$TF_VAR_ovpn_password" > vpn_credentials
+    set -x
+    sed -i 's/auth-user-pass/auth-user-pass vpn_credentials/g' vpn.conf
+    # Start the VPN.
+    openvpn --config vpn.conf --daemon
+    until ping -c 1 8.8.8.8 > /dev/null; do
+        echo "waiting for vpn connection to become available"
+        sleep 5
+    done
+    # Use AWS VPC DNS rather than host's.
+    # shellcheck disable=SC2155
+    local vpc_dns="$(terraform output -json | jq -r '.vpc_dns.value')"
+    cp /etc/resolv.conf /etc/resolv.conf.bak
+    echo "nameserver $vpc_dns" > /etc/resolv.conf
+    echo "nameserver 8.8.8.8"  >> /etc/resolv.conf
+    # Export all of the VPC details.
+    # shellcheck disable=SC2155,SC2183,SC2046
+    {
+        export TF_VAR_tectonic_aws_external_private_zone="$(terraform output -json | jq -r '.private_zone_id.value')"
+        export TF_VAR_tectonic_aws_external_vpc_id="$(terraform output -json | jq -r '.vpc_id.value')"
+        export TF_VAR_tectonic_aws_external_master_subnet_ids="$(printf "[%s, %s]" $(terraform output -json | jq '.subnets.value[0,1]'))"
+        export TF_VAR_tectonic_aws_external_worker_subnet_ids="$(printf "[%s, %s]" $(terraform output -json | jq '.subnets.value[2,3]'))"
+        export TF_VAR_tectonic_base_domain="$(terraform output -json | jq -r '.base_domain.value')"
+    }
+    popd
+}
+
+destroy_vpc() {
+    common_vpc
+    # Restore host DNS settings.
+    [ -f /etc/resolv.conf.bak ] && cat /etc/resolv.conf.bak > /etc/resolv.conf && rm /etc/resolv.conf.bak
+    pushd "$WORKSPACE/contrib/internal-cluster"
+    pkill openvpn || true
+    until ping -c 1 8.8.8.8 > /dev/null; do
+        echo "waiting for network to become available"
+        sleep 5
+    done
+    terraform destroy --force
+    popd
 }
 
 destroy() {
@@ -136,8 +210,12 @@ main () {
             assume_role "$@";;
         create)
             create "$@";;
+        create-vpc)
+            create_vpc "$@";;
         destroy)
             destroy "$@";;
+        destroy-vpc)
+            destroy_vpc "$@";;
         plan)
             plan "$@";;
         set-role)

--- a/tests/smoke/aws/vars/aws-vpc.tfvars
+++ b/tests/smoke/aws/vars/aws-vpc.tfvars
@@ -1,0 +1,31 @@
+tectonic_worker_count = "4"
+
+tectonic_master_count = "3"
+
+tectonic_etcd_count = "3"
+
+tectonic_etcd_servers = [""]
+
+tectonic_cl_channel = "stable"
+
+tectonic_admin_email = "example@coreos.com"
+
+tectonic_admin_password_hash = "$2a$12$k9wa31uE/4uD9aVtT/vNtOZwxXyEJ/9DwXXEYB/eUpb9fvEPsH/kO" # PASSWORD
+
+tectonic_ca_cert = ""
+
+tectonic_ca_key = ""
+
+tectonic_aws_ssh_key = "jenkins"
+
+tectonic_aws_master_ec2_type = "m4.large"
+
+tectonic_aws_worker_ec2_type = "m4.large"
+
+tectonic_aws_etcd_ec2_type = "m4.large"
+
+tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
+
+tectonic_aws_external_vpc_public = false
+
+tectonic_aws_az_count = "2"


### PR DESCRIPTION
Enable a smoke test that creates Tectonic cluster in a private VPC. In
order for this to work, we need to first create a VPN connection into
the private VPC. This commit adds two commands to smoke.sh for managing
the state of the private VPC `create-vpc` and `destroy-vpc`.