### PR TITLE
modules/bootkube: Add "maxUnavailable:0" to the rolling update strategy.

### DIFF
--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -8,6 +8,10 @@ metadata:
     k8s-app: kube-controller-manager
 spec:
   replicas: ${master_count}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -8,6 +8,10 @@ metadata:
     k8s-app: kube-scheduler
 spec:
   replicas: ${master_count}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
This is necessary when updating the component with required pod anti-affinity.