### PR TITLE
frontend: If Terraform apply fails, stop later step spinners

### DIFF
--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -94,13 +94,13 @@ class TF_PowerOn extends React.Component {
         consoleSubsteps.push(<AWS_DomainValidation key="domain" />);
       }
       consoleSubsteps.push(
-        <WaitingLi done={dnsReady} key="dns">
+        <WaitingLi done={dnsReady} cancel={tfError} key="dns">
           <span title={msg}>{msg}</span>
         </WaitingLi>
       );
       msg = `Starting Tectonic console`;
       consoleSubsteps.push(
-        <WaitingLi done={tectonicConsole.ready} key="consoleReady">
+        <WaitingLi done={tectonicConsole.ready} cancel={tfError} key="consoleReady">
           <span title={msg}>{msg}</span>
         </WaitingLi>
       );

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -597,7 +597,7 @@ export const PrivateKeyArea = (props) => {
   return <FileArea {...areaProps} />;
 };
 
-export const WaitingLi = ({done, error, children, substep}) => {
+export const WaitingLi = ({done, error, cancel, children, substep}) => {
   const progressClasses = classNames({
     'wiz-launch-progress__step': !substep,
     'wiz-launch-progress__substep': substep,
@@ -608,7 +608,8 @@ export const WaitingLi = ({done, error, children, substep}) => {
   const iconClasses = classNames('fa', 'fa-fw', {
     'fa-exclamation-circle': error,
     'fa-check-circle': done && !error,
-    'fa-spin fa-circle-o-notch': !done && !error,
+    'fa-ban': !done && !error && cancel,
+    'fa-spin fa-circle-o-notch': !done && !error && !cancel,
   });
 
   return <li className={progressClasses}>


### PR DESCRIPTION
If the Terraform apply step fails, change the spinner icons for later steps to indicate that they are not expected to progress. However, still allow those steps to indicate success or error (e.g. the "Resolving..." step may still succeed).

Applies to both AWS and Bare Metal.

Fixes #1271

![screenshot-2](https://user-images.githubusercontent.com/460802/27759828-a4515788-5e74-11e7-821b-dba5d7693d40.png)
![screenshot-4](https://user-images.githubusercontent.com/460802/27759829-bbd1750a-5e74-11e7-9dd6-00acb7e544bf.png)