### PR TITLE
Makefile: support Terraform v0.10.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,4 +127,4 @@ vendor-smoke: $(TOP_DIR)/tests/smoke/glide.yaml
 	@cd $(TOP_DIR)/tests/smoke && glide up -v
 	@cd $(TOP_DIR)/tests/smoke && glide-vc --use-lock-file --no-tests --only-code
 
-.PHONY: make clean terraform terraform-dev structure-check docs examples terraform-get
+.PHONY: make clean terraform terraform-dev structure-check docs examples terraform-get terraform-init

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,12 @@ localconfig:
 	mkdir -p $(BUILD_DIR)
 	cp examples/*$(subst /,-,$(PLATFORM)) $(BUILD_DIR)/terraform.tfvars
 
-terraform-get:
+terraform-init:
+ifneq ($(shell $(TF_CMD) version | grep -E "Terraform v0\.1[0-9]\.[0-9]+"), )
+	cd $(BUILD_DIR) && $(TF_CMD) init $(TF_INIT_OPTIONS) $(TOP_DIR)/platforms/$(PLATFORM)
+endif
+
+terraform-get: terraform-init
 	cd $(BUILD_DIR) && $(TF_CMD) get $(TF_GET_OPTIONS) $(TOP_DIR)/platforms/$(PLATFORM)
 
 plan: installer-env terraform-get


### PR DESCRIPTION
This change adds support for the new `init` command in Terraform 0.10+ which will download the provider modules on demand.

It will only perform the init command if the version of Terraform used is greater then 0.9.x