### PR TITLE
ELB Name is CLUSTER-api-int

### DIFF
--- a/modules/aws/ignition/resources/detect-master.sh
+++ b/modules/aws/ignition/resources/detect-master.sh
@@ -23,7 +23,7 @@ while true; do
   sleep 15
 done
 
-API_HEALTHY=$(aws elb describe-instance-health --region="$REGION" --load-balancer-name "$CLUSTER_NAME-api-internal" | jq -r '[ .InstanceStates[] | select(.State | contains("InService")) ] | length > 1')
+API_HEALTHY=$(aws elb describe-instance-health --region="$REGION" --load-balancer-name "$CLUSTER_NAME-int" | jq -r '[ .InstanceStates[] | select(.State | contains("InService")) ] | length > 1')
 
 if [ "$API_HEALTHY" == "true" ]; then
     echo "Healthy API instances found, cluster is already installed."

--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -24,7 +24,7 @@ resource "aws_elb" "api-internal" {
   }
 
   tags = "${merge(map(
-      "Name", "${var.cluster_name}-api-internal",
+      "Name", "${var.cluster_name}-int",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
       "tectonicClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"


### PR DESCRIPTION
The ELB name was changed in #920 from `CLUSTER-api-internal` to `CLUSTER-int`
In addition the tag Name is set for the AWS ELB, but is not the same as the actual ELB name.  In the AWS console `CLUSTER-int` shows up on the right side which is the actual ELB name, but in the tags for the ELB `Name=CLUSTER-api-internal` is listed which may cause confusion.