### PR TITLE
vmware: enable vmware tools on controller/master

### DIFF
--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -18,6 +18,7 @@ data "ignition_config" "node" {
     "${data.ignition_systemd_unit.kubelet-env.id}",
     "${data.ignition_systemd_unit.bootkube.id}",
     "${data.ignition_systemd_unit.tectonic.id}",
+    "${data.ignition_systemd_unit.vmtoolsd_member.id}",
   ]
 
   networkd = [


### PR DESCRIPTION
VMware Tools were enabled on etcd nodes but not enabled on Controller/Worker nodes. Systemd unit resource already existed, however was not part of the main ignition-config resource. Binaries for open-vm-tools are already part of CoreOS Container Linux VMware release image.

https://github.com/vmware/open-vm-tools
