### PR TITLE
vmware: enable tls for staticly-provisioned etcd

### DIFF
--- a/modules/vmware/etcd/resources/etcd-cluster
+++ b/modules/vmware/etcd/resources/etcd-cluster
@@ -1,1 +1,1 @@
-${etcd-name}=http://${etcd-address}:2380
+${etcd-name}=https://${etcd-address}:2380

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -89,3 +89,23 @@ variable hostname {
   type        = "map"
   description = "Hostname of the node"
 }
+
+variable "tls_ca_crt_pem" {
+  default = ""
+}
+
+variable "tls_client_key_pem" {
+  default = ""
+}
+
+variable "tls_client_crt_pem" {
+  default = ""
+}
+
+variable "tls_peer_key_pem" {
+  default = ""
+}
+
+variable "tls_peer_crt_pem" {
+  default = ""
+}

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -8,6 +8,12 @@ module "etcd" {
   base_domain        = "${var.tectonic_base_domain}"
   external_endpoints = ["${compact(var.tectonic_etcd_servers)}"]
 
+  tls_ca_crt_pem     = "${module.bootkube.etcd_ca_crt_pem}"
+  tls_client_crt_pem = "${module.bootkube.etcd_client_crt_pem}"
+  tls_client_key_pem = "${module.bootkube.etcd_client_key_pem}"
+  tls_peer_key_pem   = "${module.bootkube.etcd_peer_crt_pem}"
+  tls_peer_crt_pem   = "${module.bootkube.etcd_peer_key_pem}"
+
   hostname   = "${var.tectonic_vmware_etcd_hostnames}"
   dns_server = "${var.tectonic_vmware_node_dns}"
   ip_address = "${var.tectonic_vmware_etcd_ip}"

--- a/platforms/vmware/remote.tf
+++ b/platforms/vmware/remote.tf
@@ -1,3 +1,50 @@
+resource "null_resource" "etcd_secrets" {
+  count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count }"
+
+  connection {
+    type    = "ssh"
+    host    = "${element(module.etcd.ip_address, count.index)}"
+    user    = "core"
+    timeout = "60m"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_ca_crt_pem}"
+    destination = "$HOME/etcd_ca.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_client_crt_pem}"
+    destination = "$HOME/etcd_client.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_client_key_pem}"
+    destination = "$HOME/etcd_client.key"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_peer_crt_pem}"
+    destination = "$HOME/etcd_peer.crt"
+  }
+
+  provisioner "file" {
+    content     = "${module.bootkube.etcd_peer_key_pem}"
+    destination = "$HOME/etcd_peer.key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mkdir -p /etc/ssl/etcd",
+      "sudo mv /home/core/etcd_ca.crt /etc/ssl/etcd/ca.crt",
+      "sudo mv /home/core/etcd_client.crt /etc/ssl/etcd/client.crt",
+      "sudo mv /home/core/etcd_client.key /etc/ssl/etcd/client.key",
+      "sudo mv /home/core/etcd_peer.key /etc/ssl/etcd/peer.key",
+      "sudo mv /home/core/etcd_peer.crt /etc/ssl/etcd/peer.crt",
+    ]
+  }
+}
+
 resource "null_resource" "bootstrap" {
   # Without depends_on, this remote-exec may start before the kubeconfig copy.  # Terraform only does one task at a time, so it would try to bootstrap  # Kubernetes and Tectonic while no Kubelets are running. Ensure all nodes  # receive a kubeconfig before proceeding with bootkube and tectonic.  #depends_on = ["null_resource.kubeconfig-masters"]
 

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -30,6 +30,12 @@ module "bootkube" {
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"
+  etcd_tls_enabled = "${var.tectonic_etcd_tls_enabled}"
+
+  etcd_cert_dns_names = ["${formatlist("%s.%s",
+        values(var.tectonic_vmware_etcd_hostnames),
+        var.tectonic_base_domain
+  )}"]
 
   experimental_enabled = "${var.tectonic_experimental}"
 


### PR DESCRIPTION
Fixes #459 with a follow up on https://github.com/coreos/tectonic-installer/pull/751
- sets locksmith on etcd nodes to use etcd tls information (if etcd not external or self-hosted)
- sets etcd nodes to use TLS settings part of 751 for etcd-member service
- sets etcd-member service to use endpoints via https (if not self-hosted)
- introduces variables required for etcd tls
- copies over tls secrets to nodes via file provisioners

Tested with parameters
```
tectonic_master_count = 1
tectonic_worker_count = 1
tectonic_etcd_count = 3
```
and
```
tectonic_experimental = false
```
![image](https://user-images.githubusercontent.com/11538902/27367184-30e2580a-5619-11e7-8b4a-0d2f49141a58.png)

***VS***

```
tectonic_experimental = false
```
![image](https://user-images.githubusercontent.com/11538902/27367198-430be294-5619-11e7-99b1-fe2e7d652883.png)

