### PR TITLE
frontend: Don't let users enter AWS creds with starting/trailing spaces

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -54,6 +54,9 @@ const awsCredsForm = new Form(AWS_CREDS, [
       if (v.length < 20) {
         return 'AWS key IDs are at least 20 characters.';
       }
+      if (v.trim() !== v) {
+        return 'AWS key IDs cannot start or end with whitespace.';
+      }
     }),
   }),
   new Field(AWS_SECRET_ACCESS_KEY, {
@@ -61,6 +64,9 @@ const awsCredsForm = new Form(AWS_CREDS, [
     validator: compose(validate.nonEmpty, (v) => {
       if (v.length < 40) {
         return 'AWS secrets are at least 40 characters.';
+      }
+      if (v.trim() !== v) {
+        return 'AWS secrets cannot start or end with whitespace.';
       }
     }),
   }),


### PR DESCRIPTION
Fixes an annoyance where tf apply would fail despite valid AWS creds.

Apparently, however terraform is using these creds, it's not using them the same way as the go code. In the GUI, creds with trailing spaces get accepted as valid, then tf apply errors-out with a weird complaint about a signature missing an equal sign.