### PR TITLE
modules/tectonic,tests/smoke: make stats URL configurable

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -28,6 +28,7 @@ This document gives an overview of variables used in all platforms of the Tecton
 | tectonic_master_count | The number of master nodes to be created. This applies only to cloud platforms. | string | `1` |
 | tectonic_pull_secret_path | The path the pull secret file in JSON format.<br><br>Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`. | string | `` |
 | tectonic_service_cidr | This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12 | string | `10.3.0.0/16` |
+| tectonic_stats_url | The Tectonic statistics collection URL to which to report. | string | `https://stats-collector.tectonic.com` |
 | tectonic_update_app_id | (internal) The Tectonic Omaha update App ID | string | `6bc7b986-4654-4a0f-94b3-84ce6feb1db4` |
 | tectonic_update_channel | (internal) The Tectonic Omaha update channel | string | `tectonic-1.6` |
 | tectonic_update_server | (internal) The URL of the Tectonic Omaha update server | string | `https://tectonic.update.core-os.net` |

--- a/config.tf
+++ b/config.tf
@@ -313,3 +313,9 @@ variable "tectonic_experimental" {
 If set to true, experimental Tectonic assets are being deployed.
 EOF
 }
+
+variable "tectonic_stats_url" {
+  type        = "string"
+  default     = "https://stats-collector.tectonic.com"
+  description = "The Tectonic statistics collection URL to which to report."
+}

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -230,6 +230,9 @@ tectonic_pull_secret_path = ""
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
+// The Tectonic statistics collection URL to which to report.
+tectonic_stats_url = "https://stats-collector.tectonic.com"
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -193,6 +193,9 @@ tectonic_pull_secret_path = ""
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
+// The Tectonic statistics collection URL to which to report.
+tectonic_stats_url = "https://stats-collector.tectonic.com"
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -205,6 +205,9 @@ tectonic_service_cidr = "10.3.0.0/16"
 // Example: `ssh-rsa AAAB3N...`
 tectonic_ssh_authorized_key = ""
 
+// The Tectonic statistics collection URL to which to report.
+tectonic_stats_url = "https://stats-collector.tectonic.com"
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -122,6 +122,9 @@ tectonic_pull_secret_path = ""
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
+// The Tectonic statistics collection URL to which to report.
+tectonic_stats_url = "https://stats-collector.tectonic.com"
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/examples/terraform.tfvars.openstack-nova
+++ b/examples/terraform.tfvars.openstack-nova
@@ -112,6 +112,9 @@ tectonic_pull_secret_path = ""
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
+// The Tectonic statistics collection URL to which to report.
+tectonic_stats_url = "https://stats-collector.tectonic.com"
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -101,6 +101,9 @@ tectonic_pull_secret_path = ""
 // This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12
 tectonic_service_cidr = "10.3.0.0/16"
 
