### PR TITLE
contrib/internal-cluster: use datasource in favor of AMI IDs

### DIFF
--- a/contrib/internal-cluster/vars.tf
+++ b/contrib/internal-cluster/vars.tf
@@ -35,25 +35,6 @@ variable ovpn_password {
   description = "password to use when connecting"
 }
 
-variable ovpn_ami_ids {
-  # For details see: https://docs.openvpn.net/how-to-tutorialsguides/virtual-platforms/amazon-ec2-appliance-ami-quick-start-guide/
-  description = "AMI IDs of the OVPN appliance images per region."
-  type        = "map"
-
-  default = {
-    us-west-1      = "ami-4a02492a"
-    us-west-2      = "ami-d3e743b3"
-    us-east-1      = "ami-bc3566ab"
-    us-east-2      = "ami-10306a75"
-    eu-west-1      = "ami-f53d7386"
-    eu-central-1   = "ami-ad1fe6c2"
-    ap-southeast-1 = "ami-a859ffcb"
-    ap-northeast-1 = "ap-northeast-1"
-    ap-southeast-2 = "ami-89477aea"
-    sa-east-1      = "ami-0c069b60kj"
-  }
-}
-
 output "ovpn_url" {
   value = "https://${aws_eip.ovpn_eip.public_ip}:443"
 }

--- a/contrib/internal-cluster/vpn.tf
+++ b/contrib/internal-cluster/vpn.tf
@@ -1,3 +1,28 @@
+# For details see https://docs.openvpn.net/how-to-tutorialsguides/virtual-platforms/amazon-ec2-appliance-ami-quick-start-guide
+data "aws_ami" "openvpn_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["OpenVPN Access Server*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "owner-id"
+    values = ["573553919781"]
+  }
+}
+
 resource "aws_vpn_gateway" "vpg" {
   vpc_id = "${aws_vpc.vpc.id}"
 
@@ -12,7 +37,7 @@ resource "aws_vpn_gateway" "vpg" {
 resource "aws_instance" "ovpn" {
   # 1st available AZ
   availability_zone      = "${data.aws_availability_zones.available.names[0]}"
-  ami                    = "${lookup(var.ovpn_ami_ids, var.vpc_aws_region)}"
+  ami                    = "${data.aws_ami.openvpn_ami.image_id}"
   instance_type          = "t2.micro"
   subnet_id              = "${aws_subnet.pub_subnet_generic.id}"
   vpc_security_group_ids = ["${aws_security_group.vpn_sg.id}"]


### PR DESCRIPTION
Currently those IDs are hardcoded. When they are being updated, we have
to bump manually.

This fixes it by looking up those AMIs using a datasource.

Fixes #1265
