### PR TITLE
Enforce Real HA of critical K8's components

### DIFF
--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -21,6 +21,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
               labelSelector:
                 matchExpressions:
                 - key: tier
@@ -31,7 +34,6 @@ spec:
                   operator: In
                   values:
                   - kube-contoller-manager
-              topologyKey: kubernetes.io/hostname
       containers:
       - name: kube-controller-manager
         image: ${hyperkube_image}

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -21,6 +21,9 @@ spec:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+          - weight: 50
+            podAffinityTerm:
               labelSelector:
                 matchExpressions:
                 - key: tier
@@ -31,7 +34,6 @@ spec:
                   operator: In
                   values:
                   - kube-scheduler
-              topologyKey: kubernetes.io/hostname
       containers:
       - name: kube-scheduler
         image: ${hyperkube_image}


### PR DESCRIPTION
Ensure that critical control-plane scheduling always occurs in multiple nodes & AZ's where possible for cluster disaster recovery.

Old scheduling rules would allow all pods to run on the same host bringing down the cluster with extended AZ unavailability or Host Corruption