### PR TITLE
tests/smoke/cluster_test.go: increase timeout/delay for getting pod logs

### DIFF
--- a/tests/smoke/cluster_test.go
+++ b/tests/smoke/cluster_test.go
@@ -106,8 +106,8 @@ func getIdentityLogs(t *testing.T) error {
 }
 
 func testGetIdentityLogs(t *testing.T) {
-	max := 3 * time.Minute
-	err := retry(getIdentityLogs, t, 3*time.Second, max)
+	max := 10 * time.Minute
+	err := retry(getIdentityLogs, t, 15*time.Second, max)
 	if err != nil {
 		t.Fatalf("Failed to gather identity logs in %v.", max)
 	}


### PR DESCRIPTION
Tests failing because we are trying to read logs ... but the pod is still being created when we time-out trying to read these logs. This is Friday night hot-fix that should help us a bit. We could wait for the pod to be there before starting a time-out clock.. but this will help.

```
        --- FAIL: Test/Cluster/GetIdentityLogs (180.00s)
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to find pods with prefix "tectonic-identity" (found pods in tectonic-system: )
        	smoke_test.go:113: retrying in 3s
        	smoke_test.go:112: failed with error: failed to gather logs for tectonic-system/tectonic-identity, failed to get pod logs: container "tectonic-identity" in pod "tectonic-identity-3240565221-0tswt" is waiting to start: ContainerCreating
        	smoke_test.go:113: retrying in 3s
        	cluster_test.go:112: Failed to gather identity logs in 3m0s.
```
