### PR TITLE
Upgrade Node.js

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def quay_creds = [
   )
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.19'
+def builder_image = 'quay.io/coreos/tectonic-builder:v1.20'
 
 pipeline {
   agent none

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -21,8 +21,8 @@ RUN go get github.com/coreos/license-bill-of-materials
 
 ### Install Terraform, NodeJS and Yarn
 ENV TERRAFORM_VERSION="0.9.6"
-ENV NODE_VERSION="v6.10.0"
-ENV YARN_VERSION="v0.21.3"
+ENV NODE_VERSION="v8.1.2"
+ENV YARN_VERSION="v0.24.6"
 # yarn needs a home writable by any user running the container
 ENV HOME /opt/home
 RUN mkdir -p ${HOME}

--- a/installer/README.md
+++ b/installer/README.md
@@ -28,8 +28,8 @@ Get a [license](https://account.coreos.com) and follow the guides to create Tect
 ## Build prerequisites
 
 - [Go 1.8](https://golang.org/doc/install)
-- [Nodejs >=6.x](https://nodejs.org/en/download/)
-- [Yarn >=0.20.x](https://yarnpkg.com/lang/en/docs/install/)
+- [Nodejs >=8.x](https://nodejs.org/en/download/)
+- [Yarn >=0.24.x](https://yarnpkg.com/lang/en/docs/install/)
 - The tectonic-installer repo must be located at `$GOPATH/src/github.com/coreos/tectonic-installer`
 
 ### Build / Run

--- a/release.groovy
+++ b/release.groovy
@@ -25,7 +25,7 @@ pipeline {
             containers: [
               containerTemplate(
                 name: 'webapp-agent',
-                image: 'quay.io/coreos/tectonic-builder:v1.19',
+                image: 'quay.io/coreos/tectonic-builder:v1.20',
                 ttyEnabled: true,
                 command: 'cat',
               )


### PR DESCRIPTION
Bump node to 8.1.2 & yarn to 0.24.6. This lets us use async/await in some frontend tests.