### PR TITLE
config.tf: Bump tco to 0.3.5.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -23,7 +23,7 @@ variable "tectonic_container_images" {
     identity                        = "quay.io/coreos/dex:v2.4.1"
     container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.0"
     kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.6.4-kvo.3"
-    tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.3.4"
+    tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.3.5"
     node_agent                      = "quay.io/coreos/node-agent:787844277099e8c10d617c3c807244fc9f873e46"
     prometheus_operator             = "quay.io/coreos/prometheus-operator:v0.10.1"
     prometheus                      = "quay.io/prometheus/prometheus:v1.7.1"


### PR DESCRIPTION
Changes:
- Migrate to new go-omaha lib and refactoring (#143 #146 #147).
- Reset the failure status when triggering the upgrade manually (#145).
- Store etcd backup revision in the config so it can be retrieved back (#149).