+// The Tectonic statistics collection URL to which to report.
+tectonic_stats_url = "https://stats-collector.tectonic.com"
+
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -72,6 +72,7 @@ resource "template_dir" "tectonic" {
 
     kube_apiserver_url = "${var.kube_apiserver_url}"
     oidc_issuer_url    = "https://${var.base_address}/identity"
+    stats_url          = "${var.stats_url}"
 
     # TODO: We could also patch https://www.terraform.io/docs/providers/random/ to add an UUID resource.
     cluster_id = "${format("%s-%s-%s-%s-%s", substr(random_id.cluster_id.hex, 0, 8), substr(random_id.cluster_id.hex, 8, 4), substr(random_id.cluster_id.hex, 12, 4), substr(random_id.cluster_id.hex, 16, 4), substr(random_id.cluster_id.hex, 20, 12))}"

--- a/modules/tectonic/resources/manifests/stats-emitter.yaml
+++ b/modules/tectonic/resources/manifests/stats-emitter.yaml
@@ -58,7 +58,7 @@ spec:
           - /spartakus
           - volunteer
           - --cluster-id=$(CLUSTER_ID)
-          - --database=https://stats-collector.tectonic.com
+          - --database=${stats_url}
           - --extensions=/etc/tectonic/stats/extensions
         env:
         - name: CLUSTER_ID

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -112,3 +112,8 @@ variable "master_count" {
   description = "The amount of master nodes present in the cluster."
   type        = "string"
 }
+
+variable "stats_url" {
+  description = "The statistics collection URL to which to report."
+  type        = "string"
+}

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -75,6 +75,7 @@ module "tectonic" {
   ingress_kind      = "NodePort"
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
+  stats_url         = "${var.tectonic_stats_url}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -62,6 +62,7 @@ module "tectonic" {
   ingress_kind      = "NodePort"
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
+  stats_url         = "${var.tectonic_stats_url}"
 }
 
 resource "null_resource" "tectonic" {

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -76,6 +76,7 @@ module "tectonic" {
   ingress_kind      = "HostPort"
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${length(var.tectonic_metal_controller_names)}"
+  stats_url         = "${var.tectonic_stats_url}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -75,6 +75,7 @@ module "tectonic" {
   ingress_kind      = "HostPort"
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
+  stats_url         = "${var.tectonic_stats_url}"
 }
 
 module "etcd" {

--- a/platforms/openstack/nova/main.tf
+++ b/platforms/openstack/nova/main.tf
@@ -76,6 +76,7 @@ module "tectonic" {
   experimental      = "${var.tectonic_experimental}"
 
   master_count = "${var.tectonic_master_count}"
+  stats_url    = "${var.tectonic_stats_url}"
 }
 
 data "null_data_source" "local" {

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -70,6 +70,7 @@ module "tectonic" {
   ingress_kind      = "HostPort"
   experimental      = "${var.tectonic_experimental}"
   master_count      = "${var.tectonic_master_count}"
+  stats_url         = "${var.tectonic_stats_url}"
 }
 
 data "archive_file" "assets" {

--- a/tests/smoke/aws/vars/aws-ca.tfvars
+++ b/tests/smoke/aws/vars/aws-ca.tfvars
@@ -27,3 +27,5 @@ tectonic_aws_etcd_ec2_type = "m4.large"
 tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
 
 tectonic_aws_external_vpc_id = ""
+
+tectonic_stats_url = "https://stats-collector-staging.tectonic.com"

--- a/tests/smoke/aws/vars/aws-exp.tfvars
+++ b/tests/smoke/aws/vars/aws-exp.tfvars
@@ -25,3 +25,5 @@ tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
 tectonic_aws_external_vpc_id = ""
 
 tectonic_experimental = true
+
+tectonic_stats_url = "https://stats-collector-staging.tectonic.com"

--- a/tests/smoke/aws/vars/aws-tls.tfvars
+++ b/tests/smoke/aws/vars/aws-tls.tfvars
@@ -31,3 +31,5 @@ tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
 tectonic_aws_external_vpc_id = ""
 
 tectonic_etcd_tls_enabled = true
+
+tectonic_stats_url = "https://stats-collector-staging.tectonic.com"

--- a/tests/smoke/aws/vars/aws-vpc.tfvars
+++ b/tests/smoke/aws/vars/aws-vpc.tfvars
@@ -31,3 +31,5 @@ tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
 tectonic_aws_external_vpc_public = false
 
 tectonic_aws_az_count = "2"
+
+tectonic_stats_url = "https://stats-collector-staging.tectonic.com"

--- a/tests/smoke/aws/vars/aws.tfvars
+++ b/tests/smoke/aws/vars/aws.tfvars
@@ -27,3 +27,5 @@ tectonic_aws_etcd_ec2_type = "m4.large"
 tectonic_aws_vpc_cidr_block = "10.0.0.0/16"
 
 tectonic_aws_external_vpc_id = ""
+
+tectonic_stats_url = "https://stats-collector-staging.tectonic.com"

--- a/tests/smoke/bare-metal/vars/metal.tfvars
+++ b/tests/smoke/bare-metal/vars/metal.tfvars
@@ -139,3 +139,5 @@ tectonic_etcd_count = 0
 
 # Enable TLS for etcd
 tectonic_etcd_tls_enabled = true
+
+tectonic_stats_url = "https://stats-collector-staging.tectonic.com"


### PR DESCRIPTION
This commit makes the stats reporting URL configurable so that all test
clusters will report statistics to the staging stats database. Although
we already filter out all test data from the production database, it is
useful to submit statistics to the staging database so that we can
happily automate tests that fetch data from that database without
interfering with or causing problems in prod.

Updated: turns out to be consistent with how we setup vars, for the
Tectonic module on any platform, we need to be more verbose.

cc @Quentin-M @kans 