### PR TITLE
aws: remove SSH listen from API-external ELB

### DIFF
--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -54,13 +54,6 @@ resource "aws_elb" "api-external" {
   connection_draining_timeout = 300
 
   listener {
-    instance_port     = 22
-    instance_protocol = "tcp"
-    lb_port           = 22
-    lb_protocol       = "tcp"
-  }
-
-  listener {
     instance_port     = 443
     instance_protocol = "tcp"
     lb_port           = 443


### PR DESCRIPTION
Cleanup

Fixes https://github.com/coreos/tectonic-installer/issues/1134

API-External ELB is setup with listening on SSH ports however security groups do not allow SSH traffic.

I believe this is an old configuration from older versions where SSHing into master was done via ELB.

