### PR TITLE
Run 'grafiti' as cleanup step after AWS smoke test failure

### DIFF
--- a/Documentation/files/aws-policy-grafiti.json
+++ b/Documentation/files/aws-policy-grafiti.json
@@ -1,0 +1,197 @@
+{
+    "Statement": [
+        {
+            "Action": [
+                "autoscaling:CreateAutoScalingGroup",
+                "autoscaling:CreateLaunchConfiguration",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:DescribeScalingActivities",
+                "autoscaling:DescribeTags",
+                "autoscaling:UpdateAutoScalingGroup",
+                "autoscaling:DeleteAutoScalingGroup",
+                "autoscaling:DeleteLaunchConfiguration"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:AllocateAddress",
+                "ec2:AssociateAddress",
+                "ec2:AssociateRouteTable",
+                "ec2:AttachInternetGateway",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:CreateInternetGateway",
+                "ec2:CreateNatGateway",
+                "ec2:CreateRoute",
+                "ec2:CreateRouteTable",
+                "ec2:CreateSecurityGroup",
+                "ec2:CreateSubnet",
+                "ec2:CreateTags",
+                "ec2:CreateVpc",
+                "ec2:CreateVolume",
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeImages",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeInstanceAttribute",
+                "ec2:DescribeKeyPairs",
+                "ec2:DescribeNatGateways",
+                "ec2:DescribeNetworkAcls",
+                "ec2:DescribeRegions",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcAttribute",
+                "ec2:DescribeVpnGateways",
+                "ec2:DescribeVpnConnections",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeVpcClassicLink",
+                "ec2:ModifyInstanceAttribute",
+                "ec2:ModifySubnetAttribute",
+                "ec2:ModifyVpcAttribute",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RunInstances",
+                "ec2:TerminateInstances",
+                "ec2:DeleteRoute",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DisassociateRouteTable",
+                "ec2:ReplaceRouteTableAssociation",
+                "ec2:DeleteRouteTable",
+                "ec2:DeleteSubnet",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:ModifyNetworkInterfaceAttribute",
+                "ec2:DeleteNatGateway",
+                "ec2:DeleteNetworkInterface",
+                "ec2:DeleteSecurityGroup",
+                "ec2:DetachInternetGateway",
+                "ec2:DeleteInternetGateway",
+                "ec2:ReleaseAddress",
+                "ec2:DeleteVpc",
+                "ec2:DetachVpnGateway",
+                "ec2:DeleteVpnGateway",
+                "ec2:DeleteVpnConnection",
+                "ec2:DeleteVpnConnectionRoute"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
+                "elasticloadbalancing:ConfigureHealthCheck",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:DescribeInstanceHealth"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:CreateInstanceProfile",
+                "iam:CreateRole",
+                "iam:GetInstanceProfile",
+                "iam:GetUser",
+                "iam:GetRole",
+                "iam:GetRolePolicy",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:ListInstanceProfiles",
+                "iam:ListInstanceProfilesForRole",
+                "iam:ListRoles",
+                "iam:ListRolePolicies",
+                "iam:DeleteRole"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "route53:ChangeResourceRecordSets",
+                "route53:ChangeTagsForResource",
+                "route53:GetChange",
+                "route53:GetHostedZone",
+                "route53:CreateHostedZone",
+                "route53:DeleteHostedZone",
+                "route53:ListHostedZones",
+                "route53:ListResourceRecordSets",
+                "route53:ListTagsForResource",
+                "route53:ListTagsForResources",
+                "route53:UpdateHostedZoneComment"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:ListBucket",
+                "s3:GetBucketCors",
+                "s3:GetBucketWebsite",
+                "s3:GetBucketVersioning",
+                "s3:GetAccelerateConfiguration",
+                "s3:GetBucketRequestPayment",
+                "s3:GetBucketLogging",
+                "s3:GetLifecycleConfiguration",
+                "s3:GetBucketReplication",
+                "s3:GetReplicationConfiguration",
+                "s3:GetBucketLocation",
+                "s3:GetBucketTagging",
+                "s3:DeleteBucket",
+                "s3:PutBucketAcl",
+                "s3:PutBucketTagging"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:PutObjectTagging",
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectTagging",
+                "s3:GetObjectVersion",
+                "s3:DeleteObject"
+            ],
+            "Resource": "arn:aws:s3:::*"
+        },
+        {
+            "Action": [
+                "sts:GetCallerIdentity"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "tag:GetResources"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ],
+    "Version": "2012-10-17"
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,7 @@ pipeline {
     stage("Tests") {
       environment {
         TECTONIC_INSTALLER_ROLE = 'tectonic-installer'
+        GRAFITI_DELETER_ROLE = 'grafiti-deleter'
       }
       steps {
         parallel (
@@ -109,31 +110,36 @@ pipeline {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'
-                  timeout(45) {
-                    sh """#!/bin/bash -ex
-                    . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-tls.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws-tls.tfvars
-                    """
-                  }
-                  catchError {
-                    timeout (5) {
-                      sshagent(['aws-smoke-test-ssh-key']) {
-                        sh """#!/bin/bash
-                        # Running without -ex because we don't care if this fails
-                        . ${WORKSPACE}/tests/smoke/aws/smoke.sh common vars/aws-tls.tfvars
-                        ${WORKSPACE}/tests/smoke/aws/cluster-foreach.sh ${WORKSPACE}/tests/smoke/forensics.sh
+                  script {
+                    try {
+                      timeout(45) {
+                        sh """#!/bin/bash -ex
+                        . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-tls.tfvars | tee ${WORKSPACE}/terraform.log
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws-tls.tfvars
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-tls.tfvars
                         """
                       }
-                    }
-                  }
-                  retry(3) {
-                    timeout(15) {
-                      sh """#!/bin/bash -ex
-                      . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                      ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-tls.tfvars
-                      """
+                    } catch (err) {
+                      timeout (5) {
+                        sshagent(['aws-smoke-test-ssh-key']) {
+                          sh """#!/bin/bash
+                          # Running without -ex because we don't care if this fails
+                          . ${WORKSPACE}/tests/smoke/aws/smoke.sh common vars/aws-tls.tfvars
+                          ${WORKSPACE}/tests/smoke/aws/cluster-foreach.sh ${WORKSPACE}/tests/smoke/forensics.sh
+                          """
+                        }
+                      }
+                      timeout(5) {
+                        sh """#!/bin/bash -x
+                        . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$GRAFITI_DELETER_ROLE"
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-tls.tfvars
+                        """
+                      }
+
+                      // Stage should fail
+                      throw err
                     }
                   }
                 }
@@ -217,30 +223,34 @@ pipeline {
                         sh """#!/bin/bash -ex
                         . ${WORKSPACE}/tests/smoke/aws/smoke.sh create-vpc
                         ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-vpc.tfvars
-                        ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-vpc.tfvars
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-vpc.tfvars | tee ${WORKSPACE}/terraform.log
                         ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws-vpc.tfvars
-
                         ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
                         ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
                         """
                       }
-                    }
-                    catch (error) {
-                        throw error
-                    }
-                    finally {
-                      retry(3) {
-                        timeout(15) {
-                          sh """#!/bin/bash -x
-                            ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
-                            ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
-
-                            # As /build is created by root, make sure to remove it again
-                            # so non-root can create it later.
-                            rm -r ${WORKSPACE}/build
-                          """
-                        }
+                    } catch (err) {
+                      timeout(15) {
+                        sh """#!/bin/bash -x
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
+                        """
                       }
+                      timeout(5) {
+                        sh """#!/bin/bash -x
+                        . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$GRAFITI_DELETER_ROLE"
+                        ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-vpc.tfvars
+                        """
+                      }
+
+                      // Stage should fail
+                      throw err
+                    } finally {
+                      sh """#!/bin/bash -ex
+                      # As /build is created by root, make sure to remove it again
+                      # so non-root can create it later.
+                      rm -r ${WORKSPACE}/build
+                      """
                     }
                   }
                 }
@@ -538,36 +548,6 @@ pipeline {
             }
           }
         )
-      }
-      post {
-        failure {
-          node('worker && ec2') {
-            withCredentials([creds, quay_creds]) {
-              withDockerContainer(params.builder_image) {
-                checkout scm
-                unstash 'installer'
-                timeout(15) {
-                  sh """#!/bin/bash -x
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
-                  """
-                }
-                timeout(20) {
-                  sh """#!/bin/bash -x
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
-                  """
-                }
-                timeout(10) {
-                  sh """#!/bin/bash -x
-                  docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws.tfvars
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-vpc.tfvars
-                  """
-                }
-              }
-            }
-          }
-        }
       }
     }
 


### PR DESCRIPTION
Jenkinsfile: removed grafiti docker container dependency
tests/smoke/aws: removed grafiti docker container dependency

Environment variables required by `grafiti` to delete orphaned cluster resources are present within `tectonic-builder` containers and not accessible by a `grafiti` container. Cluster cleanup should be done by the same container that created the cluster.