### PR TITLE
CONTRIBUTING: adds basic make commands to run before submitting a PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ This is a rough outline of what a contributor's workflow looks like:
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - Make sure the tests pass, and add any new tests as appropriate.
+  - Please run the following commands, at a minimum, before submitting your
+  pull request:
+```shell
+$ terraform fmt .
+$ make examples
+$ make docs
+$ make structure-check
+```
 - Submit a pull request to the original repository.
 
 Thanks for your contributions!


### PR DESCRIPTION
From an idea in https://github.com/coreos/tectonic-installer/pull/1122#issuecomment-309531602,
as a new contributor I didn't know from reading the CONTRIBUTING
document that I was expected to run certain `make` commands. This
commit spells it out for contributors that come after me. As tests
are added this list should be expanded.