### PR TITLE
platforms/openstack/neutron: Fix external resources for self-hosted etcd

### DIFF
--- a/platforms/openstack/neutron/dns.tf
+++ b/platforms/openstack/neutron/dns.tf
@@ -45,6 +45,7 @@ resource "aws_route53_record" "worker_nodes" {
 
 resource "aws_route53_record" "etcd_srv_discover" {
   name    = "_etcd-server._tcp"
+  count   = "${var.tectonic_experimental ? 0 : 1}"
   type    = "SRV"
   records = ["${formatlist("0 0 2380 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
   ttl     = "300"
@@ -53,6 +54,7 @@ resource "aws_route53_record" "etcd_srv_discover" {
 
 resource "aws_route53_record" "etcd_srv_client" {
   name    = "_etcd-client._tcp"
+  count   = "${var.tectonic_experimental ? 0 : 1}"
   type    = "SRV"
   records = ["${formatlist("0 0 2379 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
   ttl     = "60"
@@ -60,7 +62,7 @@ resource "aws_route53_record" "etcd_srv_client" {
 }
 
 resource "aws_route53_record" "etc_a_nodes" {
-  count   = "${var.tectonic_etcd_count}"
+  count   = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
   type    = "A"
   ttl     = "60"
   name    = "${var.tectonic_cluster_name}-etcd-${count.index}"

--- a/platforms/openstack/neutron/network.tf
+++ b/platforms/openstack/neutron/network.tf
@@ -26,7 +26,7 @@ resource "openstack_networking_router_interface_v2" "interface" {
 # etcd
 
 resource "openstack_networking_port_v2" "etcd" {
-  count              = "${var.tectonic_etcd_count}"
+  count              = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
   name               = "${var.tectonic_cluster_name}_port_etcd_${count.index}"
   network_id         = "${openstack_networking_network_v2.network.id}"
   security_group_ids = ["${module.etcd.secgroup_id}"]

--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -1,7 +1,7 @@
 # etcd
 
 resource "openstack_compute_instance_v2" "etcd_node" {
-  count     = "${var.tectonic_etcd_count}"
+  count     = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
   name      = "${var.tectonic_cluster_name}_etcd_node_${count.index}"
   image_id  = "${var.tectonic_openstack_image_id}"
   flavor_id = "${var.tectonic_openstack_flavor_id}"


### PR DESCRIPTION
With `experimental=true`, no etcd nodes should be created, and external
DNS records are not needed.

/cc @s-urbaniak 