### PR TITLE
modules/openstack/secgroups: Refactor to use neutron API

### DIFF
--- a/modules/openstack/secgroups/output.tf
+++ b/modules/openstack/secgroups/output.tf
@@ -1,31 +1,43 @@
 output "secgroup_master_names" {
-  value = ["${compact(list(
-    openstack_compute_secgroup_v2.default.name,
-    openstack_compute_secgroup_v2.master.name,
-    var.tectonic_experimental ? openstack_compute_secgroup_v2.self_hosted_etcd.name : "",
-  ))}"]
+  value = [
+    "${openstack_networking_secgroup_v2.base.name}",
+    "${openstack_networking_secgroup_v2.k8s.name}",
+    "${openstack_networking_secgroup_v2.etcd.name}",
+  ]
 }
 
 output "secgroup_master_ids" {
-  value = ["${compact(list(
-    openstack_compute_secgroup_v2.default.id,
-    openstack_compute_secgroup_v2.master.id,
-    var.tectonic_experimental ? openstack_compute_secgroup_v2.self_hosted_etcd.id : "",
-  ))}"]
+  value = [
+    "${openstack_networking_secgroup_v2.base.id}",
+    "${openstack_networking_secgroup_v2.k8s.id}",
+    "${openstack_networking_secgroup_v2.etcd.id}",
+  ]
 }
 
 output "secgroup_node_names" {
-  value = ["${openstack_compute_secgroup_v2.node.name}", "${openstack_compute_secgroup_v2.default.name}"]
+  value = [
+    "${openstack_networking_secgroup_v2.base.name}",
+    "${openstack_networking_secgroup_v2.k8s.name}",
+  ]
 }
 
 output "secgroup_node_ids" {
-  value = ["${openstack_compute_secgroup_v2.node.id}", "${openstack_compute_secgroup_v2.default.id}"]
+  value = [
+    "${openstack_networking_secgroup_v2.base.id}",
+    "${openstack_networking_secgroup_v2.k8s.id}",
+  ]
 }
 
 output "secgroup_etcd_names" {
-  value = ["${openstack_compute_secgroup_v2.etcd.name}", "${openstack_compute_secgroup_v2.default.name}"]
+  value = [
+    "${openstack_networking_secgroup_v2.base.name}",
+    "${openstack_networking_secgroup_v2.etcd.name}",
+  ]
 }
 
 output "secgroup_etcd_ids" {
-  value = ["${openstack_compute_secgroup_v2.etcd.id}", "${openstack_compute_secgroup_v2.default.id}"]
+  value = [
+    "${openstack_networking_secgroup_v2.base.id}",
+    "${openstack_networking_secgroup_v2.etcd.id}",
+  ]
 }

--- a/modules/openstack/secgroups/rules/default/secgroup.tf
+++ b/modules/openstack/secgroups/rules/default/secgroup.tf
@@ -1,0 +1,17 @@
+resource "openstack_networking_secgroup_rule_v2" "ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 22
+  port_range_max    = 22
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "icmp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}

--- a/modules/openstack/secgroups/rules/default/variables.tf
+++ b/modules/openstack/secgroups/rules/default/variables.tf
@@ -1,0 +1,3 @@
+variable "secgroup_id" {
+  type = "string"
+}

--- a/modules/openstack/secgroups/rules/etcd/secgroup.tf
+++ b/modules/openstack/secgroups/rules/etcd/secgroup.tf
@@ -1,0 +1,20 @@
+resource "openstack_networking_secgroup_rule_v2" "etcd" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 2379
+  port_range_max    = 2380
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "bootstrap_etcd" {
+  count             = "${var.self_hosted ? 1 : 0}"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 12379
+  port_range_max    = 12380
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}

--- a/modules/openstack/secgroups/rules/etcd/variables.tf
+++ b/modules/openstack/secgroups/rules/etcd/variables.tf
@@ -1,0 +1,7 @@
+variable "secgroup_id" {
+  type = "string"
+}
+
+variable "self_hosted" {
+  default = false
+}

