### PR TITLE
modules/bootkube: fix kenc.yaml indentation

### DIFF
--- a/modules/bootkube/resources/experimental/manifests/kenc.yaml
+++ b/modules/bootkube/resources/experimental/manifests/kenc.yaml
@@ -54,5 +54,5 @@ spec:
           path: /var/lock
   updateStrategy:
     rollingUpdate:
-    maxUnavailable: 1
+      maxUnavailable: 1
     type: RollingUpdate


### PR DESCRIPTION
This reenables kenc to be deployed and thus self-hosted etcd to be
recoverable.