### PR TITLE
tests/smoke/aws/: grafiti cleanup hook if smoke test fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,24 +207,27 @@ pipeline {
       post {
         failure {
           node('worker && ec2') {
-            withCredentials(creds) {
+            withCredentials([creds, quay_creds]) {
               withDockerContainer(builder_image) {
                 checkout scm
                 unstash 'installer'
-                retry(3) {
-                  timeout(15) {
-                    sh """#!/bin/bash -ex
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
-                    """
-                  }
+                timeout(15) {
+                  sh """#!/bin/bash -x
+                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
+                  """
                 }
-                retry(3) {
-                  timeout(20) {
-                    sh """#!/bin/bash -ex
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
-                    """
-                  }
+                timeout(20) {
+                  sh """#!/bin/bash -x
+                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
+                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
+                  """
+                }
+                timeout(10) {
+                  sh """#!/bin/bash -x
+                  docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
+                  ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws.tfvars
+                  ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-vpc.tfvars
+                  """
                 }
               }
             }


### PR DESCRIPTION
Jenkinsfile: added step after second destroy attempt that cleans all
created resources

tests/smoke/aws/: function that runs the grafiti Docker container and
deletes resources based on `tectonicClusterID`

In the case of `terraform destroy` failure, `grafiti delete` will clean up resources unsuccessfully destroyed using their `tectonicClusterID` tag.

Fixes #1116 