### PR TITLE
tests/smoke/aws/vars: reduce test node count

### DIFF
--- a/tests/smoke/aws/vars/aws-vpc.tfvars
+++ b/tests/smoke/aws/vars/aws-vpc.tfvars
@@ -1,8 +1,8 @@
-tectonic_worker_count = "4"
+tectonic_worker_count = "2"
 
-tectonic_master_count = "3"
+tectonic_master_count = "1"
 
-tectonic_etcd_count = "3"
+tectonic_etcd_count = "1"
 
 tectonic_etcd_servers = [""]
 


### PR DESCRIPTION
This commit reduces the node count for the private vpc test in order to
accomplish two goals:
1. smoke test bringing up a single master cluster; and
2. reduce total resource utilization.

This test should give us greater confidence in the installer since it
tests a new configuration.

cc @Quentin-M @kans 