### PR TITLE
Shellcheck everything

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -11,7 +11,10 @@ REPO=github.com/coreos/tectonic-installer/installer
 find=$(shell [ -d $(1) ] && find $(1) -type f $(2) | sed 's/ /\\ /g')
 
 GO_FILES=$(call find,.,-name '*.go')
-SHELL_FILES=$(call find,scripts,-name '*.sh')
+SHELL_FILES_SCRIPTS=$(call find,scripts,-name '*.sh')
+SHELL_FILES_MODULES=$(call find,../modules,-name '*.sh')
+SHELL_FILES_TESTS=$(call find,../tests,-name '*.sh')
+SHELL_FILES=$(SHELL_FILES_SCRIPTS) $(SHELL_FILES_MODULES) $(SHELL_FILES_TESTS)
 
 .PHONY: all
 all:

--- a/modules/aws/ignition/resources/init-assets.sh
+++ b/modules/aws/ignition/resources/init-assets.sh
@@ -5,6 +5,7 @@ set -e
 trap "{ /usr/bin/rkt gc --grace-period=0; /usr/bin/rkt image gc --grace-period 0; } &> /dev/null" EXIT
 
 mkdir -p /run/metadata
+# shellcheck disable=SC2086,SC2154
 /usr/bin/rkt run \
     --dns=host --net=host --trust-keys-from-https --interactive \
     \
@@ -25,13 +26,16 @@ if [ "$MASTER" != "true" ]; then
 fi
 
 # Download the assets from S3.
-/usr/bin/bash /opt/s3-puller.sh ${assets_s3_location} /opt/tectonic/tectonic.zip
+# shellcheck disable=SC2154
+/usr/bin/bash /opt/s3-puller.sh "${assets_s3_location}" /opt/tectonic/tectonic.zip
 unzip -o -d /opt/tectonic/ /opt/tectonic/tectonic.zip
 rm /opt/tectonic/tectonic.zip
 
 # Populate the kubelet.env file.
 mkdir -p /etc/kubernetes
+# shellcheck disable=SC2154
 echo "KUBELET_IMAGE_URL=${kubelet_image_url}" > /etc/kubernetes/kubelet.env
+# shellcheck disable=SC2154
 echo "KUBELET_IMAGE_TAG=${kubelet_image_tag}" >> /etc/kubernetes/kubelet.env
 
 exit 0

--- a/modules/aws/ignition/resources/s3-puller.sh
+++ b/modules/aws/ignition/resources/s3-puller.sh
@@ -5,6 +5,7 @@ if [ "$#" -ne "2" ]; then
     exit 1
 fi
 
+# shellcheck disable=SC2086,SC2154
 /usr/bin/sudo /usr/bin/rkt run \
     --net=host --dns=host \
     --trust-keys-from-https ${awscli_image} \
@@ -18,4 +19,5 @@ fi
         done
     '
 
