### PR TITLE
frontend: Add links to assets zip docs

### DIFF
--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -5,7 +5,7 @@ import { TectonicGA } from '../tectonic-ga';
 export const DryRun = () => <div className="row">
   <div className="col-xs-12">
     <div className="form-group">
-      Your cluster assets have been created. You can download these assets and customize underlying infrastructure as needed.
+      Your cluster assets have been created. You can download these <a href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" target="_blank">assets</a> and customize underlying infrastructure as needed.
       Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.
       &nbsp;<a href="https://coreos.com/tectonic/docs/latest/install/aws/manual-boot.html"
         onClick={TectonicGA.sendDocsEvent} target="_blank">

--- a/installer/frontend/components/submit-definition.jsx
+++ b/installer/frontend/components/submit-definition.jsx
@@ -71,7 +71,7 @@ export const SubmitDefinition = connect(
         <span> After submission, the definition cannot be updated. Go <a onClick={!inProgress && navigatePrevious} className={inProgress && 'disabled'}>back</a> to update or make changes.</span>
       </p>
       <p>
-        You'll be able to download your assets zip file after the definition is submitted.
+        You'll be able to download your <a href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" target="_blank">assets zip file</a> after the definition is submitted.
       </p>
       <br />
       {feature}


### PR DESCRIPTION
Link mentions of assets zip in the GUI text to the relevant docs page.

Fixes #1259 

![screenshot-1](https://user-images.githubusercontent.com/460802/27720736-49b49788-5d96-11e7-9a0e-17c50e0dbf6d.png)
![screenshot-2](https://user-images.githubusercontent.com/460802/27720738-4cdeec9c-5d96-11e7-9f76-bfc6fd3ed83d.png)
