### PR TITLE
monitoring: ensure triggering alerts on down targets

### DIFF
--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-rules.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-rules.yaml
@@ -48,14 +48,14 @@ data:
     ### Up Alerting ###
     
     Alert TargetDown
-      IF 100 * (count(up == 0) / count(up)) > 3
+      IF 100 * (count by(job) (up == 0) / count by(job) (up)) > 10
       FOR 10m
       LABELS {
         severity = "warning"
       }
       ANNOTATIONS {
         summary = "Targets are down",
-        description = "More than {{ $value }}% of targets are down."
+        description = "{{ $value }}% or more of {{ $labels.job }} targets are down."
       }
     
     ### Dead man's switch ###
@@ -122,24 +122,24 @@ data:
     
     ALERT K8SManyNodesNotReady
       IF
-        count by (cluster) (kube_node_status_ready{condition="true"} == 0) > 1
+        count(kube_node_status_ready{condition="true"} == 0) > 1
         AND
           (
-            count by (cluster) (kube_node_status_ready{condition="true"} == 0)
+            count(kube_node_status_ready{condition="true"} == 0)
           /
-            count by (cluster) (kube_node_status_ready{condition="true"})
+            count(kube_node_status_ready{condition="true"})
           ) > 0.2
       FOR 1m
       LABELS {
         severity = "critical",
       }
       ANNOTATIONS {
-        summary = "Many K8s nodes are Not Ready",
-        description = "{{ $value }} K8s nodes (more than 10% of cluster {{ $labels.cluster }}) are in the NotReady state.",
+        summary = "Many Kubernetes nodes are Not Ready",
+        description = "{{ $value }} Kubernetes nodes (more than 10% are in the NotReady state).",
       }
     
     ALERT K8SKubeletDown
-      IF count by (cluster) (up{job="kubelet"} == 0) / count by (cluster) (up{job="kubelet"}) > 0.03
+      IF count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) > 0.03
       FOR 1h
       LABELS {
         severity = "warning",
@@ -150,7 +150,7 @@ data:
       }
     
     ALERT K8SKubeletDown
-      IF absent(up{job="kubelet"}) or count by (cluster) (up{job="kubelet"} == 0) / count by (cluster) (up{job="kubelet"}) > 0.1
+      IF absent(up{job="kubelet"} == 1) or count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) > 0.1
       FOR 1h
       LABELS {
         severity = "critical",
@@ -343,7 +343,7 @@ data:
       histogram_quantile(0.5,sum by (le,cluster) (scheduler_binding_latency_microseconds_bucket)) / 1e6
   kube-apiserver.rules: |+
     ALERT K8SApiserverDown
-      IF absent({job="apiserver"}) or (count by(cluster) (up{job="apiserver"} == 1) < count by(cluster) (up{job="apiserver"}))
+      IF absent(up{job="apiserver"} == 1)
       FOR 5m
       LABELS {
         severity = "critical"
@@ -372,7 +372,7 @@ data:
       }
   kube-controller-manager.rules: |+
     ALERT K8SControllerManagerDown
-      IF absent(up{job="kube-controller-manager"}) or (count by(cluster) (up{job="kube-controller-manager"} == 1) == 0)
+      IF absent(up{job="kube-controller-manager"} == 1)
       FOR 5m
       LABELS {
         severity = "critical",
@@ -380,10 +380,11 @@ data:
       ANNOTATIONS {
         summary = "Controller manager is down",
         description = "There is no running K8S controller manager. Deployments and replication controllers are not making progress.",
+        runbook = "https://coreos.com/tectonic/docs/latest/troubleshooting/controller-recovery.html#recovering-a-controller-manager",
       }
   kube-scheduler.rules: |+
     ALERT K8SSchedulerDown
-      IF absent(up{job="kube-scheduler"}) or (count by(cluster) (up{job="kube-scheduler"} == 1) == 0)
+      IF absent(up{job="kube-scheduler"} == 1)
       FOR 5m
       LABELS {
         severity = "critical",
@@ -391,17 +392,18 @@ data:
       ANNOTATIONS {
         summary = "Scheduler is down",
         description = "There is no running K8S scheduler. New pods are not being assigned to nodes.",
+        runbook = "https://coreos.com/tectonic/docs/latest/troubleshooting/controller-recovery.html#recovering-a-scheduler",
       }
   node.rules: |+
     ALERT NodeExporterDown
-      IF up{job="node-exporter"} == 0
+      IF absent(up{job="node-exporter"} == 1)
       FOR 10m
       LABELS {
         severity = "warning"
       }
       ANNOTATIONS {
         summary = "node-exporter cannot be scraped",
-        description = "Prometheus could not scrape a node-exporter for more than 10m.",
+        description = "Prometheus could not scrape a node-exporter for more than 10m, or node-exporters have disappeared from discovery.",
       }
   prometheus.rules: |+
     ALERT FailedReload


### PR DESCRIPTION
This is a bugfix for the previously introduced alerting rules. The alerting rules did not trigger correctly, in the case where a target is still discovered cannot be scraped successfully, this is now fixed. Additionally runbook links to recovery guides for the kube-scheduler and kube-controller-manager.

The alerting rules have already been reviewed by the monitoring team and have been merged in the Tectonic Prometheus Operator, this PR is just to sync the state.

@s-urbaniak @alexsomesan @Quentin-M 

/cc @robszumski @fabxc @mxinden @gouthamve