+# shellcheck disable=SC1001,SC1083,SC2086
 /usr/bin/sudo mv /tmp/$${1//\//+} $2

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -10,13 +10,14 @@ mkdir -p /etc/kubernetes/manifests/
 [ -d /opt/tectonic/experimental ] && mv /opt/tectonic/experimental/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/experimental
 [ -d /opt/tectonic/bootstrap-experimental ] && mv /opt/tectonic/bootstrap-experimental/* /opt/tectonic/bootstrap-manifests/ && rm -r /opt/tectonic/bootstrap-experimental
 
+# shellcheck disable=SC2154
 /usr/bin/rkt run \
   --trust-keys-from-https \
-  --volume assets,kind=host,source=$(pwd) \
+  --volume assets,kind=host,source="$(pwd)" \
   --mount volume=assets,target=/assets \
   --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
   --mount volume=etc-kubernetes,target=/etc/kubernetes \
-  ${bootkube_image} \
+  "${bootkube_image}" \
   --net=host \
   --dns=host \
   --exec=/bootkube -- start --asset-dir=/assets

--- a/modules/tectonic/resources/tectonic-rkt.sh
+++ b/modules/tectonic/resources/tectonic-rkt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck disable=SC2086,SC2154
 /usr/bin/rkt run \
   --trust-keys-from-https \
   --volume assets,kind=host,source="$(pwd)" \

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -161,6 +161,7 @@ kubectl create -f ingress/default-backend/service.yaml
 kubectl create -f ingress/default-backend/deployment.yaml
 kubectl create -f ingress/ingress.yaml
 
+# shellcheck disable=SC2154
 if [ "${ingress_kind}" = "HostPort" ]; then
   kubectl create -f ingress/hostport/service.yaml
   kubectl create -f ingress/hostport/daemonset.yaml

--- a/modules/update-payload/awsutil.sh
+++ b/modules/update-payload/awsutil.sh
@@ -16,10 +16,10 @@ function aws_upload_file {
   contentType=$4
 
   resource="/${bucket}/${dest}"
-  dateValue=`date -u +"%a, %d %b %Y %H:%M:%S GMT"`
+  dateValue=$(date -u +"%a, %d %b %Y %H:%M:%S GMT")
   stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
 
-  signature="$(echo -en ${stringToSign} | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64)"
+  signature="$(echo -en "${stringToSign}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64)"
 
   url="http://${bucket}.s3.amazonaws.com/${dest}"
 
@@ -31,7 +31,7 @@ function aws_upload_file {
       -H "Date: ${dateValue}" \
       -H "Content-type: ${contentType}" \
       -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:${signature}" \
-      ${url}
+      "${url}"
 
   echo "uploaded $file to $resource"
 }
@@ -45,10 +45,10 @@ function aws_download_file {
   contentType=$4
 
   resource="/${bucket}/${file}"
-  dateValue=`date -u +"%a, %d %b %Y %H:%M:%S GMT"`
+  dateValue=$(date -u +"%a, %d %b %Y %H:%M:%S GMT")
   stringToSign="GET\n\n${contentType}\n${dateValue}\n${resource}"
 
-  signature="$(echo -en ${stringToSign} | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64)"
+  signature="$(echo -en "${stringToSign}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64)"
 
   url="http://${bucket}.s3.amazonaws.com/${file}"
 
@@ -59,7 +59,7 @@ function aws_download_file {
       -H "Date: ${dateValue}" \
       -H "Content-type: ${contentType}" \
       -H "Authorization: AWS ${AWS_ACCESS_KEY_ID}:${signature}" \
-      ${url} -o ${dest}
+      "${url}" -o "${dest}"
 
   echo "downloaded $url to $dest"
 }

--- a/modules/update-payload/make-update-payload.sh
+++ b/modules/update-payload/make-update-payload.sh
@@ -21,7 +21,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "Invoking terraform to populate the templates..." >&2
-pushd ${DIR}
+pushd "${DIR}"
 while true; do echo "place_holder_for_terraform_input"; done | terraform apply ./
 popd
 
@@ -45,17 +45,23 @@ echo "Using deployments: [${deployments[*]}]" >&2
 echo "Using app versions: [${appversions[*]}]" >&2
 
 # Get the update payload version.
+# shellcheck disable=SC2086
 VERSION=$(yaml2json < ${ASSETS_DIR}/app-version-tectonic-cluster.yaml | jq .status.currentVersion)
 
 # Get the deployments.
 for f in ${deployments[*]}; do
   tmpfile=$(mktemp /tmp/deployment.XXXXXX)
+  # shellcheck disable=SC2086
   yaml2json < ${ASSETS_DIR}/${f} > ${tmpfile}
   tmpfiles+=(${tmpfile})
 done
 
+# TODO: (ggreer) I'm pretty sure ">" is *not* what we want here
+# shellcheck disable=SC2071
 if [[ ${#tmpfiles[*]} > 0 ]]; then
+    # shellcheck disable=SC2086
     DEPLOYMENTS=$(jq -s . ${tmpfiles[*]})
+    # shellcheck disable=SC2086
     rm ${tmpfiles[*]}
 fi
 
@@ -64,8 +70,11 @@ unset tmpfiles
 # Get the desired versions.
 for f in ${appversions[*]}; do
   tmpfile=$(mktemp /tmp/desiredVersion.XXXXXX)
+  # shellcheck disable=SC2086
   name=$(yaml2json < ${ASSETS_DIR}/${f} | jq .metadata.name)
+  # shellcheck disable=SC2086
   desiredVersion=$(yaml2json < ${ASSETS_DIR}/${f} | jq .status.currentVersion)
+  # shellcheck disable=SC2086
   cat <<EOF > ${tmpfile}
 {
   "name": ${name},
@@ -75,12 +84,17 @@ EOF
   tmpfiles+=(${tmpfile})
 done
 
+# TODO: (ggreer) I'm pretty sure ">" is *not* what we want here
+# shellcheck disable=SC2071
 if [[ ${#tmpfiles[*]} > 0 ]]; then
+    # shellcheck disable=SC2086
     DESIRED_VERSIONS=$(jq -s . ${tmpfiles[*]})
+    # shellcheck disable=SC2086
     rm ${tmpfiles[*]}
 fi
 
 # Create the final payload.
+# shellcheck disable=SC2086
 cat <<EOF | jq . > ${DIR}/payload.json
 {
   "version": ${VERSION},

--- a/modules/update-payload/publish-payload.sh
+++ b/modules/update-payload/publish-payload.sh
@@ -22,7 +22,8 @@ fi
 
 which updateservicectl > /dev/null
 if [[ $? == 0 ]]; then
-    export UPDATESERVICECTL=$(which updateservicectl)
+    export UPDATESERVICECTL
+    UPDATESERVICECTL=$(which updateservicectl)
 fi
 
 if [[ ${UPDATESERVICECTL} == "" ]]; then
@@ -34,12 +35,12 @@ set -e
 
 payload=${DIR}/payload.json
 
-if [ ! -f ${payload} ]; then
+if [ ! -f "${payload}" ]; then
     echo "Expecting payload.json in the current directory"
     exit 1
 fi
 
-VERSION=${VERSION:-$(cat ${payload} | jq -r .version)}
+VERSION=${VERSION:-$(jq -r .version < "${payload}")}
 CHANNEL=$1
 
 echo "Publishing new payload ${VERSION} to channel ${CHANNEL}"
@@ -47,10 +48,10 @@ echo "Publishing new payload ${VERSION} to channel ${CHANNEL}"
 SERVER=${SERVER:-"https://tectonic.update.core-os.net"}
 APPID=${APPID:-"6bc7b986-4654-4a0f-94b3-84ce6feb1db4"}
 
-${UPDATESERVICECTL} --server ${SERVER} \
-                    --key ${COREUPDATE_KEY} \
-                    --user ${COREUPDATE_USR} \
+${UPDATESERVICECTL} --server "${SERVER}" \
+                    --key "${COREUPDATE_KEY}" \
+                    --user "${COREUPDATE_USR}" \
                     channel update \
-                    --channel ${CHANNEL} \
-                    --app-id ${APPID} \
-                    --version ${VERSION}
+                    --channel "${CHANNEL}" \
+                    --app-id "${APPID}" \
+                    --version "${VERSION}"

--- a/modules/update-payload/upload-payload.sh
+++ b/modules/update-payload/upload-payload.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source ${DIR}/awsutil.sh
+# shellcheck disable=SC1090
+source "${DIR}/awsutil.sh"
 
 # A script that uploads the payload.json to aws s3 bucket, and
 # create a new package on the core update server.
@@ -33,7 +34,8 @@ fi
 
 which updateservicectl > /dev/null
 if [[ $? == 0 ]]; then
-    export UPDATESERVICECTL=$(which updateservicectl)
+    export UPDATESERVICECTL
+    UPDATESERVICECTL=$(which updateservicectl)
 fi
 
 if [[ ${UPDATESERVICECTL} == "" ]]; then
@@ -52,6 +54,7 @@ for f in "${payload}" "${payload}.sig"; do
     fi
 done
 
+# shellcheck disable=SC2002,SC2086
 VERSION=${VERSION:-$(cat ${payload} | jq -r .version)}
 
 if [[ ${VERSION} == "" ]]; then
@@ -65,7 +68,9 @@ PAYLOAD_URL="https://s3-us-west-2.amazonaws.com/${BUCKET}/${DESTINATION}"
 
 echo "Uploading payload to \"${PAYLOAD_URL}\", version: \"${VERSION}\""
 
+# shellcheck disable=SC2086,SC2154
 aws_upload_file ${payload} ${DESTINATION} ${BUCKET} application/json
+# shellcheck disable=SC2086,SC2154
 aws_upload_file ${payload}.sig ${DESTINATION}.sig ${BUCKET} application/pgp-signature
 
 SERVER=${SERVER:-"https://tectonic.update.core-os.net"}
@@ -75,6 +80,7 @@ echo "Payload successfully uploaded"
 
 echo "Creating package ${VERSION} on Core Update server ${SERVER} for ${APPID}"
 
+# shellcheck disable=SC2086,SC2154
 ${UPDATESERVICECTL} --server ${SERVER} \
                     --key ${COREUPDATE_KEY} \
                     --user ${COREUPDATE_USR} \

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2002,SC2015,SC2086,SC2091
 set -exuo pipefail
 shopt -s expand_aliases
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -20,9 +21,12 @@ assume_role() {
     ROLE_ARN="$(aws iam get-role --role-name="$ROLE_NAME" | jq -r '.Role.Arn')"
     # shellcheck disable=SC2155
     CREDENTIALS="$(aws sts assume-role --role-arn="$ROLE_ARN" --role-session-name=tectonic-installer | jq '.Credentials')"
-    export AWS_ACCESS_KEY_ID=$(echo "$CREDENTIALS" | jq -r '.AccessKeyId')
-    export AWS_SECRET_ACCESS_KEY=$(echo "$CREDENTIALS" | jq -r '.SecretAccessKey')
-    export AWS_SESSION_TOKEN=$(echo "$CREDENTIALS" | jq -r '.SessionToken')
+    export AWS_ACCESS_KEY_ID
+    AWS_ACCESS_KEY_ID=$(echo "$CREDENTIALS" | jq -r '.AccessKeyId')
+    export AWS_SECRET_ACCESS_KEY
+    AWS_SECRET_ACCESS_KEY=$(echo "$CREDENTIALS" | jq -r '.SecretAccessKey')
+    export AWS_SESSION_TOKEN
+    AWS_SESSION_TOKEN=$(echo "$CREDENTIALS" | jq -r '.SessionToken')
     set -x
 }
 
@@ -68,6 +72,7 @@ common() {
         echo "Cluster name too long. Truncated to $CLUSTER"
     elif [ "$LENGTH" -lt "$MAX_LENGTH" ]
     then
+        # shellcheck disable=SC2034
         APPEND=$(( MAX_LENGTH - LENGTH ))
         APPEND_STR="012345678901234567890123456789"
         CLUSTER="$CLUSTER${APPEND_STR:0:APPEND}"


### PR DESCRIPTION
- `make shellcheck` now checks shell scripts in `tests/` and  `modules/`
- Update all shell scripts in those dirs to pass, either by fixing the warning/error or disabling the rule for that line.

Shellcheck is part of the Jenkins tests, so new lint errors should fail the build. We can clean up the existing stuff in time. Basically, this stops us from making new mistakes.