### PR TITLE
vmware: fixed example variable names for VMWare terraform vars

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -19,7 +19,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_ingress_domain | The domain name which resolves to Tectonic Ingress (i.e. worker node(s)) | string | - |
 | tectonic_vmware_master_gateway | Default Gateway IP address for Master nodes(s) | string | - |
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:    tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
-| tectonic_vmware_master_ip | Terraform map of Master node(s) IP Addresses, Example:    tectonic_vmware_vm_masterips = {   "0" = "192.168.246.20/24"   "1" = "192.168.246.21/24" } | map | - |
+| tectonic_vmware_master_ip | Terraform map of Master node(s) IP Addresses, Example:    tectonic_vmware_master_ip = {   "0" = "192.168.246.20/24"   "1" = "192.168.246.21/24" } | map | - |
 | tectonic_vmware_master_memory | Master node(s) Memory Size in MB | string | `4096` |
 | tectonic_vmware_master_vcpu | Master node(s) vCPU count | string | `1` |
 | tectonic_vmware_network | Portgroup to attach the cluster nodes | string | - |
@@ -31,8 +31,8 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_worker_gateway | Default Gateway IP address for Master nodes(s) | string | - |
-| tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:    tectonic_vmware_vm_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |
-| tectonic_vmware_worker_ip | Terraform map of Worker node(s) IP Addresses, Example:    tectonic_vmware_vm_workerips = {   "0" = "192.168.246.30/24"   "1" = "192.168.246.31/24" } | map | - |
+| tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:    tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |
+| tectonic_vmware_worker_ip | Terraform map of Worker node(s) IP Addresses, Example:    tectonic_vmware_worker_ip = {   "0" = "192.168.246.30/24"   "1" = "192.168.246.31/24" } | map | - |
 | tectonic_vmware_worker_memory | Worker node(s) Memory Size in MB | string | `4096` |
 | tectonic_vmware_worker_vcpu | Worker node(s) vCPU count | string | `1` |
 

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -153,7 +153,7 @@ tectonic_vmware_master_gateway = ""
 tectonic_vmware_master_hostnames = ""
 
 // Terraform map of Master node(s) IP Addresses, Example: 
-//   tectonic_vmware_vm_masterips = {
+//   tectonic_vmware_master_ip = {
 //   "0" = "192.168.246.20/24"
 //   "1" = "192.168.246.21/24"
 // }
@@ -193,14 +193,14 @@ tectonic_vmware_vm_template_folder = ""
 tectonic_vmware_worker_gateway = ""
 
 // Terraform map of Worker node(s) Hostnames, Example: 
-//   tectonic_vmware_vm_worker_hostnames = {
+//   tectonic_vmware_worker_hostnames = {
 //   "0" = "mycluster-worker-0"
 //   "1" = "mycluster-worker-1"
 // }
 tectonic_vmware_worker_hostnames = ""
 
 // Terraform map of Worker node(s) IP Addresses, Example: 
-//   tectonic_vmware_vm_workerips = {
+//   tectonic_vmware_worker_ip = {
 //   "0" = "192.168.246.30/24"
 //   "1" = "192.168.246.31/24"
 // }

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -151,7 +151,7 @@ variable "tectonic_vmware_master_ip" {
 
   description = <<EOF
   Terraform map of Master node(s) IP Addresses, Example: 
-  tectonic_vmware_vm_masterips = {
+  tectonic_vmware_master_ip = {
   "0" = "192.168.246.20/24"
   "1" = "192.168.246.21/24"
 }
@@ -182,7 +182,7 @@ variable "tectonic_vmware_worker_hostnames" {
 
   description = <<EOF
   Terraform map of Worker node(s) Hostnames, Example: 
-  tectonic_vmware_vm_worker_hostnames = {
+  tectonic_vmware_worker_hostnames = {
   "0" = "mycluster-worker-0"
   "1" = "mycluster-worker-1"
 }
@@ -194,7 +194,7 @@ variable "tectonic_vmware_worker_ip" {
 
   description = <<EOF
   Terraform map of Worker node(s) IP Addresses, Example: 
-  tectonic_vmware_vm_workerips = {
+  tectonic_vmware_worker_ip = {
   "0" = "192.168.246.30/24"
   "1" = "192.168.246.31/24"
 }


### PR DESCRIPTION
The variables were changed at some point without changing the
examples in the comments. This just updates those comments to
eliminate potential for confusion