### PR TITLE
Jenkinsfile: bump smoke test timeout to 60 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'
-                  timeout(60) {
+                  timeout(45) {
                     sh """#!/bin/bash -ex
                     . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
@@ -169,7 +169,7 @@ pipeline {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'
-                  timeout(60) {
+                  timeout(45) {
                     sh """#!/bin/bash -ex
                     . ${WORKSPACE}/tests/smoke/aws/smoke.sh create-vpc
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-vpc.tfvars

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'
-                  timeout(35) {
+                  timeout(60) {
                     sh """#!/bin/bash -ex
                     . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
@@ -169,7 +169,7 @@ pipeline {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'
-                  timeout(45) {
+                  timeout(60) {
                     sh """#!/bin/bash -ex
                     . ${WORKSPACE}/tests/smoke/aws/smoke.sh create-vpc
                     ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-vpc.tfvars


### PR DESCRIPTION
We saw the following flake two times already:
```
+ bin/smoke -test.v -test.parallel=1 --cluster
=== RUN   Test
=== RUN   Test/Common
=== RUN   Test/Common/APIAvailable
=== RUN   Test/Cluster
=== RUN   Test/Cluster/AllNodesRunning
=== RUN   Test/Cluster/GetIdentityLogs
=== RUN   Test/Cluster/AllPodsRunning
Sending interrupt signal to process
After 10s process did not stop
```

https://jenkins-tectonic-installer.prod.coreos.systems/blue/rest/organizations/jenkins/pipelines/tectonic-installer/branches/PR-1247/runs/27/nodes/39/steps/81/log/?start=0
https://jenkins-tectonic-installer.prod.coreos.systems/blue/rest/organizations/jenkins/pipelines/tectonic-installer/branches/PR-1272/runs/2/nodes/39/steps/75/log/?start=0

Currently we have 35/45 minute timeouts in the Jenkinsfile. The Go based
integration tests have a 36 minute timeout, hence we are not accounting
the time to create a cluster at all.

This fixes it by bumping the total timeout to 60 minutes to also account
for cluster creation.

/cc @mxinden