### PR TITLE
bootkube: Add required pod anti-affinity field with proper label selectors.

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -96,6 +96,8 @@ resource "template_dir" "bootkube" {
     etcd_client_key = "${base64encode(file(
       var.etcd_client_key != "" ? var.etcd_client_key : "/dev/null"
     ))}"
+
+    tectonic_version = "${var.versions["tectonic"]}"
   }
 }
 

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -98,6 +98,8 @@ resource "template_dir" "bootkube" {
     ))}"
 
     tectonic_version = "${var.versions["tectonic"]}"
+
+    master_count = "${var.master_count}"
   }
 }
 

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -7,7 +7,7 @@ metadata:
     tier: control-plane
     k8s-app: kube-controller-manager
 spec:
-  replicas: 2
+  replicas: ${master_count}
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -13,25 +13,19 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-controller-manager
+        pod-anti-affinity: kube-controller-manager-${tectonic_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: tier
-                  operator: In
-                  values:
-                  - control-plane
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - kube-contoller-manager
-              topologyKey: kubernetes.io/hostname
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                pod-anti-affinity: kube-controller-manager-${tectonic_version}
+            namespaces:
+              - kube-system
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: kube-controller-manager
         image: ${hyperkube_image}

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
-  replicas: 2
+  replicas: ${master_count}
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -15,23 +15,17 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-scheduler
+        pod-anti-affinity: kube-scheduler-${tectonic_version}
     spec:
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: tier
-                  operator: In
-                  values:
-                  - control-plane
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - kube-scheduler
-              topologyKey: kubernetes.io/hostname
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                pod-anti-affinity: kube-scheduler-${tectonic_version}
+            namespaces:
+              - kube-system
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: kube-scheduler
         image: ${hyperkube_image}

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -102,3 +102,8 @@ variable "oidc_groups_claim" {
   description = "The OpenID claim to use for specifying user groups (string or array of strings)"
   type        = "string"
 }
+
+variable "master_count" {
+  description = "The number of the master nodes"
+  type        = "string"
+}

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -40,6 +40,8 @@ module "bootkube" {
   ]
 
   experimental_enabled = "${var.tectonic_experimental}"
+
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -27,6 +27,8 @@ module "bootkube" {
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
+
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -39,6 +39,8 @@ module "bootkube" {
   etcd_cert_dns_names = ["${var.tectonic_metal_controller_domains}"]
 
   experimental_enabled = "${var.tectonic_experimental}"
+
+  master_count = "${length(var.tectonic_metal_controller_names)}"
 }
 
 module "tectonic" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -40,6 +40,8 @@ module "bootkube" {
   ]
 
   experimental_enabled = "${var.tectonic_experimental}"
+
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -40,6 +40,8 @@ module "bootkube" {
   ]
 
   experimental_enabled = "${var.tectonic_experimental}"
+
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -32,6 +32,8 @@ module "bootkube" {
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
 
   experimental_enabled = "${var.tectonic_experimental}"
+
+  master_count = "${var.tectonic_master_count}"
 }
 
 module "tectonic" {


### PR DESCRIPTION
Per discussion at https://github.com/coreos/tectonic-installer/issues/347#issuecomment-307177869,
the core components will now have a required pod anti-affinity field
with a label selector that selects labels of the pods of the same version,
so that multiple pods of the same version don't get scheduled into one node while
the pods of different versions can still be scheduled together

/cc @aaronlevy @alexsomesan @s-urbaniak @Quentin-M