### PR TITLE
Omit console AWS infra for vanilla clusters

### DIFF
--- a/modules/aws/master-asg/elb.tf
+++ b/modules/aws/master-asg/elb.tf
@@ -89,6 +89,7 @@ resource "aws_route53_record" "api-external" {
 }
 
 resource "aws_elb" "console" {
+  count           = "${var.vanilla_k8s ? 0 : 1}"
   name            = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-con"
   subnets         = ["${var.subnet_ids}"]
   internal        = "${var.public_vpc ? false : true}"
@@ -126,7 +127,7 @@ resource "aws_elb" "console" {
 }
 
 resource "aws_route53_record" "ingress-public" {
-  count   = "${var.public_vpc}"
+  count   = "${var.vanilla_k8s ? 0 : var.public_vpc}"
   zone_id = "${var.external_zone_id}"
   name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}.${var.base_domain}"
   type    = "A"
@@ -139,6 +140,7 @@ resource "aws_route53_record" "ingress-public" {
 }
 
 resource "aws_route53_record" "ingress-private" {
+  count   = "${var.vanilla_k8s ? 0 : 1}"
   zone_id = "${var.internal_zone_id}"
   name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}.${var.base_domain}"
   type    = "A"

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -30,7 +30,7 @@ resource "aws_autoscaling_group" "masters" {
   launch_configuration = "${aws_launch_configuration.master_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
-  load_balancers = ["${aws_elb.api-internal.id}", "${join("",aws_elb.api-external.*.id)}", "${aws_elb.console.id}"]
+  load_balancers = ["${aws_elb.api-internal.id}", "${join("",aws_elb.api-external.*.id)}", "${join("",aws_elb.console.*.id)}"]
 
   tags = [
     {

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -105,3 +105,8 @@ variable "master_iam_role" {
   default     = ""
   description = "IAM role to use for the instance profiles of master nodes."
 }
+
+variable "vanilla_k8s" {
+  description = "If true, no infrastructure will be created to access tectonic services on the master nodes."
+  default     = false
+}

--- a/modules/aws/vpc/sg-elb.tf
+++ b/modules/aws/vpc/sg-elb.tf
@@ -24,6 +24,7 @@ resource "aws_security_group" "api" {
 }
 
 resource "aws_security_group" "console" {
+  count  = "${var.vanilla_k8s ? 0 : 1}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
   tags = "${merge(map(

--- a/modules/aws/vpc/sg-master.tf
+++ b/modules/aws/vpc/sg-master.tf
@@ -189,6 +189,7 @@ resource "aws_security_group_rule" "master_ingress_services" {
 }
 
 resource "aws_security_group_rule" "master_ingress_services_from_console" {
+  count                    = "${var.vanilla_k8s ? 0 : 1}"
   type                     = "ingress"
   security_group_id        = "${aws_security_group.master.id}"
   source_security_group_id = "${aws_security_group.console.id}"

--- a/modules/aws/vpc/sg-worker.tf
+++ b/modules/aws/vpc/sg-worker.tf
@@ -169,6 +169,7 @@ resource "aws_security_group_rule" "worker_ingress_services" {
 }
 
 resource "aws_security_group_rule" "worker_ingress_services_from_console" {
+  count                    = "${var.vanilla_k8s ? 0 : 1}"
   type                     = "ingress"
   security_group_id        = "${aws_security_group.worker.id}"
   source_security_group_id = "${aws_security_group.console.id}"

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -56,3 +56,8 @@ variable "master_azs" {
 variable "worker_azs" {
   type = "list"
 }
+
+variable "vanilla_k8s" {
+  description = "If true, no infrastructure will be created to access tectonic services on any nodes."
+  default     = false
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -16,6 +16,7 @@ module "vpc" {
   cluster_id              = "${module.tectonic.cluster_id}"
   extra_tags              = "${var.tectonic_aws_extra_tags}"
   enable_etcd_sg          = "${!var.tectonic_experimental && length(compact(var.tectonic_etcd_servers)) == 0 ? 1 : 0}"
+  vanilla_k8s             = "${var.tectonic_vanilla_k8s}"
 
   # VPC layout settings.
   #
@@ -127,6 +128,7 @@ module "masters" {
   extra_tags                   = "${var.tectonic_aws_extra_tags}"
   autoscaling_group_extra_tags = "${var.tectonic_autoscaling_group_extra_tags}"
   custom_dns_name              = "${var.tectonic_dns_name}"
+  vanilla_k8s                  = "${var.tectonic_vanilla_k8s}"
 
   root_volume_type = "${var.tectonic_aws_master_root_volume_type}"
   root_volume_size = "${var.tectonic_aws_master_root_volume_size}"


### PR DESCRIPTION
When creating a cluster on AWS an ELB, two Route 53 routes and a security group entry is created for the purpose of accessing the Tectonic Console service. This service isn't running on vanilla clusters so the infrastructure doesn't need to exist.