### PR TITLE
platforms/aws: set controller manager’s timers to work around ELB’s TTL

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -99,7 +99,7 @@ resource "template_dir" "bootkube" {
 
     tectonic_version = "${var.versions["tectonic"]}"
 
-    master_count = "${var.master_count}"
+    master_count              = "${var.master_count}"
     node_monitor_grace_period = "${var.node_monitor_grace_period}"
     pod_eviction_timeout      = "${var.pod_eviction_timeout}"
   }

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -100,6 +100,8 @@ resource "template_dir" "bootkube" {
     tectonic_version = "${var.versions["tectonic"]}"
 
     master_count = "${var.master_count}"
+    node_monitor_grace_period = "${var.node_monitor_grace_period}"
+    pod_eviction_timeout      = "${var.pod_eviction_timeout}"
   }
 }
 

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -38,6 +38,8 @@ spec:
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
         - --leader-elect=true
+        - --node-monitor-grace-period=${node_monitor_grace_period}
+        - --pod-eviction-timeout=${pod_eviction_timeout}
         - --cloud-provider=${cloud_provider}
         livenessProbe:
           httpGet:

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -107,3 +107,15 @@ variable "master_count" {
   description = "The number of the master nodes"
   type        = "string"
 }
+
+variable "node_monitor_grace_period" {
+  description = "Amount of time which we allow running Node to be unresponsive before marking it unhealthy. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status. N must be stricly > 1."
+  type        = "string"
+  default     = "40s"
+}
+
+variable "pod_eviction_timeout" {
+  description = "The grace period for deleting pods on failed nodes. The eviction process will start after node_monitor_grace_period + pod_eviction_timeout."
+  type        = "string"
+  default     = "5m"
+}


### PR DESCRIPTION
The default behavior of Kubernetes's controller manager is to mark a node
as Unhealthy after 40s without an update from the node's kubelet. However,
AWS ELB's Route53 records have a fixed TTL of 60s. Therefore, when an ELB's
node disappears (e.g. scaled down or crashed), kubelet might fail to report
for a period of time that exceed the default grace period of 40s and the
node might become Unhealthy. While the eviction process won't start until
the pod_eviction_timeout is reached, 5min by default, certain operators
might already have taken action. This is the case for the etcd operator as
of v0.3.3, which removes the likely-healthy etcd pods from the the
cluster, potentially leading to a loss-of-quorum as generally all kubelets
are affected simultaneously.

To cope with this issue, we increase the grace period, and reduce the
pod eviction time-out accordingly so pods still get evicted after an total
time of 340s after the first post-status failure.

[Here](https://github.com/kubernetes-incubator/kubespray/blob/master/docs/kubernetes-reliability.md) is a good read explaining how the various grace periods and update
periods work together and how their values should be calculated. Note that 
we do not let the users configure kubelet's `--node-status-update-frequency`
and controller-manager's `–-node-monitor-period` due to the fact that these flags are
set in different Terraform modules. Therefore, this PR does not introduce the ability to 
set fast-paced failure detection and pod eviction. The grace period must still be 
set > 10-20sec, with 40sec being the minimum recommended. This is a non-goal as
this PR mainly tries to address the issues we are facing with self-hosted etcd on AWS. 

Fixes https://github.com/coreos-inc/tectonic-issues/issues/268

Ref: https://github.com/kubernetes/kubernetes/issues/41916
Ref: https://github.com/kubernetes-incubator/kube-aws/issues/598

/cc @xiang90 @sym3tri @robszumski @bison 