### PR TITLE
modules/aws/etcd/nodes.tf: change hardcoded value of IOPS to 100

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -48,6 +48,6 @@ resource "aws_instance" "etcd_node" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
   }
 }


### PR DESCRIPTION
This is to prevent Terraform from destroying/re-creating the etcd nodes right away
after a deployment where root_volume_type is not io1.

I am tempted to add ``lifecycle { ignore_changes = [ "*" ] }``.

Fixes #1035
Also created https://github.com/coreos/tectonic-installer/issues/1167 for future ref