### PR TITLE
Jenkinsfile: Keep up to 100 builds. 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
   options {
     timeout(time:60, unit:'MINUTES')
     timestamps()
-    buildDiscarder(logRotator(numToKeepStr:'20'))
+    buildDiscarder(logRotator(numToKeepStr:'100'))
   }
 
   stages {


### PR DESCRIPTION
This should help us get a better idea of what's failing. I floated the idea in the Monday meeting and nobody seemed to object.