### PR TITLE
GUI tests: wait for platform select to be visible, not body.

### DIFF
--- a/installer/frontend/ui-tests/pages/platformPage.js
+++ b/installer/frontend/ui-tests/pages/platformPage.js
@@ -1,7 +1,7 @@
 const platformPageCommands = {
   selectPlatform() {
     return this
-      .waitForElementVisible('body', 100000)
+      .waitForElementVisible('select#platformType', 100000)
       .click('@awsPlatform')
       .click('@nextStep');
   },


### PR DESCRIPTION
Should fix a flakiness issue with GUI tests.