### PR TITLE
platforms/aws: Support attaching workers to ELBs

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -34,6 +34,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_worker_ec2_type | Instance size for the worker node(s). Example: `t2.medium`. | string | `t2.medium` |
 | tectonic_aws_worker_extra_sg_ids | (optional) List of additional security group IDs for worker nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_aws_worker_iam_role_name | (optional) Name of IAM role to use for the instance profiles of worker nodes. The name is also the last part of a role's ARN.<br><br>Example:  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer  * Role Name = tectonic-installer | string | `` |
+| tectonic_aws_worker_load_balancers | (optional) List of ELBs to attach all worker instances to. This is useful for exposing NodePort services via load-balancers managed separately from the cluster.<br><br>Example:  * `["ingress-nginx"]` | list | `<list>` |
 | tectonic_aws_worker_root_volume_iops | The amount of provisioned IOPS for the root block device of worker nodes. Ignored if the volume type is not io1. | string | `100` |
 | tectonic_aws_worker_root_volume_size | The size of the volume in gigabytes for the root block device of worker nodes. | string | `30` |
 | tectonic_aws_worker_root_volume_type | The type of volume for the root block device of worker nodes. | string | `gp2` |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -135,6 +135,13 @@ tectonic_aws_worker_ec2_type = "t2.medium"
 //  * Role Name = tectonic-installer
 // tectonic_aws_worker_iam_role_name = ""
 
+// (optional) List of ELBs to attach all worker instances to.
+// This is useful for exposing NodePort services via load-balancers managed separately from the cluster.
+// 
+// Example:
+//  * `["ingress-nginx"]`
+// tectonic_aws_worker_load_balancers = ""
+
 // The amount of provisioned IOPS for the root block device of worker nodes.
 // Ignored if the volume type is not io1.
 tectonic_aws_worker_root_volume_iops = "100"

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -35,6 +35,12 @@ variable "sg_ids" {
   description = "The security group IDs to be applied."
 }
 
+variable "load_balancers" {
+  description = "List of ELBs to attach all worker instances to."
+  type        = "list"
+  default     = []
+}
+
 variable "extra_tags" {
   description = "Extra AWS tags to be applied to created resources."
   type        = "map"

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -53,6 +53,7 @@ resource "aws_autoscaling_group" "workers" {
   max_size             = "${var.instance_count * 3}"
   min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.worker_conf.id}"
+  load_balancers       = ["${var.load_balancers}"]
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
   tags = [

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -166,6 +166,7 @@ module "workers" {
   subnet_ids                   = "${module.vpc.worker_subnet_ids}"
   vpc_id                       = "${module.vpc.vpc_id}"
   worker_iam_role              = "${var.tectonic_aws_worker_iam_role_name}"
+  load_balancers               = ["${var.tectonic_aws_worker_load_balancers}"]
 
   ign_docker_dropin_id          = "${module.ignition_workers.docker_dropin_id}"
   ign_kubelet_service_id        = "${module.ignition_workers.kubelet_service_id}"

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -292,3 +292,16 @@ Example:
  * Role Name = tectonic-installer
 EOF
 }
+
+variable "tectonic_aws_worker_load_balancers" {
+  type    = "list"
+  default = []
+
+  description = <<EOF
+(optional) List of ELBs to attach all worker instances to.
+This is useful for exposing NodePort services via load-balancers managed separately from the cluster.
+
+Example:
+ * `["ingress-nginx"]`
+EOF
+}


### PR DESCRIPTION
Adds support for attaching worker instances to Elastic Load Balancers.
This is useful for exposing `NodePort` services via load-balancers with
life-cycles managed separately from the cluster.  A common example is
ingress controllers.