### PR TITLE
m/tectonic/r/m/etcd/cluster-config.yaml: add resource requests

### DIFF
--- a/modules/tectonic/resources/manifests/etcd/cluster-config.yaml
+++ b/modules/tectonic/resources/manifests/etcd/cluster-config.yaml
@@ -6,3 +6,8 @@ metadata:
 spec:
   size: ${etcd_cluster_size}
   version: "${etcd_version}"
+  pod:
+    resources:
+      requests:
+        cpu: 500m
+        memory: 300Mi


### PR DESCRIPTION
As suggested by @xiang90, this PR introduces resource requests to self-hosted etcd in order to guarantee that they will get enough resources to support the cluster.

Since we document that `t2.medium` instances are the bare-minimum, and since we default to that, this sets the recommended resources for a 10 nodes Kubernetes cluster (500m CPU / 300MB RAM), which should comply with what we currently have.