### PR TITLE
tests/conformance: remove double quotes to make bash docker run happy

### DIFF
--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -99,7 +99,7 @@ function wait_for_pods() {
 }
 
 # shellcheck disable=SC2086
-docker run --env-file ./env.list -i -v $"{WORKSPACE}":"${PROJECT}" ${MNT_SECRETS} -w "${PROJECT}" "${TECTONIC_BUILDER}" /bin/bash <<EOF
+docker run --env-file ./env.list -i -v ${WORKSPACE}:${PROJECT} ${MNT_SECRETS} -w ${PROJECT} ${TECTONIC_BUILDER} /bin/bash <<EOF
   
 mkdir -p ${PROJECT}/build/${CLUSTER}/
 ln -sf ${PROJECT}/tests/smoke/aws/vars/aws.tfvars ${PROJECT}/build/${CLUSTER}/terraform.tfvars
@@ -116,5 +116,7 @@ echo "API Server UP!"
 kubectl get pods --all-namespaces
 kubectl get nodes
   
-docker pull "${KUBE_CONFORMANCE}"
-docker run -v "${KUBECONFIG}":/kubeconfig "${KUBE_CONFORMANCE}"
+# shellcheck disable=SC2086
+docker pull ${KUBE_CONFORMANCE}
+# shellcheck disable=SC2086
+docker run -v ${KUBECONFIG}:/kubeconfig ${KUBE_CONFORMANCE}


### PR DESCRIPTION
Docker run complains about the double quotes even though shellcheck wants them :(