### PR TITLE
azure: Fix node naming

### DIFF
--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -6,7 +6,7 @@ resource "azurerm_availability_set" "etcd" {
 
 resource "azurerm_virtual_machine" "etcd_node" {
   count                 = "${var.etcd_count}"
-  name                  = "${var.cluster_name}-etcd-${count.index}"
+  name                  = "${format("%s-%s-%03d", var.cluster_name, var.role, count.index + 1)}"
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${var.network_interface_ids[count.index]}"]
   vm_size               = "${var.vm_size}"
@@ -28,7 +28,7 @@ resource "azurerm_virtual_machine" "etcd_node" {
   }
 
   os_profile {
-    computer_name  = "etcd"
+    computer_name  = "${format("%s%s%03d", var.cluster_name, "e", count.index + 1)}"
     admin_username = "core"
     admin_password = ""
     custom_data    = "${base64encode("${data.ignition_config.etcd.*.rendered[count.index]}")}"
@@ -45,11 +45,11 @@ resource "azurerm_virtual_machine" "etcd_node" {
 }
 
 resource "random_id" "storage" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "etcd_storage" {
-  name                = "${random_id.storage.hex}"
+  name                = "${var.cluster_name}${random_id.storage.hex}etcd"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/etcd/variables.tf
+++ b/modules/azure/etcd/variables.tf
@@ -57,3 +57,7 @@ variable "network_interface_ids" {
 variable "endpoints" {
   type = "list"
 }
+
+variable "role" {
+  type = "string"
+}

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -6,11 +6,11 @@
 
 # Generate unique storage name
 resource "random_id" "tectonic_master_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_master" {
-  name                = "${random_id.tectonic_master_storage_name.hex}"
+  name                = "${var.cluster_name}${random_id.tectonic_master_storage_name.hex}m"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"
@@ -49,7 +49,7 @@ resource "azurerm_network_interface" "tectonic_master" {
 
 resource "azurerm_virtual_machine" "tectonic_master" {
   count                 = "${var.master_count}"
-  name                  = "${var.cluster_name}-master${count.index}"
+  name                  = "${format("%s-%s-%03d", var.cluster_name, var.role, count.index + 1)}"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${element(azurerm_network_interface.tectonic_master.*.id, count.index)}"]
@@ -72,7 +72,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
   }
 
   os_profile {
-    computer_name  = "${var.cluster_name}-master${count.index}"
+    computer_name  = "${format("%s%s%03d", var.cluster_name, "m", count.index + 1)}"
     admin_username = "core"
     admin_password = ""
 

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -97,3 +97,7 @@ variable "tectonic_service_disabled" {
 variable "use_custom_fqdn" {
   default = false
 }
+
+variable "role" {
+  type = "string"
+}

--- a/modules/azure/master-ss/master.tf
+++ b/modules/azure/master-ss/master.tf
@@ -6,11 +6,11 @@
 
 # Generate unique storage name
 resource "random_id" "tectonic_master_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_master" {
-  name                = "${random_id.tectonic_master_storage_name.hex}"
+  name                = "${var.cluster_name}${random_id.tectonic_master_storage_name.hex}m"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/worker-as/variables.tf
+++ b/modules/azure/worker-as/variables.tf
@@ -75,3 +75,7 @@ variable "cloud_provider" {
 variable "kubelet_node_label" {
   type = "string"
 }
+
+variable "role" {
+  type = "string"
+}

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -1,10 +1,10 @@
 # Generate unique storage name
 resource "random_id" "tectonic_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {
-  name                = "${random_id.tectonic_storage_name.hex}"
+  name                = "${var.cluster_name}${random_id.tectonic_storage_name.hex}wrk"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"
@@ -50,7 +50,7 @@ resource "azurerm_network_interface" "tectonic_worker" {
 
 resource "azurerm_virtual_machine" "tectonic_worker" {
   count                 = "${var.worker_count}"
-  name                  = "${var.cluster_name}-worker${count.index}"
+  name                  = "${format("%s-%s-%03d", var.cluster_name, var.role, count.index + 1)}"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${element(azurerm_network_interface.tectonic_worker.*.id, count.index)}"]
@@ -73,7 +73,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   }
 
   os_profile {
-    computer_name  = "${var.cluster_name}-worker${count.index}"
+    computer_name  = "${format("%s%s%03d", var.cluster_name, "w", count.index + 1)}"
     admin_username = "core"
     admin_password = ""
     custom_data    = "${base64encode("${data.ignition_config.worker.rendered}")}"

--- a/modules/azure/worker-ss/workers.tf
+++ b/modules/azure/worker-ss/workers.tf
@@ -3,11 +3,11 @@
 
 # Generate unique storage name
 resource "random_id" "tectonic_storage_name" {
-  byte_length = 4
+  byte_length = 2
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {
-  name                = "${random_id.tectonic_storage_name.hex}"
+  name                = "${var.cluster_name}${random_id.tectonic_storage_name.hex}wrk"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -47,6 +47,7 @@ module "etcd" {
   subnet                = "${module.vnet.master_subnet}"
   endpoints             = "${module.vnet.etcd_private_ips}"
   network_interface_ids = "${module.vnet.etcd_network_interface_ids}"
+  role                  = "etcd"
 }
 
 module "masters" {
@@ -76,6 +77,7 @@ module "masters" {
   tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 
   use_custom_fqdn = "${var.tectonic_azure_use_custom_fqdn}"
+  role            = "master"
 }
 
 module "workers" {
@@ -99,6 +101,7 @@ module "workers" {
   tectonic_kube_dns_service_ip = "${module.bootkube.kube_dns_service_ip}"
   cloud_provider               = ""
   kubelet_node_label           = "node-role.kubernetes.io/node"
+  role                         = "worker"
 }
 
 module "dns" {


### PR DESCRIPTION
Tweaks some of the resources names to adhere to Azure limits:

* Add cluster prefixes for AS, fix computer names
* Add `role` var to further parameterize node names
* Shorten `random_id` byte length to 2
* Set etcd to use tectonic module def for cluster name
* Fix node naming => `${cluster_name}{e,m,w}###`
* Use `cluster_name` as prefix for storage objects