### PR TITLE
frontend: Fix text on Bare Metal Define Masters / Workers pages

### DIFF
--- a/installer/frontend/components/bm-nodeforms.jsx
+++ b/installer/frontend/components/bm-nodeforms.jsx
@@ -258,12 +258,7 @@ class NodeForm extends React.Component {
         <span className="fa fa-upload"></span> Bulk Upload Addresses</a>
       </div>
       <div>
-        <div>
-          {docs}
-
-          Enter the MAC addresses of the nodes you'd like to use as masters,
-          and the host names you'll use to refer to them.
-        </div>
+        {docs}
         <div className="">
           <div className="row">
             <div className="col-xs-5">
@@ -302,7 +297,9 @@ export const mastersForm = new Form('MASTERSFORM', [mastersFields]);
 
 export const BM_Controllers = () => <NodeForm
   name="Master"
-  docs={`Master nodes run essential cluster services and don't run end-user apps.`}
+  docs={`Master nodes run essential cluster services and don't run end-user apps. Enter
+      the MAC addresses of the nodes you'd like to use as masters, and the host names
+      you'll use to refer to them.`}
   field={mastersFields} />;
 
 BM_Controllers.canNavigateForward = mastersForm.canNavigateForward;
@@ -312,7 +309,8 @@ export const workersForm = new Form('WORKERS_FORM', [workerFields]);
 export const BM_Workers = () => <NodeForm
   name="Worker"
   docs={`Worker nodes run end-user's apps. The cluster software automatically shares load
-      between these nodes.`}
+      between these nodes. Enter the MAC addresses of the nodes you'd like to use as
+      workers, and the host names you'll use to refer to them.`}
   field={workerFields} />;
 
 BM_Workers.canNavigateForward = workersForm.canNavigateForward;


### PR DESCRIPTION
Change "you'd like to use as masters" to "you'd like to use as workers" on Define Workers page.
Add missing space char that wasn't being output after `{docs}`.

Before | After
--- | ---
![screenshot-1](https://user-images.githubusercontent.com/460802/27718193-44d0586c-5d85-11e7-97df-06658c545bbb.png) | ![screenshot-1](https://user-images.githubusercontent.com/460802/27718334-5b2ca588-5d86-11e7-826f-509f176e02b1.png)
![screenshot-4](https://user-images.githubusercontent.com/460802/27718219-8f2bb2b2-5d85-11e7-82e4-5ae222192cb2.png) | ![screenshot-1](https://user-images.githubusercontent.com/460802/27718319-3e36b810-5d86-11e7-90e7-d97c50ca2d98.png)
