### PR TITLE
Jenkinsfile: retry destroy on AWS Smoke until #1017/#1054 are fixed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,8 +88,15 @@ pipeline {
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws.tfvars
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws.tfvars
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
                     """
+                  }
+                  retry(3) {
+                    timeout(15) {
+                      sh """#!/bin/bash -ex
+                      . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                      ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
+                      """
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Because we cannot `destroy` the AWS cluster on first try due to various [flakes](https://github.com/coreos/tectonic-installer/issues/1017). None of the Smoke Tests passed today, mostly due to the IGW time-out issue (currently hardcoded in Terraform). This add retries on the `destroy` step, thus allowing the smoke tests to pass if we were able to destroy the cluster eventually. What this means technically is that we expect our users to run destroy multiples times. This change should be reverted once everything is back to normal.

We keep the failure hook in case `apply` fails, so we can garbage collect.