### PR TITLE
frontend: Fix next step tooltip & allow tooltips to apply to multiple elements

### DIFF
--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -77,7 +77,7 @@ const Pager = ({showPrev, showNext, disableNext, loadingNext, navigatePrevious, 
                       className={nextLinkClasses}>
                 {loadingNext &&
                  <span><i className="fa fa-spin fa-circle-o-notch"></i>{' '}</span>}
-                 Next Step
+                Next Step
               </button>
             </WithTooltip>
           </div>

--- a/installer/frontend/components/tooltip.jsx
+++ b/installer/frontend/components/tooltip.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import _ from 'lodash';
-import classnames from 'classnames';
 
 export const Tooltip = ({children}) => <span className="tooltip">{children}</span>;
 
@@ -33,11 +32,16 @@ export const WithTooltip = props => {
   const {children, shouldShow = true, generateText} = props;
   const text = generateText ? generateText(props) : props.text;
   const onlyChild = React.Children.only(children);
-  const nextProps = _.assign({}, _.omit(props, 'children', 'shouldShow', 'generateText', 'text'), onlyChild.props, {className: classnames(onlyChild.props.className, 'withtooltip')});
+  const nextProps = _.assign({}, _.omit(props, 'children', 'shouldShow', 'generateText', 'text'), onlyChild.props);
+  const newChild = React.cloneElement(onlyChild, nextProps);
 
   // If there is no text, then assume the tooltip is already nested.
   const tooltip = typeof text === 'string' && shouldShow && <Tooltip>{text}</Tooltip>;
-  const nestedChildren = nextProps.children ? [].concat(nextProps.children, tooltip) : [tooltip];
 
-  return React.cloneElement(onlyChild, nextProps, ...nestedChildren);
+  // Use a wrapping div so that the tooltip will work even if the child
+  // element's pointer-events property is "none".
+  return <div className="withtooltip" style={{display: 'inline-block'}}>
+    {newChild}
+    {tooltip}
+  </div>;
 };

--- a/installer/frontend/components/tooltip.jsx
+++ b/installer/frontend/components/tooltip.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import _ from 'lodash';
-
 export const Tooltip = ({children}) => <span className="tooltip">{children}</span>;
 
 /**
@@ -31,17 +29,14 @@ export const Tooltip = ({children}) => <span className="tooltip">{children}</spa
 export const WithTooltip = props => {
   const {children, shouldShow = true, generateText} = props;
   const text = generateText ? generateText(props) : props.text;
-  const onlyChild = React.Children.only(children);
-  const nextProps = _.assign({}, _.omit(props, 'children', 'shouldShow', 'generateText', 'text'), onlyChild.props);
-  const newChild = React.cloneElement(onlyChild, nextProps);
 
   // If there is no text, then assume the tooltip is already nested.
   const tooltip = typeof text === 'string' && shouldShow && <Tooltip>{text}</Tooltip>;
 
-  // Use a wrapping div so that the tooltip will work even if the child
-  // element's pointer-events property is "none".
+  // Use a wrapping div so that the tooltip will work even if a child element's
+  // pointer-events property is "none".
   return <div className="withtooltip" style={{display: 'inline-block'}}>
-    {newChild}
+    {children}
     {tooltip}
   </div>;
 };


### PR DESCRIPTION
The "Next Step" button's tooltip was not working because it has the CSS rule `pointer-events: none`. This fixes it by changing `WithTooltip` to use a wrapping `div` instead of modifying its child element.

Also, if we use a wrapping `div`, I think it makes sense to allow `WithTooltip` to have multiple `children`, which simplifies the code.

![screenshot-1](https://user-images.githubusercontent.com/460802/27854313-4f5b9934-61a1-11e7-9bd4-db69a7c64e80.png)
