### PR TITLE
docs: fix command syntax errors

### DIFF
--- a/Documentation/admin/aws-scale.md
+++ b/Documentation/admin/aws-scale.md
@@ -1,10 +1,23 @@
 # Scaling Tectonic AWS clusters
 
-To scale worker nodes, adjust `tectonic_worker_count` in `terraform.vars` and run:
+To scale worker nodes, adjust `tectonic_worker_count` in `terraform.tfvars`.
+
+Use the `plan` command to check your syntax: 
 
 ```
-$ terraform apply $ terraform plan \
+$ terraform plan \
   -var-file=build/${CLUSTER}/terraform.tfvars \
   -target module.workers \
   platforms/aws
 ```
+
+Once you are ready to make the changes live, use `apply`:
+
+```
+$ terraform apply \
+  -var-file=build/${CLUSTER}/terraform.tfvars \
+  -target module.workers \
+  platforms/aws
+```
+
+The new nodes should automatically show up in the Tectonic Console shortly after they boot.


### PR DESCRIPTION
typo: `$ terraform apply $ terraform plan \`