### PR TITLE
vmware: private key variable

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -26,7 +26,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_node_dns | DNS Server to be useddd by Virtual Machine(s) | string | - |
 | tectonic_vmware_server | vCenter Server IP/FQDN | string | - |
 | tectonic_vmware_ssh_authorized_key | SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."` | string | - |
-| tectonic_vmware_ssh_private_key_path | SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used. | string | `` |
+| tectonic_vmware_ssh_private_key_path | SSH private key file in .pem format corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used. | string | `` |
 | tectonic_vmware_sslselfsigned | Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"` | string | - |
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -185,7 +185,7 @@ tectonic_vmware_server = ""
 // SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."`
 tectonic_vmware_ssh_authorized_key = ""
 
-// SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used.
+// SSH private key file in .pem format corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used.
 tectonic_vmware_ssh_private_key_path = ""
 
 // Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"`

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -26,7 +26,7 @@ resource "vsphere_virtual_machine" "node" {
   connection {
     type        = "ssh"
     user        = "core"
-    private_key = "${file(var.tectonic_vmware_ssh_private_key_path != "" ? pathexpand(var.tectonic_vmware_ssh_private_key_path) : "/dev/null")}"
+    private_key = "${file(var.private_key != "" ? pathexpand(var.private_key) : "/dev/null")}"
   }
 
   provisioner "file" {

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -125,6 +125,12 @@ variable "kubeconfig" {
   description = "Contents of Kubeconfig"
 }
 
+variable "private_key" {
+  type        = "string"
+  description = "SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used."
+  default     = ""
+}
+
 variable "image_re" {
   description = <<EOF
 (internal) Regular expression used to extract repo and tag components from image strings

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -127,7 +127,7 @@ variable "kubeconfig" {
 
 variable "private_key" {
   type        = "string"
-  description = "SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used."
+  description = "SSH private key file in .pem format corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used."
   default     = ""
 }
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -60,6 +60,7 @@ module "masters" {
   vm_disk_template_folder = "${var.tectonic_vmware_vm_template_folder}"
   vmware_folder           = "${vsphere_folder.tectonic_vsphere_folder.path}"
   kubeconfig              = "${module.bootkube.kubeconfig}"
+  private_key             = "${var.tectonic_vmware_ssh_private_key_path}"
   image_re                = "${var.tectonic_image_re}"
 }
 
@@ -92,5 +93,6 @@ module "workers" {
   vm_disk_template_folder = "${var.tectonic_vmware_vm_template_folder}"
   vmware_folder           = "${vsphere_folder.tectonic_vsphere_folder.path}"
   kubeconfig              = "${module.bootkube.kubeconfig}"
+  private_key             = "${var.tectonic_vmware_ssh_private_key_path}"
   image_re                = "${var.tectonic_image_re}"
 }

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -54,7 +54,7 @@ variable "tectonic_vmware_ssh_authorized_key" {
 
 variable "tectonic_vmware_ssh_private_key_path" {
   type        = "string"
-  description = "SSH private key file corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used."
+  description = "SSH private key file in .pem format corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used."
   default     = ""
 }
 


### PR DESCRIPTION
Looks like https://github.com/coreos/tectonic-installer/pull/995 broke the master for vmware. This is my fault with bad testing :( 

VMware module was referencing `tectonic_vmware_ssh_private_key_path` variable that exists in platform/variables.tf but not known to individual module. This pr passes `tectonic_vmware_ssh_private_key_path` to VMware module.
