### PR TITLE
tectonic: bump ingress replicas 1 -> 2

### DIFF
--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -25,6 +25,22 @@ spec:
         component: ui
       name: tectonic-console
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - ui
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - tectonic-console
+              topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /opt/bridge/bin/bridge

--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:

--- a/modules/tectonic/resources/manifests/identity/deployment.yaml
+++ b/modules/tectonic/resources/manifests/identity/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:

--- a/modules/tectonic/resources/manifests/identity/deployment.yaml
+++ b/modules/tectonic/resources/manifests/identity/deployment.yaml
@@ -23,6 +23,22 @@ spec:
         k8s-app: tectonic-identity
         component: identity
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - identity
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - tectonic-identity
+              topologyKey: kubernetes.io/hostname
       volumes:
       - name: config
         configMap:

--- a/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: default-http-backend
   namespace: tectonic-system
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
@@ -10,6 +10,18 @@ spec:
       labels:
         k8s-app: default-http-backend
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - default-http-backend
+              topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend

--- a/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     component: ingress-controller
     type: nginx
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -16,6 +16,22 @@ spec:
         component: ingress-controller
         type: nginx
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - ingress-controller
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - tectonic-lb
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: nginx-ingress-lb
           image: ${ingress_controller_image}


### PR DESCRIPTION
Increase the size of replicas for ingress controller (nodeport) and ingress default-backend from 1 to 2
