### PR TITLE
frontend: Change AWS docs link to open GUI installer docs

### DIFF
--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -37,7 +37,7 @@ const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PL
   }
   return <p className="text-muted">
     Use the graphical installer to input cluster details, this is best for demos and your first Tectonic cluster.
-    &nbsp;&nbsp;<a href={DOCS[platform]} target="_blank" >{platformName} documentation&nbsp;&nbsp;<i className="fa fa-external-link" /></a>
+    &nbsp;&nbsp;<a href={DOCS[platform]} target="_blank">{platformName} documentation&nbsp;&nbsp;<i className="fa fa-external-link" /></a>
   </p>;
 });
 

--- a/installer/frontend/platforms.js
+++ b/installer/frontend/platforms.js
@@ -29,7 +29,7 @@ export const SELECTED_PLATFORMS = (window.config ? window.config.platforms : [])
 
 export const DOCS = {
   [BARE_METAL_TF]: 'https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html',
-  [AWS_TF]: 'https://coreos.com/tectonic/docs/latest/install/aws/aws-terraform.html',
+  [AWS_TF]: 'https://coreos.com/tectonic/docs/latest/install/aws/index.html',
   [AZURE]: 'https://coreos.com/tectonic/docs/latest/install/azure/azure-terraform.html',
   [OPENSTACK]: 'https://coreos.com/tectonic/docs/latest/install/openstack/openstack-terraform.html',
 };


### PR DESCRIPTION
Shouldn't this link open the GUI installer docs?