### PR TITLE
Azure: configure corresponding AS for VMs

### DIFF
--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -54,6 +54,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${element(azurerm_network_interface.tectonic_master.*.id, count.index)}"]
   vm_size               = "${var.vm_size}"
+  availability_set_id   = "${azurerm_availability_set.tectonic_masters.id}"
 
   storage_image_reference {
     publisher = "CoreOS"

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -1,6 +1,3 @@
-# TODO
-# Add to availabilityset
-
 # Generate unique storage name
 resource "random_id" "tectonic_storage_name" {
   byte_length = 4
@@ -58,6 +55,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${element(azurerm_network_interface.tectonic_worker.*.id, count.index)}"]
   vm_size               = "${var.vm_size}"
+  availability_set_id   = "${azurerm_availability_set.tectonic_workers.id}"
 
   storage_image_reference {
     publisher = "CoreOS"


### PR DESCRIPTION
This change assigns the newly introduced Availability Sets to the corresponding Virtual Machines.
Without this, the node VMs would not actually be placed in the respective AvSets.

/cc: @discordianfish 