### PR TITLE
platforms/openstack/neutron: Add LBaaSv2 for masters

### DIFF
--- a/platforms/openstack/neutron/lbaas.tf
+++ b/platforms/openstack/neutron/lbaas.tf
@@ -1,0 +1,36 @@
+resource "openstack_lb_loadbalancer_v2" "master_lb" {
+  vip_subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+  name          = "${var.tectonic_cluster_name}_master"
+}
+
+resource "openstack_lb_pool_v2" "master_lb_pool" {
+  lb_method       = "ROUND_ROBIN"
+  protocol        = "TCP"
+  name            = "https"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.master_lb.id}"
+}
+
+resource "openstack_lb_listener_v2" "master_lb_listener" {
+  default_pool_id = "${openstack_lb_pool_v2.master_lb_pool.id}"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.master_lb.id}"
+  protocol        = "TCP"
+  protocol_port   = 443
+  name            = "https"
+}
+
+resource "openstack_lb_monitor_v2" "master_lb_monitor" {
+  delay       = 30
+  max_retries = 3
+  pool_id     = "${openstack_lb_pool_v2.master_lb_pool.id}"
+  timeout     = 5
+  type        = "TCP"
+  name        = "https"
+}
+
+resource "openstack_lb_member_v2" "master_lb_members" {
+  count         = "${var.tectonic_master_count}"
+  address       = "${element(openstack_networking_port_v2.master.*.all_fixed_ips[count.index], 0)}"
+  pool_id       = "${openstack_lb_pool_v2.master_lb_pool.id}"
+  protocol_port = 443
+  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+}

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -188,7 +188,7 @@ module "dns" {
 
   admin_email = "${var.tectonic_admin_email}"
 
-  api_ips          = "${openstack_networking_floatingip_v2.master.*.address}"
+  api_ips          = "${openstack_networking_floatingip_v2.loadbalancer.*.address}"
   etcd_count       = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
   etcd_ips         = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
   etcd_tls_enabled = "${var.tectonic_etcd_tls_enabled}"

--- a/platforms/openstack/neutron/network.tf
+++ b/platforms/openstack/neutron/network.tf
@@ -90,3 +90,8 @@ resource "openstack_networking_floatingip_v2" "worker" {
   count = "${var.tectonic_worker_count}"
   pool  = "${var.tectonic_openstack_floatingip_pool}"
 }
+
+resource "openstack_networking_floatingip_v2" "loadbalancer" {
+  pool    = "${var.tectonic_openstack_floatingip_pool}"
+  port_id = "${openstack_lb_loadbalancer_v2.master_lb.vip_port_id}"
+}

--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -124,6 +124,7 @@ resource "null_resource" "tectonic" {
     "openstack_compute_instance_v2.master_node",
     "openstack_networking_port_v2.master",
     "openstack_networking_floatingip_v2.master",
+    "openstack_networking_floatingip_v2.loadbalancer",
   ]
 
   connection {


### PR DESCRIPTION
Add LBaaSv2 load balancer to balance traffic for k8s masters.
DNS record for the API is updated to point to the load balancer
rather than the masters directly. A floating IP is associated with
the load balancer to provide internet connectivity.

/cc @s-urbaniak 