### PR TITLE
vmware: 1409.2.0 updates/remove vmtoolsd from ignition

### DIFF
--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -7,7 +7,7 @@ Generally, the VMware platform templates adhere to the standards defined by the 
 ## Prerequsities
 
 1. Download the latest Container Linux Stable OVA from; https://coreos.com/os/docs/latest/booting-on-vmware.html.
-1. Import `coreos_production_vmware_ova.ova` into vCenter. For the most part all settings can be kept as is, however in "Customize template", "DHCP Support for Interface 0" *must* be changed to **"no"**. See [1802](https://github.com/coreos/bugs/issues/1802)
+1. Import `coreos_production_vmware_ova.ova` into vCenter. Generally, all settings can be kept as is. Consider "thin" provisioning and naming the template with CoreOS Container Linux Version.
 1. Resize the Virtual Machine Disk size to 30 GB or larger
 1. Convert the Container Linux image into a Virtual Machine template.
 1. Pre-Allocated IP addresses for the cluster and pre-create DNS records

--- a/modules/vmware/etcd/ignition.tf
+++ b/modules/vmware/etcd/ignition.tf
@@ -12,7 +12,6 @@ data "ignition_config" "etcd" {
   systemd = [
     "${data.ignition_systemd_unit.locksmithd.id}",
     "${data.ignition_systemd_unit.etcd3.*.id[count.index]}",
-    "${data.ignition_systemd_unit.vmtoolsd_member.id}",
   ]
 
   networkd = [
@@ -99,21 +98,5 @@ data "ignition_networkd_unit" "vmnetwork" {
   Gateway=${var.gateway}
   UseDomains=yes
   Domains=${var.base_domain}
-EOF
-}
-
-data "ignition_systemd_unit" "vmtoolsd_member" {
-  name   = "vmtoolsd.service"
-  enable = true
-
-  content = <<EOF
-  [Unit]
-  Description=VMware Tools Agent
-  Documentation=http://open-vm-tools.sourceforge.net/
-  ConditionVirtualization=vmware
-  [Service]
-  ExecStartPre=/usr/bin/ln -sfT /usr/share/oem/vmware-tools /etc/vmware-tools
-  ExecStart=/usr/share/oem/bin/vmtoolsd
-  TimeoutStopSec=5
 EOF
 }

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -18,7 +18,6 @@ data "ignition_config" "node" {
     "${data.ignition_systemd_unit.kubelet-env.id}",
     "${data.ignition_systemd_unit.bootkube.id}",
     "${data.ignition_systemd_unit.tectonic.id}",
-    "${data.ignition_systemd_unit.vmtoolsd_member.id}",
   ]
 
   networkd = [
@@ -99,22 +98,6 @@ data "ignition_systemd_unit" "tectonic" {
   name    = "tectonic.service"
   enable  = "${var.tectonic_service_disabled == 0 ? true : false}"
   content = "${var.tectonic_service}"
-}
-
-data "ignition_systemd_unit" "vmtoolsd_member" {
-  name   = "vmtoolsd.service"
-  enable = true
-
-  content = <<EOF
-  [Unit]
-  Description=VMware Tools Agent
-  Documentation=http://open-vm-tools.sourceforge.net/
-  ConditionVirtualization=vmware
-  [Service]
-  ExecStartPre=/usr/bin/ln -sfT /usr/share/oem/vmware-tools /etc/vmware-tools
-  ExecStart=/usr/share/oem/bin/vmtoolsd
-  TimeoutStopSec=5
-EOF
 }
 
 data "ignition_networkd_unit" "vmnetwork" {


### PR DESCRIPTION
Ignition v0.14.0 (introduced to stable in Container Linux 1409.2.0) [enables VMware Tools services](https://github.com/coreos/ignition/pull/339) by default. Enabling the service via ignition is no longer required & causes issues with booting up CL 1409.2.0 via Terraform. Removing the dependency from Ignition resources.

Also updates the documentation as `DHCP=no` is the default and makes recommendations to use thin provisioning in template and making the VM template name reflect CL version number.

This change assumes user provisioning to VMware infrastructure is using the latest stable CL image.