### PR TITLE
modules/update-payload: Retain cluo manage-agent behavior

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/container-linux-update-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/container-linux-update-operator.yaml
@@ -22,6 +22,7 @@ spec:
         image: ${container_linux_update_operator_image}
         command:
         - "/bin/update-operator"
+        - "--manage-agent=true"
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -30,7 +30,8 @@
             "containers": [
               {
                 "command": [
-                  "/bin/update-operator"
+                  "/bin/update-operator",
+                  "--manage-agent=true"
                 ],
                 "env": [
                   {


### PR DESCRIPTION
* CLUO will default to manage-agent=false in a future release. Retain the original behavior in Tectonic until the new version operator for this component is ready.
* Corresponds to this change which will go into a future CLUO release https://github.com/coreos/container-linux-update-operator/pull/104