### PR TITLE
tests/smoke/aws: enable destroy retry for vpc test

### DIFF
--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -106,6 +106,7 @@ create_vpc() {
     set +x
     # shellcheck disable=SC2155
     export TF_VAR_ovpn_password="$(tr -cd '[:alnum:]' < /dev/urandom | head -c 32 ; echo)"
+    export TF_VAR_base_domain="tectonic.dev.coreos.systems"
     set -x
     # Create the vpc.
     terraform apply
@@ -140,7 +141,6 @@ create_vpc() {
         export TF_VAR_tectonic_aws_external_vpc_id="$(terraform output -json | jq -r '.vpc_id.value')"
         export TF_VAR_tectonic_aws_external_master_subnet_ids="$(printf "[%s, %s]" $(terraform output -json | jq '.subnets.value[0,1]'))"
         export TF_VAR_tectonic_aws_external_worker_subnet_ids="$(printf "[%s, %s]" $(terraform output -json | jq '.subnets.value[2,3]'))"
-        export TF_VAR_tectonic_base_domain="$(terraform output -json | jq -r '.base_domain.value')"
     }
     popd
 }

--- a/tests/smoke/aws/vars/aws-vpc.tfvars
+++ b/tests/smoke/aws/vars/aws-vpc.tfvars
@@ -6,6 +6,8 @@ tectonic_etcd_count = "3"
 
 tectonic_etcd_servers = [""]
 
+tectonic_base_domain = "tectonic.dev.coreos.systems"
+
 tectonic_cl_channel = "stable"
 
 tectonic_admin_email = "example@coreos.com"


### PR DESCRIPTION
This commit enables the cleanup destroy block to run for private VPC
test clusters even if `create-vpc` was not run in the same shell.

To test:
```sh
docker run --rm -it -v $PWD:/go/src/tectonic-installer \
    -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
    --device=/dev/net/tun --cap-add=NET_ADMIN \
    -w /go/src/tectonic-installer quay.io/coreos/tectonic-builder:v1.15 /bin/bash
./tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
```
Verify that Terraform does not hang while waiting for input. Instead,
Terraform should error because it could not find the tfstate file in
question, which is expected unless the cluster was created. The benefit
is that now, as long as the cluster was created, it does not matter if
`create-vpc` was run or not.

cc @ggreer @Quentin-M 