### PR TITLE
Use shellcheck v0.4.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def quay_creds = [
   )
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.20'
+def builder_image = 'quay.io/coreos/tectonic-builder:v1.22'
 
 pipeline {
   agent none

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -19,7 +19,8 @@ RUN go get github.com/jstemmer/go-junit-report
 ### License parser
 RUN go get github.com/coreos/license-bill-of-materials
 
-### Install Terraform, NodeJS and Yarn
+### Install Shellcheck, Terraform, NodeJS and Yarn
+ENV SHELLCHECK_VERSION="v0.4.6"
 ENV TERRAFORM_VERSION="0.9.6"
 ENV NODE_VERSION="v8.1.2"
 ENV YARN_VERSION="v0.24.6"
@@ -30,7 +31,7 @@ RUN chmod 777 -R ${HOME}
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y -q \
-    build-essential sudo curl wget git autoconf automake unzip libtool jq shellcheck awscli gnupg1 \
+    build-essential sudo curl wget git autoconf automake unzip libtool jq awscli gnupg1 \
     openvpn xvfb xauth
 
 # Install Terraform
@@ -55,6 +56,12 @@ RUN cd /tmp && \
     rm -f /tmp/yarn.tar.gz && \
     mv /tmp/dist /usr/local/yarn && \
     ln -s /usr/local/yarn/bin/yarn /usr/local/bin/yarn
+
+# Install Shellcheck
+RUN cd /tmp && \
+    wget --quiet https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz && \
+    tar xJf shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz && \
+    mv /tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck
 
 # Install Chrome for installer gui tests
 # Use Chrome beta because v60 or higher is needed for headless mode

--- a/modules/update-payload/make-update-payload.sh
+++ b/modules/update-payload/make-update-payload.sh
@@ -4,14 +4,12 @@
 # It's using the manifests in the candidate assets dir.
 # yaml2json(https://github.com/bronze1man/yaml2json) and jq are required.
 
-which yaml2json > /dev/null
-if [[ $? != 0 ]]; then
+if ! which yaml2json > /dev/null; then
     echo "Require yaml2json (https://github.com/bronze1man/yaml2json)" >&2
     exit 1
 fi
 
-which jq > /dev/null
-if [[ $? != 0 ]]; then
+if ! which jq > /dev/null; then
     echo "Require jq" >&2
     exit 1
 fi

--- a/modules/update-payload/publish-payload.sh
+++ b/modules/update-payload/publish-payload.sh
@@ -20,8 +20,7 @@ if [[ ${COREUPDATE_USR} == ""  || ${COREUPDATE_KEY} == "" || $# != 1 ]]; then
     print_usage
 fi
 
-which updateservicectl > /dev/null
-if [[ $? == 0 ]]; then
+if which updateservicectl > /dev/null; then
     export UPDATESERVICECTL
     UPDATESERVICECTL=$(which updateservicectl)
 fi

--- a/modules/update-payload/upload-payload.sh
+++ b/modules/update-payload/upload-payload.sh
@@ -24,14 +24,12 @@ if [[ ${AWS_ACCESS_KEY_ID} == "" || ${AWS_SECRET_ACCESS_KEY} == "" || ${COREUPDA
     print_usage
 fi
 
-which jq > /dev/null
-if [[ $? != 0 ]]; then
+if ! which jq > /dev/null; then
     echo "Require jq"
     exit 1
 fi
 
-which updateservicectl > /dev/null
-if [[ $? == 0 ]]; then
+if which updateservicectl > /dev/null; then
     export UPDATESERVICECTL
     UPDATESERVICECTL=$(which updateservicectl)
 fi

--- a/release.groovy
+++ b/release.groovy
@@ -20,7 +20,7 @@ def creds = [
   ]
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.20'
+def builder_image = 'quay.io/coreos/tectonic-builder:v1.22'
 
 pipeline {
   agent none

--- a/tests/smoke/aws/cluster-foreach.sh
+++ b/tests/smoke/aws/cluster-foreach.sh
@@ -3,6 +3,7 @@ set -x
 set -e
 
 fail () {
+  # shellcheck disable=SC2181
   if [ $? -ne 0 ]
   then
     echo "$0 failed but exiting 0 because we don't want to fail tests"


### PR DESCRIPTION
- Update builder image to use shellcheck v0.4.6.
- Fix new shellcheck errors.
- Update Jenkinsfile to use new builder image.

Ubuntu & Debian are on v0.4.4. People using homebrew or other installation methods are likely on newer versions that cause `make lint` to report shellcheck errors that Jenkins doesn't catch.