### PR TITLE
frontend: Consistent order of tectonic license & experimental features

### DIFF
--- a/installer/frontend/components/bm-cluster-info.jsx
+++ b/installer/frontend/components/bm-cluster-info.jsx
@@ -26,9 +26,8 @@ export const BM_ClusterInfo = () => {
           <p className="text-muted">Give this cluster a name that will help you identify it.</p>
         </div>
       </div>
-      <TectonicLicense />
-      <br />
       <ExperimentalFeatures />
+      <TectonicLicense />
     </div>
   );
 };


### PR DESCRIPTION
The order differed between baremetal & aws. Now they're the same.

Doesn't actually affect the layout, since we currently have no experimental feature checkboxes.