### PR TITLE
platforms/azure: Remove etcd-lb and connect to etcd directly

### DIFF
--- a/modules/azure/vnet/etcd.tf
+++ b/modules/azure/vnet/etcd.tf
@@ -9,7 +9,6 @@ resource "azurerm_network_interface" "etcd_nic" {
     name                                    = "tectonic_etcd_configuration"
     subnet_id                               = "${var.external_vnet_name == "" ?  join(" ", azurerm_subnet.master_subnet.*.id) : var.external_master_subnet_id }"
     private_ip_address_allocation           = "dynamic"
-    load_balancer_backend_address_pools_ids = ["${azurerm_lb_backend_address_pool.etcd-lb.id}"]
   }
 }
 
@@ -31,7 +30,7 @@ resource "azurerm_network_security_group" "etcd_group" {
   }
 
   security_rule {
-    name                       = "etcd-client-perr"
+    name                       = "etcd-client-peer"
     source_port_range          = "*"
     destination_port_range     = "2379-2380"
     protocol                   = "Tcp"
@@ -39,18 +38,6 @@ resource "azurerm_network_security_group" "etcd_group" {
     source_address_prefix      = "VirtualNetwork"
     access                     = "Allow"
     priority                   = "101"
-    direction                  = "Inbound"
-  }
-
-  security_rule {
-    name                       = "all-in"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    protocol                   = "*"
-    destination_address_prefix = "0.0.0.0/0"
-    source_address_prefix      = "0.0.0.0/0"
-    access                     = "Allow"
-    priority                   = "103"
     direction                  = "Inbound"
   }
 
@@ -65,51 +52,4 @@ resource "azurerm_network_security_group" "etcd_group" {
     priority                   = "104"
     direction                  = "Outbound"
   }
-}
-
-resource "azurerm_lb" "tectonic_etcd_lb" {
-  name                = "${var.tectonic_cluster_name}-etcd-lb"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-
-  frontend_ip_configuration {
-    name = "default"
-
-    public_ip_address_id          = "${azurerm_public_ip.etcd_publicip.id}"
-    private_ip_address_allocation = "dynamic"
-  }
-}
-
-resource "azurerm_public_ip" "etcd_publicip" {
-  name                         = "${var.tectonic_cluster_name}_etcd_publicip"
-  location                     = "${var.location}"
-  resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "static"
-  domain_name_label            = "${var.tectonic_cluster_name}-etcd"
-}
-
-resource "azurerm_lb_rule" "etcd-lb" {
-  name                           = "${var.tectonic_cluster_name}-etcd-lb-rule-client"
-  resource_group_name            = "${var.resource_group_name}"
-  loadbalancer_id                = "${azurerm_lb.tectonic_etcd_lb.id}"
-  backend_address_pool_id        = "${azurerm_lb_backend_address_pool.etcd-lb.id}"
-  probe_id                       = "${azurerm_lb_probe.etcd-lb.id}"
-  protocol                       = "tcp"
-  frontend_port                  = 2379
-  backend_port                   = 2379
-  frontend_ip_configuration_name = "default"
-}
-
-resource "azurerm_lb_probe" "etcd-lb" {
-  name                = "${var.tectonic_cluster_name}-etcd-lb-probe"
-  loadbalancer_id     = "${azurerm_lb.tectonic_etcd_lb.id}"
-  resource_group_name = "${var.resource_group_name}"
-  protocol            = "Tcp"
-  port                = 2379
-}
-
-resource "azurerm_lb_backend_address_pool" "etcd-lb" {
-  name                = "${var.tectonic_cluster_name}-etcd-lb-pool"
-  resource_group_name = "${var.resource_group_name}"
-  loadbalancer_id     = "${azurerm_lb.tectonic_etcd_lb.id}"
 }

--- a/modules/azure/vnet/nsg-etcd.tf
+++ b/modules/azure/vnet/nsg-etcd.tf
@@ -112,8 +112,7 @@ resource "azurerm_network_security_rule" "etcd_ingress_client_master" {
   source_port_range      = "*"
   destination_port_range = "2379"
 
-  # TODO: Need to allow traffic from master
-  source_address_prefix       = "*"
+  source_address_prefix       = "${azurerm_subnet.master_subnet.address_prefix}"
   destination_address_prefix  = "*"
   resource_group_name         = "${var.external_resource_group == "" ? var.resource_group_name : var.external_resource_group}"
   network_security_group_name = "${azurerm_network_security_group.etcd.name}"

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -46,7 +46,3 @@ output "etcd_network_interface_ids" {
 output "etcd_private_ips" {
   value = ["${azurerm_network_interface.etcd_nic.*.private_ip_address}"]
 }
-
-output "etcd_public_ip" {
-  value = "${azurerm_public_ip.etcd_publicip.ip_address}"
-}

--- a/modules/azure/vnet/security-groups.tf
+++ b/modules/azure/vnet/security-groups.tf
@@ -3,19 +3,6 @@ resource "azurerm_network_security_group" "cluster_default" {
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
-  # TODO: enable all inbound traffic to make debugging easier
-  security_rule {
-    name                       = "cluster_default_ingress"
-    priority                   = 4000
-    direction                  = "Inbound"
-    access                     = "Allow"
-    protocol                   = "*"
-    source_port_range          = "*"
-    destination_port_range     = "*"
-    source_address_prefix      = "*"
-    destination_address_prefix = "*"
-  }
-
   # Allow horizontal traffic in the vnet
   security_rule {
     name                       = "cluster_default_internal"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -106,7 +106,7 @@ module "dns" {
 
   master_ip_addresses = "${module.masters.ip_address}"
   console_ip_address  = "${module.masters.console_ip_address}"
-  etcd_ip_addresses   = ["${module.vnet.etcd_public_ip}"]
+  etcd_ip_addresses   = "${module.vnet.etcd_private_ips}"
 
   base_domain  = "${var.tectonic_base_domain}"
   cluster_name = "${var.tectonic_cluster_name}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -23,7 +23,7 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_endpoints   = ["${module.vnet.etcd_public_ip}"]
+  etcd_endpoints   = "${module.vnet.etcd_private_ips}"
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"


### PR DESCRIPTION
This closes #464.

There is no reason for using an lb for that, so it should be removed to reduce attack surface and simplify configuration.