### PR TITLE
frontend: Remove Container Linux Update Channel input

### DIFF
--- a/installer/frontend/__tests__/examples/aws-vpc.json
+++ b/installer/frontend/__tests__/examples/aws-vpc.json
@@ -41,7 +41,6 @@
     "tectonic_aws_worker_root_volume_size": 1000,
     "tectonic_aws_worker_root_volume_type": "io1",
     "tectonic_base_domain": "example.com",
-    "tectonic_cl_channel": "stable",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "test",
     "tectonic_dns_name": "test",

--- a/installer/frontend/__tests__/examples/aws.json
+++ b/installer/frontend/__tests__/examples/aws.json
@@ -33,7 +33,6 @@
     "tectonic_aws_worker_root_volume_size": 30,
     "tectonic_aws_worker_root_volume_type": "gp2",
     "tectonic_base_domain": "tectonic.dev.coreos.systems",
-    "tectonic_cl_channel": "stable",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "test",
     "tectonic_dns_name": "test",

--- a/installer/frontend/__tests__/examples/metal.json
+++ b/installer/frontend/__tests__/examples/metal.json
@@ -9,7 +9,6 @@
     "tectonic_admin_email": "admin@example.com",
     "tectonic_admin_password_hash": "$2a$12$96LR7NxL/T7LaijR0fxl3.aVI8owkpq0B./ogZ8wNmzF1bGPEZPBK",
     "tectonic_base_domain": "unused",
-    "tectonic_cl_channel": "stable",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "my-cluster",
     "tectonic_dns_name": "",

--- a/installer/frontend/__tests__/examples/tectonic-aws-vpc.progress
+++ b/installer/frontend/__tests__/examples/tectonic-aws-vpc.progress
@@ -41,7 +41,6 @@
     "caType": "self-signed",
     "clusterName": "test",
     "clusterSubdomain": "test",
-    "channelToUse": "stable",
     "externalETCDClient": "",
     "etcdOption": "provisioned",
     "tectonicLicense": "<TECTONIC_LICENSE>",

--- a/installer/frontend/__tests__/examples/tectonic-aws.progress
+++ b/installer/frontend/__tests__/examples/tectonic-aws.progress
@@ -36,7 +36,6 @@
     "caType": "self-signed",
     "clusterName": "test",
     "clusterSubdomain": "test",
-    "channelToUse": "stable",
     "externalETCDClient": "",
     "etcdOption": "selfHosted",
     "tectonicLicense": "<TECTONIC_LICENSE>",

--- a/installer/frontend/__tests__/examples/tectonic-baremetal.progress
+++ b/installer/frontend/__tests__/examples/tectonic-baremetal.progress
@@ -17,7 +17,6 @@
         "host": "node1.example.com"
       }
     ],
-    "channelToUse": "stable",
     "osToUse": "1353.8.0",
     "podCIDR": "10.2.0.0/16",
     "serviceCIDR": "10.3.0.0/16",

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -41,7 +41,6 @@ export const BM_WORKERS = 'workers';
 export const CA_CERTIFICATE = 'caCertificate';
 export const CA_PRIVATE_KEY = 'caPrivateKey';
 export const CA_TYPE = 'caType';
-export const CHANNEL_TO_USE = 'channelToUse';
 export const CLUSTER_NAME = 'clusterName';
 export const CLUSTER_SUBDOMAIN = 'clusterSubdomain';
 export const CONTROLLER_DOMAIN = 'controllerDomain';
@@ -249,7 +248,6 @@ export const toAWS_TF = (cc, FORMS, opts={}) => {
       tectonic_aws_worker_root_volume_type: workers[STORAGE_TYPE],
       tectonic_aws_ssh_key: cc[AWS_SSH],
       tectonic_base_domain: getZoneDomain(cc),
-      tectonic_cl_channel: cc[CHANNEL_TO_USE],
       tectonic_cluster_cidr: cc[POD_CIDR],
       tectonic_cluster_name: cc[CLUSTER_NAME],
       tectonic_master_count: controllers[NUMBER_OF_INSTANCES],
@@ -318,7 +316,6 @@ export const toBaremetal_TF = (cc, FORMS, opts={}) => {
       // eslint-disable-next-line no-sync
       tectonic_admin_password_hash: bcrypt.hashSync(cc[ADMIN_PASSWORD], opts.salt || bcrypt.genSaltSync(bcryptCost)),
       tectonic_cluster_name: cc[CLUSTER_NAME],
-      tectonic_cl_channel: cc[CHANNEL_TO_USE],
       tectonic_admin_email: cc[ADMIN_EMAIL],
       tectonic_metal_cl_version: cc[BM_OS_TO_USE],
       tectonic_metal_ingress_domain: getTectonicDomain(cc),

--- a/installer/frontend/components/aws-cluster-info.jsx
+++ b/installer/frontend/components/aws-cluster-info.jsx
@@ -1,30 +1,19 @@
 import { connect } from 'react-redux';
 import React from 'react';
 
-import { Input, Select, Connect } from './ui';
+import { Input, Connect } from './ui';
 import { TectonicLicense, licenseForm } from './tectonic-license';
 import { ExperimentalFeatures } from './experimental-features';
 import { AWS_Tags, tagsFields } from './aws-tags';
-import { Alert } from './alert';
-import { Form, Field } from '../form';
+import { Form } from '../form';
 import fields from '../fields';
-import { AWS_CLUSTER_INFO, CHANNEL_TO_USE, CLUSTER_NAME } from '../cluster-config';
+import { AWS_CLUSTER_INFO, CLUSTER_NAME } from '../cluster-config';
 
 const clusterInfoForm = new Form(AWS_CLUSTER_INFO, [
   licenseForm,
   tagsFields,
   fields[CLUSTER_NAME],
-  new Field(CHANNEL_TO_USE, {
-    default: 'stable',
-    validator: v => ['stable', 'beta', 'alpha'].includes(v) ? '' : 'unknown channel',
-  }),
 ]);
-
-const ChannelWarning = connect(({clusterConfig}) => ({channel: clusterConfig[CHANNEL_TO_USE]}))(
-  ({channel}) => (channel !== 'alpha' ? null : <Alert>
-    The Alpha channel can be unstable. It should only be used for testing or development.
-  </Alert>)
-);
 
 const TagsWithPlaceholder = connect(({clusterConfig}) => ({clusterName: clusterConfig[CLUSTER_NAME] || 'myclustername'}))(({clusterName}) => <AWS_Tags placeholder={`e.g. ${clusterName}`} />);
 
@@ -40,23 +29,6 @@ export const AWS_ClusterInfo = () => <div>
       <p className="text-muted" style={{marginBottom: 0}}>
         This name is used in the Tectonic Console to identify this cluster.
       </p>
-    </div>
-  </div>
-
-  <div className="row form-group">
-    <div className="col-xs-3">
-      <label htmlFor="coreOsChannel">Container Linux Update Channel</label>
-    </div>
-    <div className="col-xs-6">
-      <Connect field={CHANNEL_TO_USE}>
-        <Select id="coreOsChannel">
-          <option value="" disabled>Select a CoreOS Container Linux channel</option>
-          <option value="stable">Stable</option>
-          <option value="beta">Beta</option>
-          <option value="alpha">Alpha</option>
-        </Select>
-      </Connect>
-      <ChannelWarning/>
     </div>
   </div>
 


### PR DESCRIPTION
Remove the Container Linux Update Channel dropdown option from the AWS install Cluster Info page.

See #1209 

![screenshot-1](https://user-images.githubusercontent.com/460802/27717886-3268ade8-5d83-11e7-96fd-60423c2a2b08.png)
