### PR TITLE
installer/frontend: add git short SHA + dirty flag to the header

### DIFF
--- a/installer/frontend/.babelrc
+++ b/installer/frontend/.babelrc
@@ -1,5 +1,15 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["syntax-async-functions","transform-regenerator","git-version"]
+  "plugins": [
+    "syntax-async-functions",
+    "transform-regenerator",
+    [
+      "git-version",
+      {
+        "showDirty": true,
+        "commitLength": 7
+      }
+    ]
+  ]
 }
 

--- a/installer/frontend/components/header.jsx
+++ b/installer/frontend/components/header.jsx
@@ -125,7 +125,7 @@ export class Header extends React.Component {
               </span>
             </li>}
             <li className="co-navbar-nav-item__version">
-              <span>Version: {GIT_TAG}</span>
+              <span>Version: {GIT_TAG} ({GIT_COMMIT})</span>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
We previously made https://github.com/coreos/tectonic-installer/commit/68c4adbdf492f97d728b9c5a04b51e5343d16a04 in order to make the commit/dirty flag available for debugging purposes. As we removed the `--version` and we introduced the header, this disappeared.

This PR adds a 7-characters commit SHA and the dirty flag in the header to get this information back.

![2017-06-29 13-22-29](https://user-images.githubusercontent.com/1332289/27708504-08362506-5cce-11e7-85fb-5db7b96df910.png)