--- a/modules/openstack/secgroups/rules/k8s/secgroup.tf
+++ b/modules/openstack/secgroups/rules/k8s/secgroup.tf
@@ -1,0 +1,49 @@
+resource "openstack_networking_secgroup_rule_v2" "https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 443
+  port_range_max    = 443
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "cAdvisor" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 4194
+  port_range_max    = 4194
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "flannel" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  protocol          = "udp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "kubelet" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "node_ports" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  protocol          = "tcp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${var.secgroup_id}"
+}

--- a/modules/openstack/secgroups/rules/k8s/variables.tf
+++ b/modules/openstack/secgroups/rules/k8s/variables.tf
@@ -1,0 +1,3 @@
+variable "secgroup_id" {
+  type = "string"
+}

--- a/modules/openstack/secgroups/secgroup.tf
+++ b/modules/openstack/secgroups/secgroup.tf
@@ -1,141 +1,32 @@
-resource "openstack_compute_secgroup_v2" "master" {
-  name        = "${var.cluster_name}_master"
-  description = "security group for k8s masters"
-
-  // k8s API
-  rule {
-    from_port   = 443
-    to_port     = 443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // cAdvisor
-  rule {
-    from_port   = 4194
-    to_port     = 4194
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // flannel
-  rule {
-    from_port   = 4789
-    to_port     = 4789
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // kubelet API
-  rule {
-    from_port   = 10250
-    to_port     = 10250
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // External services
-  rule {
-    from_port   = 30000
-    to_port     = 32767
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_v2" "base" {
+  name        = "${var.cluster_name}_base"
+  description = "SSH and ICMP"
 }
 
-resource "openstack_compute_secgroup_v2" "node" {
-  name        = "${var.cluster_name}_worker"
-  description = "security group for k8s nodes"
-
-  // k8s API
-  rule {
-    from_port   = 443
-    to_port     = 443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // cAdvisor
-  rule {
-    from_port   = 4194
-    to_port     = 4194
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // flannel
-  rule {
-    from_port   = 4789
-    to_port     = 4789
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // kubelet API
-  rule {
-    from_port   = 10250
-    to_port     = 10250
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // External services
-  rule {
-    from_port   = 30000
-    to_port     = 32767
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+module "default" {
+  source      = "rules/default"
+  secgroup_id = "${openstack_networking_secgroup_v2.base.id}"
 }
 
-resource "openstack_compute_secgroup_v2" "self_hosted_etcd" {
-  name        = "${var.cluster_name}_master_self_hosted_etcd"
-  description = "security group for self hosted etcd"
-
-  // etcd
-  rule {
-    from_port   = 2379
-    to_port     = 2380
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  // bootstrap etcd
-  rule {
-    from_port   = 12379
-    to_port     = 12380
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_networking_secgroup_v2" "k8s" {
+  name                 = "${var.cluster_name}_k8s"
+  description          = "Ports needed by Kubernetes"
+  delete_default_rules = true
 }
 
-resource "openstack_compute_secgroup_v2" "etcd" {
-  name        = "${var.cluster_name}_etcd_group"
-  description = "security group for etcd"
-
-  rule {
-    from_port   = 2379
-    to_port     = 2380
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+module "k8s" {
+  source      = "rules/k8s"
+  secgroup_id = "${openstack_networking_secgroup_v2.k8s.id}"
 }
 
-resource "openstack_compute_secgroup_v2" "default" {
-  name        = "${var.cluster_name}_default"
-  description = "security group defaults: SSH and ping"
+resource "openstack_networking_secgroup_v2" "etcd" {
+  name                 = "${var.cluster_name}_etcd"
+  description          = "Ports needed by etcd"
+  delete_default_rules = true
+}
 
-  rule {
-    from_port   = 22
-    to_port     = 22
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = -1
-    to_port     = -1
-    ip_protocol = "icmp"
-    cidr        = "0.0.0.0/0"
-  }
+module "etcd" {
+  source      = "rules/etcd"
+  secgroup_id = "${openstack_networking_secgroup_v2.etcd.id}"
+  self_hosted = "${var.tectonic_experimental}"
 }


### PR DESCRIPTION
The existing security group module was using the [deprecated](https://developer.openstack.org/api-ref/compute/#list-networks)
nova-networks API. Updated to use the neutron API directly
and consolidated the security groups to avoid unneccessary
duplication.

/cc @s-urbaniak 