### PR TITLE
Jenkins: print systemd logs

### DIFF
--- a/tests/smoke/aws/cluster-foreach.sh
+++ b/tests/smoke/aws/cluster-foreach.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+fail () {
+  if [ $? -ne 0 ]
+  then
+    echo "$0 failed but exiting 0 because we don't want to fail tests"
+  fi
+  exit 0
+}
+
+trap fail EXIT
+
+if [ $# -eq 0 ]
+then
+  echo "usage: $0 command"
+  echo "Make sure your AWS creds & env vars are set (\$AWS_REGION, \$CLUSTER)"
+fi
+
+if [ -z "$CLUSTER" ]
+then
+  echo "\$CLUSTER not set"
+  exit 1
+fi
+if [ -z "$AWS_REGION" ]
+then
+  echo "\$AWS_REGION not set"
+  exit 1
+fi
+
+CMD=$*
+
+ASG_NAME="${CLUSTER}-masters"
+INSTANCES=$(aws autoscaling describe-auto-scaling-groups --region="$AWS_REGION" --auto-scaling-group-names="$ASG_NAME" | jq -r .AutoScalingGroups[0].Instances[].InstanceId)
+# shellcheck disable=SC2086
+HOSTS=$(aws ec2 describe-instances --region="$AWS_REGION" --instance-ids $INSTANCES | jq -r .Reservations[].Instances[].PublicIpAddress)
+
+set +e
+for HOST in $HOSTS
+do
+  ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null "core@${HOST}" 'bash -s' < "$CMD"
+done

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -211,6 +211,8 @@ main () {
     
     shift
     case $COMMAND in
+        common)
+            common "$@";;
         assume-role)
             assume_role "$@";;
         create)

--- a/tests/smoke/forensics.sh
+++ b/tests/smoke/forensics.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+printf "hostname: %s\n" "$(hostname)"
+
+MASTER_FILE=/run/metadata/master
+if [ -f $MASTER_FILE ]
+then
+  printf "master: %s\n" "$(cat $MASTER_FILE)"
+else
+  printf "%s does not exist!\n" $MASTER_FILE
+fi
+
+TECTONIC_DIR=/opt/tectonic
+if [ -d $TECTONIC_DIR ]
+then
+  printf "ls %s: %s\n\n" $TECTONIC_DIR "$(ls -la $TECTONIC_DIR)"
+else
+  printf "%s does not exist!\n\n" $TECTONIC_DIR
+fi
+
+printf "Init assets:\n"
+journalctl -u init-assets --no-tail | cat
+printf "\n\n"
+
+printf "Bootkube:\n"
+journalctl -u bootkube --no-tail | cat
+printf "\n\n"
+
+printf "Tectonic:\n"
+journalctl -u tectonic --no-tail | cat
+printf "\n\n"


### PR DESCRIPTION
- Add forensic script to ssh to machine & print debugging info
- Add cluster-foreach script to run forensics script on each machine in the ASG.
- Get jenkins & smoke tests to run these scripts automatically (even on failure).
