### PR TITLE
*: add manifests for tectonic-etcd-operator and tectonic-etcd appversion

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -44,10 +44,11 @@ variable "tectonic_container_images" {
     kubedns_sidecar                 = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1"
     flannel                         = "quay.io/coreos/flannel:v0.7.1-amd64"
     etcd                            = "quay.io/coreos/etcd:v3.1.6"
-    etcd_operator                   = "quay.io/coreos/etcd-operator:v0.3.0"
+    etcd_operator                   = "quay.io/coreos/etcd-operator:v0.3.2"
     kenc                            = "quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035"
     awscli                          = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
     kube_version                    = "quay.io/coreos/kube-version:0.1.0"
+    tectonic_etcd_operator          = "quay.io/coreos/tectonic-etcd-operator:v0.0.1"
   }
 }
 
@@ -56,12 +57,13 @@ variable "tectonic_versions" {
   type        = "map"
 
   default = {
-    etcd         = "3.1.6"
-    prometheus   = "v1.7.1"
-    alertmanager = "v0.7.1"
-    monitoring   = "1.3.0"
-    kubernetes   = "1.6.4+tectonic.1"
-    tectonic     = "1.6.4-tectonic.1"
+    etcd                   = "3.1.7"
+    prometheus             = "v1.7.1"
+    alertmanager           = "v0.7.1"
+    monitoring             = "1.3.0"
+    kubernetes             = "1.6.4+tectonic.1"
+    tectonic               = "1.6.4-tectonic.1"
+    tectonic_etcd_operator = "0.0.1"
   }
 }
 

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -29,13 +29,15 @@ resource "template_dir" "tectonic" {
     stats_extender_image                  = "${var.container_images["stats_extender"]}"
     tectonic_channel_operator_image       = "${var.container_images["tectonic_channel_operator"]}"
     tectonic_prometheus_operator_image    = "${var.container_images["tectonic_prometheus_operator"]}"
+    tectonic_etcd_operator_image          = "${var.container_images["tectonic_etcd_operator"]}"
 
-    kubernetes_version   = "${var.versions["kubernetes"]}"
-    monitoring_version   = "${var.versions["monitoring"]}"
-    prometheus_version   = "${var.versions["prometheus"]}"
-    alertmanager_version = "${var.versions["alertmanager"]}"
-    tectonic_version     = "${var.versions["tectonic"]}"
-    etcd_version         = "${var.versions["etcd"]}"
+    kubernetes_version             = "${var.versions["kubernetes"]}"
+    monitoring_version             = "${var.versions["monitoring"]}"
+    prometheus_version             = "${var.versions["prometheus"]}"
+    alertmanager_version           = "${var.versions["alertmanager"]}"
+    tectonic_version               = "${var.versions["tectonic"]}"
+    etcd_version                   = "${var.versions["etcd"]}"
+    tectonic_etcd_operator_version = "${var.versions["tectonic_etcd_operator"]}"
 
     etcd_cluster_size = "${var.master_count > 2 ? 3 : 1}"
 

--- a/modules/tectonic/resources/manifests/updater/app-version-tectonic-etcd.yaml
+++ b/modules/tectonic/resources/manifests/updater/app-version-tectonic-etcd.yaml
@@ -1,0 +1,13 @@
+apiVersion: coreos.com/v1
+kind: AppVersion
+metadata:
+  name: tectonic-etcd
+  namespace: tectonic-system
+  labels:
+    managed-by-channel-operator: "true"
+spec:
+  desiredVersion: ${tectonic_etcd_operator_version}
+  paused: false
+status:
+  currentVersion: ${tectonic_etcd_operator_version}
+  paused: false

--- a/modules/tectonic/resources/manifests/updater/tectonic-etcd-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-etcd-operator.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tectonic-etcd-operator
+  namespace: tectonic-system
+  labels:
+    k8s-app: tectonic-etcd-operator
+    managed-by-channel-operator: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: tectonic-etcd-operator
+  template:
+    metadata:
+      labels:
+        k8s-app: tectonic-etcd-operator
+        tectonic-app-version-name: tectonic-etcd
+    spec:
+      containers:
+      - image: ${tectonic_etcd_operator_image}
+        name: tectonic-etcd-operator
+        command: ["/usr/local/bin/tectonic-etcd-operator"]
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      imagePullSecrets:
+      - name: coreos-pull-secret

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -186,12 +186,14 @@ kubectl create -f updater/kube-version-operator.yaml
 kubectl create -f updater/tectonic-channel-operator.yaml
 kubectl create -f updater/tectonic-monitoring-config.yaml
 kubectl create -f updater/tectonic-prometheus-operator.yaml
+kubectl create -f updater/tectonic-etcd-operator.yaml
 wait_for_tpr tectonic-system channel-operator-config.coreos.com
 kubectl create -f updater/tectonic-channel-operator-config.yaml
 wait_for_tpr tectonic-system app-version.coreos.com
 kubectl create -f updater/app-version-tectonic-cluster.yaml
 kubectl create -f updater/app-version-kubernetes.yaml
 kubectl create -f updater/app-version-tectonic-monitoring.yaml
+kubectl create -f updater/app-version-tectonic-etcd.yaml
 
 if [ "$EXPERIMENTAL" = "true" ]; then
   kubectl apply -f etcd/cluster-config.yaml

--- a/modules/update-payload/assets.tf
+++ b/modules/update-payload/assets.tf
@@ -22,9 +22,11 @@ resource "template_dir" "upload_payload" {
     kube_version_operator_image           = "${var.tectonic_container_images["kube_version_operator"]}"
     tectonic_channel_operator_image       = "${var.tectonic_container_images["tectonic_channel_operator"]}"
     tectonic_prometheus_operator_image    = "${var.tectonic_container_images["tectonic_prometheus_operator"]}"
+    tectonic_etcd_operator_image          = "${var.tectonic_container_images["tectonic_etcd_operator"]}"
 
-    kubernetes_version = "${var.tectonic_versions["kubernetes"]}"
-    monitoring_version = "${var.tectonic_versions["monitoring"]}"
-    tectonic_version   = "${var.tectonic_versions["tectonic"]}"
+    kubernetes_version             = "${var.tectonic_versions["kubernetes"]}"
+    monitoring_version             = "${var.tectonic_versions["monitoring"]}"
+    tectonic_version               = "${var.tectonic_versions["tectonic"]}"
+    tectonic_etcd_operator_version = "${var.tectonic_versions["tectonic_etcd_operator"]}"
   }
 }

--- a/modules/update-payload/make-update-payload.sh
+++ b/modules/update-payload/make-update-payload.sh
@@ -33,11 +33,13 @@ deployments=(
   "tectonic-channel-operator.yaml"
   "kube-version-operator.yaml"
   "tectonic-prometheus-operator.yaml"
+  "tectonic-etcd-operator.yaml"
   "container-linux-update-operator.yaml"
 )
 appversions=(
   "app-version-kubernetes.yaml"
   "app-version-tectonic-monitoring.yaml"
+  "app-version-tectonic-etcd.yaml"
 )
 
 echo "Creating update payload..." >&2


### PR DESCRIPTION
This PR adds the manifests for tectonic-etcd-operator(TEO) `v0.0.1` and the appversion `tectonic-etcd` to the installer.

The TEO will reconcile the versions for its components, etcd-operator and the etcd-cluster, according to the version map maintained by the TEO. 
For the starting TEO version `v0.0.1` these will be etcd-operator(`v0.3.2`) and etcd-cluster(`v3.1.7`). Both these versions have been updated in config.tf.

@yifan-gu @sym3tri 

/cc @xiang90 @hongchaodeng 