### PR TITLE
Azure: Set delete_os_disk_on_termination = true

### DIFF
--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -26,6 +26,7 @@ resource "azurerm_virtual_machine" "etcd_node" {
     caching       = "ReadWrite"
     create_option = "FromImage"
   }
+  delete_os_disk_on_termination = "true"
 
   os_profile {
     computer_name  = "etcd"

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -70,6 +70,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
     os_type       = "linux"
     vhd_uri       = "${azurerm_storage_account.tectonic_master.primary_blob_endpoint}${azurerm_storage_container.tectonic_master.name}/${var.cluster_name}-master${count.index}.vhd"
   }
+  delete_os_disk_on_termination = "true"
 
   os_profile {
     computer_name  = "${var.cluster_name}-master${count.index}"

--- a/modules/azure/master-ss/master.tf
+++ b/modules/azure/master-ss/master.tf
@@ -64,6 +64,7 @@ resource "azurerm_virtual_machine_scale_set" "tectonic_masters" {
     os_type        = "linux"
     vhd_containers = ["${azurerm_storage_account.tectonic_master.primary_blob_endpoint}${azurerm_storage_container.tectonic_master.name}"]
   }
+  delete_os_disk_on_termination = "true"
 
   os_profile {
     computer_name_prefix = "tectonic-master-"

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -71,6 +71,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
     os_type       = "linux"
     vhd_uri       = "${azurerm_storage_account.tectonic_worker.primary_blob_endpoint}${azurerm_storage_container.tectonic_worker.name}/${var.cluster_name}-worker${count.index}.vhd"
   }
+  delete_os_disk_on_termination = "true"
 
   os_profile {
     computer_name  = "${var.cluster_name}-worker${count.index}"

--- a/modules/azure/worker-ss/workers.tf
+++ b/modules/azure/worker-ss/workers.tf
@@ -68,6 +68,7 @@ resource "azurerm_virtual_machine_scale_set" "tectonic_workers" {
     os_type        = "linux"
     vhd_containers = ["${azurerm_storage_account.tectonic_worker.primary_blob_endpoint}${azurerm_storage_container.tectonic_worker.name}"]
   }
+  delete_os_disk_on_termination = "true"
 
   os_profile {
     computer_name_prefix = "tectonic-worker-"


### PR DESCRIPTION
Without this, replacing nodes doesn't work. Related #1243.
But either way, I think it's fine to always delete the OS disk.