### PR TITLE
config.tf: Update CLUO from v0.2.0 to v0.2.1

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -21,7 +21,7 @@ variable "tectonic_container_images" {
     bootkube                        = "quay.io/coreos/bootkube:v0.4.4"
     console                         = "quay.io/coreos/tectonic-console:v1.6.3"
     identity                        = "quay.io/coreos/dex:v2.4.1"
-    container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.0"
+    container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.1"
     kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.6.4-kvo.3"
     tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.3.4"
     node_agent                      = "quay.io/coreos/node-agent:787844277099e8c10d617c3c807244fc9f873e46"

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -234,7 +234,7 @@
                     }
                   }
                 ],
-                "image": "quay.io/coreos/container-linux-update-operator:v0.2.0",
+                "image": "quay.io/coreos/container-linux-update-operator:v0.2.1",
                 "name": "update-operator"
               }
             ]


### PR DESCRIPTION
Update container-linux-update-operator to v0.2.1 for the next Tectonic release.

* [Release notes](https://github.com/coreos/container-linux-update-operator/releases/tag/v0.2.1)
* [Images](https://quay.io/repository/coreos/container-linux-update-operator?tab=tags)

Closes https://github.com/coreos/container-linux-update-operator/issues/75

Testing on Tectonic (in addition to earlier CLUO testing):

* Spun up a bare-metal Tectonic cluster with update-operator v0.2.1
* Verify update-agent daemonset gets deployed using the right image / version
* Verify D-Bus needs reboot signal triggers a node to reboot
* Verify only one machine will reboot at a time (send multiple signals)
* Verify an actual CL upgrade succeeds (deployed at stable 1353.7.0, trigger upgrade to 1409.2.0)
* Verify Tectonic console UI shows "Rebooting..." messages appropriately
* Ongoing efforts to define "what success looks like" is tracked in https://github.com/coreos/container-linux-update-operator/issues/90

Payload is updated by this PR. Checking with @yifan-gu for testing old clusters will upgrade.