### PR TITLE
tests/conformance: avoid early termination of script

### DIFF
--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -67,12 +67,11 @@ function kubectl() {
 }
  
 function wait_for_pods() {
+    set +e
     echo "Waiting for pods in namespace $1"
     while true; do
   
-        set +e
         out=$($KUBECTL -n "$1" get po -o custom-columns=STATUS:.status.phase,NAME:.metadata.name)
-        set -e
         status=$?
         echo "$out"
   
@@ -97,6 +96,7 @@ function wait_for_pods() {
         echo "Pods not available yet, waiting for 5 seconds"
         sleep 5
     done
+    set -e
 }
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
We don't want the while loop to exit in case of errors, hence we should not `set e`. Or else it can cause false early termination. 