### PR TITLE
Add pluggable DNS modules

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -6,9 +6,9 @@ This document gives an overview of variables used in all platforms of the Tecton
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
-| tectonic_admin_email | The e-mail address used to login as the admin user to the Tectonic Console.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
+| tectonic_admin_email | The e-mail address used to: 1. login as the admin user to the Tectonic Console. 2. generate DNS zones for some providers.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
 | tectonic_admin_password_hash | The bcrypt hash of admin user password to login to the Tectonic Console. Use the bcrypt-hash tool (https://github.com/coreos/bcrypt-tool/releases/tag/v1.0.0) to generate it.<br><br>Note: This field MUST be set manually prior to creating the cluster. | string | - |
-| tectonic_base_domain | The base DNS domain of the cluster.<br><br>Example: `openstack.dev.coreos.systems`.<br><br>Note: This field MUST be set manually prior to creating the cluster. This applies only to cloud platforms. | string | - |
+| tectonic_base_domain | The base DNS domain of the cluster. It must NOT contain a trailing period. Some DNS providers will automatically add this if necessary.<br><br>Example: `openstack.dev.coreos.systems`.<br><br>Note: This field MUST be set manually prior to creating the cluster. This applies only to cloud platforms. | string | - |
 | tectonic_ca_cert | (optional) The content of the PEM-encoded CA certificate, used to generate Tectonic Console's server certificate. If left blank, a CA certificate will be automatically generated. | string | `` |
 | tectonic_ca_key | (optional) The content of the PEM-encoded CA key, used to generate Tectonic Console's server certificate. This field is mandatory if `tectonic_ca_cert` is set. | string | `` |
 | tectonic_ca_key_alg | (optional) The algorithm used to generate tectonic_ca_key. The default value is currently recommend. This field is mandatory if `tectonic_ca_cert` is set. | string | `RSA` |

--- a/config.tf
+++ b/config.tf
@@ -189,7 +189,8 @@ variable "tectonic_base_domain" {
   type = "string"
 
   description = <<EOF
-The base DNS domain of the cluster.
+The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+DNS providers will automatically add this if necessary.
 
 Example: `openstack.dev.coreos.systems`.
 
@@ -265,7 +266,9 @@ variable "tectonic_admin_email" {
   type = "string"
 
   description = <<EOF
-The e-mail address used to login as the admin user to the Tectonic Console.
+The e-mail address used to:
+1. login as the admin user to the Tectonic Console.
+2. generate DNS zones for some providers.
 
 Note: This field MUST be set manually prior to creating the cluster.
 EOF

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -1,5 +1,7 @@
 
-// The e-mail address used to login as the admin user to the Tectonic Console.
+// The e-mail address used to:
+// 1. login as the admin user to the Tectonic Console.
+// 2. generate DNS zones for some providers.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_email = ""
@@ -136,7 +138,8 @@ tectonic_aws_worker_root_volume_size = "30"
 // The type of volume for the root block device of worker nodes.
 tectonic_aws_worker_root_volume_type = "gp2"
 
-// The base DNS domain of the cluster.
+// The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+// DNS providers will automatically add this if necessary.
 // 
 // Example: `openstack.dev.coreos.systems`.
 // 

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -1,5 +1,7 @@
 
-// The e-mail address used to login as the admin user to the Tectonic Console.
+// The e-mail address used to:
+// 1. login as the admin user to the Tectonic Console.
+// 2. generate DNS zones for some providers.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_email = ""
@@ -131,7 +133,8 @@ tectonic_azure_ssh_key = ""
 // (optional) Instance size for the worker node(s). Example: Standard_DS2_v2.
 // tectonic_azure_worker_vm_size = "Standard_DS2_v2"
 
-// The base DNS domain of the cluster.
+// The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+// DNS providers will automatically add this if necessary.
 // 
 // Example: `openstack.dev.coreos.systems`.
 // 

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -1,5 +1,7 @@
 
-// The e-mail address used to login as the admin user to the Tectonic Console.
+// The e-mail address used to:
+// 1. login as the admin user to the Tectonic Console.
+// 2. generate DNS zones for some providers.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_email = ""
@@ -10,7 +12,8 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
-// The base DNS domain of the cluster.
+// The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+// DNS providers will automatically add this if necessary.
 // 
 // Example: `openstack.dev.coreos.systems`.
 // 

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -1,5 +1,7 @@
 
-// The e-mail address used to login as the admin user to the Tectonic Console.
+// The e-mail address used to:
+// 1. login as the admin user to the Tectonic Console.
+// 2. generate DNS zones for some providers.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_email = ""
@@ -10,7 +12,8 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
-// The base DNS domain of the cluster.
+// The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+// DNS providers will automatically add this if necessary.
 // 
 // Example: `openstack.dev.coreos.systems`.
 // 

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -1,5 +1,7 @@
 
-// The e-mail address used to login as the admin user to the Tectonic Console.
+// The e-mail address used to:
+// 1. login as the admin user to the Tectonic Console.
+// 2. generate DNS zones for some providers.
 // 
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_email = ""
@@ -10,7 +12,8 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
-// The base DNS domain of the cluster.
+// The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+// DNS providers will automatically add this if necessary.
 // 
 // Example: `openstack.dev.coreos.systems`.
 // 

--- a/modules/dns/designate/etcd.tf
+++ b/modules/dns/designate/etcd.tf
@@ -1,26 +1,26 @@
+resource "openstack_dns_recordset_v2" "etc_a_nodes" {
+  count   = "${var.etcd_count}"
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  name    = "${var.cluster_name}-etcd-${count.index}.${var.base_domain}."
+  records = ["${var.etcd_ips[count.index]}"]
+}
+
 resource "openstack_dns_recordset_v2" "etcd_srv_discover" {
-  count   = "${var.designate_dns_enabled ? 1 : 0}"
-  name    = "${var.etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}"
+  count   = "1"
+  name    = "${var.etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}.${var.base_domain}."
   type    = "SRV"
   zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  records = ["${formatlist("0 0 2380 %s", openstack_dns_recordset_v2.etc_a_nodes.*.fqdn)}"]
+  records = ["${formatlist("0 0 2380 %s", openstack_dns_recordset_v2.etc_a_nodes.*.name)}"]
   ttl     = "300"
 }
 
 resource "openstack_dns_recordset_v2" "etcd_srv_client" {
-  count   = "${var.designate_dns_enabled ? 1 : 0}"
-  name    = "${var.etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}"
+  count   = "1"
+  name    = "${var.etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}.${var.base_domain}."
   type    = "SRV"
   zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  records = ["${formatlist("0 0 2379 %s", openstack_dns_recordset_v2.etc_a_nodes.*.fqdn)}"]
+  records = ["${formatlist("0 0 2379 %s", openstack_dns_recordset_v2.etc_a_nodes.*.name)}"]
   ttl     = "60"
-}
-
-resource "openstack_dns_recordset_v2" "etc_a_nodes" {
-  count   = "${var.designate_dns_enabled ? var.etcd_count : 0}"
-  type    = "A"
-  ttl     = "60"
-  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  name    = "${var.cluster_name}-etcd-${count.index}"
-  records = ["${var.etcd_ips[count.index]}"]
 }

--- a/modules/dns/designate/etcd.tf
+++ b/modules/dns/designate/etcd.tf
@@ -1,0 +1,26 @@
+resource "openstack_dns_recordset_v2" "etcd_srv_discover" {
+  count   = "${var.designate_dns_enabled ? 1 : 0}"
+  name    = "${var.etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}"
+  type    = "SRV"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  records = ["${formatlist("0 0 2380 %s", openstack_dns_recordset_v2.etc_a_nodes.*.fqdn)}"]
+  ttl     = "300"
+}
+
+resource "openstack_dns_recordset_v2" "etcd_srv_client" {
+  count   = "${var.designate_dns_enabled ? 1 : 0}"
+  name    = "${var.etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}"
+  type    = "SRV"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  records = ["${formatlist("0 0 2379 %s", openstack_dns_recordset_v2.etc_a_nodes.*.fqdn)}"]
+  ttl     = "60"
+}
+
+resource "openstack_dns_recordset_v2" "etc_a_nodes" {
+  count   = "${var.designate_dns_enabled ? var.etcd_count : 0}"
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  name    = "${var.cluster_name}-etcd-${count.index}"
+  records = ["${var.etcd_ips[count.index]}"]
+}

--- a/modules/dns/designate/master.tf
+++ b/modules/dns/designate/master.tf
@@ -1,0 +1,8 @@
+resource "openstack_dns_recordset_v2" "master_nodes" {
+  count   = "${var.designate_dns_enabled ? var.master_count : 0 }"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  name    = "${var.cluster_name}-master-${count.index}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.master_ips[count.index]}"]
+}

--- a/modules/dns/designate/master.tf
+++ b/modules/dns/designate/master.tf
@@ -1,7 +1,7 @@
 resource "openstack_dns_recordset_v2" "master_nodes" {
-  count   = "${var.designate_dns_enabled ? var.master_count : 0 }"
+  count   = "${var.master_count}"
   zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  name    = "${var.cluster_name}-master-${count.index}"
+  name    = "${var.cluster_name}-master-${count.index}.${var.base_domain}."
   type    = "A"
   ttl     = "60"
   records = ["${var.master_ips[count.index]}"]

--- a/modules/dns/designate/outputs.tf
+++ b/modules/dns/designate/outputs.tf
@@ -1,3 +1,3 @@
 output "etc_a_nodes" {
-  value="${openstack_dns_recordset_v2.etc_a_nodes.*.fqdn}"
+  value = "${openstack_dns_recordset_v2.etc_a_nodes.*.name}"
 }

--- a/modules/dns/designate/outputs.tf
+++ b/modules/dns/designate/outputs.tf
@@ -1,0 +1,3 @@
+output "etc_a_nodes" {
+  value="${openstack_dns_recordset_v2.etc_a_nodes.*.fqdn}"
+}

--- a/modules/dns/designate/tectonic.tf
+++ b/modules/dns/designate/tectonic.tf
@@ -1,0 +1,22 @@
+resource "openstack_dns_zone_v2" "tectonic" {
+  count = "${var.designate_dns_enabled ? 1 : 0}"
+  name  = "${var.base_domain}"
+}
+
+resource "openstack_dns_recordset_v2" "tectonic-api" {
+  count   = "${var.designate_dns_enabled ? 1 : 0}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  name    = "${var.cluster_name}-k8s"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.master_ips}"]
+}
+
+resource "openstack_dns_recordset_v2" "tectonic-console" {
+  count   = "${var.designate_dns_enabled ? 1 : 0}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  name    = "${var.cluster_name}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.worker_ips}"]
+}

--- a/modules/dns/designate/tectonic.tf
+++ b/modules/dns/designate/tectonic.tf
@@ -1,21 +1,23 @@
 resource "openstack_dns_zone_v2" "tectonic" {
-  count = "${var.designate_dns_enabled ? 1 : 0}"
-  name  = "${var.base_domain}"
+  count = "1"
+  name  = "${var.base_domain}."
+  email = "${var.admin_email}"
+  ttl   = "60"
 }
 
 resource "openstack_dns_recordset_v2" "tectonic-api" {
-  count   = "${var.designate_dns_enabled ? 1 : 0}"
+  count   = "1"
   zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  name    = "${var.cluster_name}-k8s"
+  name    = "${var.cluster_name}-k8s.${var.base_domain}."
   type    = "A"
   ttl     = "60"
   records = ["${var.master_ips}"]
 }
 
 resource "openstack_dns_recordset_v2" "tectonic-console" {
-  count   = "${var.designate_dns_enabled ? 1 : 0}"
+  count   = "1"
   zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  name    = "${var.cluster_name}"
+  name    = "${var.cluster_name}.${var.base_domain}."
   type    = "A"
   ttl     = "60"
   records = ["${var.worker_ips}"]

--- a/modules/dns/designate/variables.tf
+++ b/modules/dns/designate/variables.tf
@@ -1,0 +1,50 @@
+variable "designate_dns_enabled" {
+  description = "Indicates whether Designate should be used"
+  type        = "string"
+}
+
+variable "etcd_tls_enabled" {
+  description = "Indicates whether TLS is used for etcd"
+  type        = "string"
+  default     = "1"
+}
+
+variable "cluster_name" {
+  description = "The name of the cluster"
+  type        = "string"
+}
+
+variable "base_domain" {
+  description = "The base domain used in records"
+  type        = "string"
+}
+
+variable "master_count" {
+  description = "The number of masters"
+  type        = "string"
+}
+
+variable "worker_count" {
+  description = "The number of workers"
+  type        = "string"
+}
+
+variable "etcd_count" {
+  description = "The number of etcd nodes"
+  type        = "string"
+}
+
+variable "etcd_ips" {
+  description = "List of string IPs for etcd nodes"
+  type        = "list"
+}
+
+variable "master_ips" {
+  description = "List of string IPs for masters"
+  type        = "list"
+}
+
+variable "worker_ips" {
+  description = "List of string IPs for workers"
+  type        = "list"
+}

--- a/modules/dns/designate/variables.tf
+++ b/modules/dns/designate/variables.tf
@@ -1,8 +1,3 @@
-variable "designate_dns_enabled" {
-  description = "Indicates whether Designate should be used"
-  type        = "string"
-}
-
 variable "etcd_tls_enabled" {
   description = "Indicates whether TLS is used for etcd"
   type        = "string"

--- a/modules/dns/designate/worker.tf
+++ b/modules/dns/designate/worker.tf
@@ -1,0 +1,8 @@
+resource "openstack_dns_recordset_v2" "worker_nodes" {
+  count   = "${var.designate_dns_enabled ? var.worker_count : 0}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
+  name    = "${var.cluster_name}-worker-${count.index}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.worker_ips[count.index]}"]
+}

--- a/modules/dns/designate/worker.tf
+++ b/modules/dns/designate/worker.tf
@@ -1,7 +1,7 @@
 resource "openstack_dns_recordset_v2" "worker_nodes" {
-  count   = "${var.designate_dns_enabled ? var.worker_count : 0}"
+  count   = "${var.worker_count}"
   zone_id = "${openstack_dns_zone_v2.tectonic.id}"
-  name    = "${var.cluster_name}-worker-${count.index}"
+  name    = "${var.cluster_name}-worker-${count.index}.${var.base_domain}."
   type    = "A"
   ttl     = "60"
   records = ["${var.worker_ips[count.index]}"]

--- a/modules/dns/route53/etcd.tf
+++ b/modules/dns/route53/etcd.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "etcd_srv_discover" {
-  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  count   = "1"
   name    = "${var.etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}"
   type    = "SRV"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"
@@ -8,7 +8,7 @@ resource "aws_route53_record" "etcd_srv_discover" {
 }
 
 resource "aws_route53_record" "etcd_srv_client" {
-  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  count   = "1"
   name    = "${var.etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}"
   type    = "SRV"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"
@@ -17,7 +17,7 @@ resource "aws_route53_record" "etcd_srv_client" {
 }
 
 resource "aws_route53_record" "etc_a_nodes" {
-  count   = "${var.route53_dns_enabled ? var.etcd_count : 0}"
+  count   = "${var.etcd_count}"
   type    = "A"
   ttl     = "60"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"

--- a/modules/dns/route53/etcd.tf
+++ b/modules/dns/route53/etcd.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_record" "etcd_srv_discover" {
+  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  name    = "${var.etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}"
+  type    = "SRV"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  records = ["${formatlist("0 0 2380 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
+  ttl     = "300"
+}
+
+resource "aws_route53_record" "etcd_srv_client" {
+  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  name    = "${var.etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}"
+  type    = "SRV"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  records = ["${formatlist("0 0 2379 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
+  ttl     = "60"
+}
+
+resource "aws_route53_record" "etc_a_nodes" {
+  count   = "${var.route53_dns_enabled ? var.etcd_count : 0}"
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  name    = "${var.cluster_name}-etcd-${count.index}"
+  records = ["${var.etcd_ips[count.index]}"]
+}

--- a/modules/dns/route53/master.tf
+++ b/modules/dns/route53/master.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_record" "master_nodes" {
+  count   = "${var.route53_dns_enabled ? var.master_count : 0 }"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  name    = "${var.cluster_name}-master-${count.index}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.master_ips[count.index]}"]
+}

--- a/modules/dns/route53/master.tf
+++ b/modules/dns/route53/master.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "master_nodes" {
-  count   = "${var.route53_dns_enabled ? var.master_count : 0 }"
+  count   = "${var.master_count}"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"
   name    = "${var.cluster_name}-master-${count.index}"
   type    = "A"

--- a/modules/dns/route53/outputs.tf
+++ b/modules/dns/route53/outputs.tf
@@ -1,3 +1,3 @@
 output "etc_a_nodes" {
-  value="${aws_route53_record.etc_a_nodes.*.fqdn}"
+  value = "${aws_route53_record.etc_a_nodes.*.fqdn}"
 }

--- a/modules/dns/route53/outputs.tf
+++ b/modules/dns/route53/outputs.tf
@@ -1,0 +1,3 @@
+output "etc_a_nodes" {
+  value="${aws_route53_record.etc_a_nodes.*.fqdn}"
+}

--- a/modules/dns/route53/tectonic.tf
+++ b/modules/dns/route53/tectonic.tf
@@ -1,10 +1,10 @@
 resource "aws_route53_zone" "tectonic" {
-  count = "${var.route53_dns_enabled ? 1 : 0}"
+  count = "1"
   name  = "${var.base_domain}"
 }
 
 resource "aws_route53_record" "tectonic-api" {
-  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  count   = "1"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"
   name    = "${var.cluster_name}-k8s"
   type    = "A"
@@ -13,7 +13,7 @@ resource "aws_route53_record" "tectonic-api" {
 }
 
 resource "aws_route53_record" "tectonic-console" {
-  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  count   = "1"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"
   name    = "${var.cluster_name}"
   type    = "A"

--- a/modules/dns/route53/tectonic.tf
+++ b/modules/dns/route53/tectonic.tf
@@ -1,0 +1,22 @@
+resource "aws_route53_zone" "tectonic" {
+  count = "${var.route53_dns_enabled ? 1 : 0}"
+  name  = "${var.base_domain}"
+}
+
+resource "aws_route53_record" "tectonic-api" {
+  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  name    = "${var.cluster_name}-k8s"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.master_ips}"]
+}
+
+resource "aws_route53_record" "tectonic-console" {
+  count   = "${var.route53_dns_enabled ? 1 : 0}"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  name    = "${var.cluster_name}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.worker_ips}"]
+}

--- a/modules/dns/route53/variables.tf
+++ b/modules/dns/route53/variables.tf
@@ -1,0 +1,50 @@
+variable "route53_dns_enabled" {
+  description = "Indicates whether Route53 should be used"
+  type        = "string"
+}
+
+variable "etcd_tls_enabled" {
+  description = "Indicates whether TLS is used for etcd"
+  type        = "string"
+  default     = "1"
+}
+
+variable "cluster_name" {
+  description = "The name of the cluster"
+  type        = "string"
+}
+
+variable "base_domain" {
+  description = "The base domain used in records"
+  type        = "string"
+}
+
+variable "master_count" {
+  description = "The number of masters"
+  type        = "string"
+}
+
+variable "worker_count" {
+  description = "The number of workers"
+  type        = "string"
+}
+
+variable "etcd_count" {
+  description = "The number of etcd nodes"
+  type        = "string"
+}
+
+variable "etcd_ips" {
+  description = "List of string IPs for etcd nodes"
+  type        = "list"
+}
+
+variable "master_ips" {
+  description = "List of string IPs for masters"
+  type        = "list"
+}
+
+variable "worker_ips" {
+  description = "List of string IPs for workers"
+  type        = "list"
+}

--- a/modules/dns/route53/variables.tf
+++ b/modules/dns/route53/variables.tf
@@ -1,8 +1,3 @@
-variable "route53_dns_enabled" {
-  description = "Indicates whether Route53 should be used"
-  type        = "string"
-}
-
 variable "etcd_tls_enabled" {
   description = "Indicates whether TLS is used for etcd"
   type        = "string"

--- a/modules/dns/route53/worker.tf
+++ b/modules/dns/route53/worker.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "worker_nodes" {
-  count   = "${var.route53_dns_enabled ? var.worker_count : 0}"
+  count   = "${var.worker_count}"
   zone_id = "${aws_route53_zone.tectonic.zone_id}"
   name    = "${var.cluster_name}-worker-${count.index}"
   type    = "A"

--- a/modules/dns/route53/worker.tf
+++ b/modules/dns/route53/worker.tf
@@ -1,0 +1,8 @@
+resource "aws_route53_record" "worker_nodes" {
+  count   = "${var.route53_dns_enabled ? var.worker_count : 0}"
+  zone_id = "${aws_route53_zone.tectonic.zone_id}"
+  name    = "${var.cluster_name}-worker-${count.index}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${var.worker_ips[count.index]}"]
+}

--- a/platforms/openstack/neutron/dns.tf
+++ b/platforms/openstack/neutron/dns.tf
@@ -1,35 +1,17 @@
-module "route53" {
-  source         = "../../../modules/dns/route53"
-
-  route53_dns_enabled = "${var.tectonic_route53_dns_enabled}"
-  cluster_name = "${var.tectonic_cluster_name}"
-  base_domain = "${var.tectonic_base_domain}"
-
-  master_count = "${var.tectonic_master_count}"
-  master_ips = "${openstack_networking_floatingip_v2.master.*.address}"
-
-  worker_count = "${var.tectonic_worker_count}"
-  worker_ips = "${openstack_networking_floatingip_v2.worker.*.address}"
-
-  etcd_count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
-  etcd_ips = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
-  etcd_tls_enabled = "${var.tectonic_etcd_tls_enabled}"
-}
-
 module "designate" {
-  source         = "../../../modules/dns/designate"
+  source = "../../../modules/dns/designate"
 
-  designate_dns_enabled = "${var.tectonic_designate_dns_enabled}"
   cluster_name = "${var.tectonic_cluster_name}"
-  base_domain = "${var.tectonic_base_domain}"
+  base_domain  = "${var.tectonic_base_domain}"
+  admin_email  = "${var.tectonic_admin_email}"
 
   master_count = "${var.tectonic_master_count}"
-  master_ips = "${openstack_networking_floatingip_v2.master.*.address}"
+  master_ips   = "${openstack_networking_floatingip_v2.master.*.address}"
 
   worker_count = "${var.tectonic_worker_count}"
-  worker_ips = "${openstack_networking_floatingip_v2.worker.*.address}"
+  worker_ips   = "${openstack_networking_floatingip_v2.worker.*.address}"
 
-  etcd_count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
-  etcd_ips = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
+  etcd_count       = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
+  etcd_ips         = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
   etcd_tls_enabled = "${var.tectonic_etcd_tls_enabled}"
 }

--- a/platforms/openstack/neutron/dns.tf
+++ b/platforms/openstack/neutron/dns.tf
@@ -1,73 +1,35 @@
-# tectonic
+module "route53" {
+  source         = "../../../modules/dns/route53"
 
-data "aws_route53_zone" "tectonic" {
-  name = "${var.tectonic_base_domain}"
+  route53_dns_enabled = "${var.tectonic_route53_dns_enabled}"
+  cluster_name = "${var.tectonic_cluster_name}"
+  base_domain = "${var.tectonic_base_domain}"
+
+  master_count = "${var.tectonic_master_count}"
+  master_ips = "${openstack_networking_floatingip_v2.master.*.address}"
+
+  worker_count = "${var.tectonic_worker_count}"
+  worker_ips = "${openstack_networking_floatingip_v2.worker.*.address}"
+
+  etcd_count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
+  etcd_ips = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
+  etcd_tls_enabled = "${var.tectonic_etcd_tls_enabled}"
 }
 
-resource "aws_route53_record" "tectonic-api" {
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.tectonic_cluster_name}-k8s"
-  type    = "A"
-  ttl     = "60"
-  records = ["${openstack_networking_floatingip_v2.master.*.address}"]
-}
+module "designate" {
+  source         = "../../../modules/dns/designate"
 
-resource "aws_route53_record" "tectonic-console" {
-  count   = "${var.tectonic_vanilla_k8s ? 0 : 1}"
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.tectonic_cluster_name}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${openstack_networking_floatingip_v2.worker.*.address}"]
-}
+  designate_dns_enabled = "${var.tectonic_designate_dns_enabled}"
+  cluster_name = "${var.tectonic_cluster_name}"
+  base_domain = "${var.tectonic_base_domain}"
 
-# master/worker
+  master_count = "${var.tectonic_master_count}"
+  master_ips = "${openstack_networking_floatingip_v2.master.*.address}"
 
-resource "aws_route53_record" "master_nodes" {
-  count   = "${var.tectonic_master_count}"
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.tectonic_cluster_name}-master-${count.index}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${openstack_networking_port_v2.master.*.all_fixed_ips[count.index]}"]
-}
+  worker_count = "${var.tectonic_worker_count}"
+  worker_ips = "${openstack_networking_floatingip_v2.worker.*.address}"
 
-resource "aws_route53_record" "worker_nodes" {
-  count   = "${var.tectonic_worker_count}"
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.tectonic_cluster_name}-worker-${count.index}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${openstack_networking_port_v2.worker.*.all_fixed_ips[count.index]}"]
-}
-
-# etcd
-
-resource "aws_route53_record" "etcd_srv_discover" {
-  count = "${var.tectonic_experimental ? 0 : 1}"
-
-  name    = "${var.tectonic_etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}"
-  type    = "SRV"
-  records = ["${formatlist("0 0 2380 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
-  ttl     = "300"
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-}
-
-resource "aws_route53_record" "etcd_srv_client" {
-  count = "${var.tectonic_experimental ? 0 : 1}"
-
-  name    = "${var.tectonic_etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}"
-  type    = "SRV"
-  records = ["${formatlist("0 0 2379 %s", aws_route53_record.etc_a_nodes.*.fqdn)}"]
-  ttl     = "60"
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-}
-
-resource "aws_route53_record" "etc_a_nodes" {
-  count   = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
-  type    = "A"
-  ttl     = "60"
-  name    = "${var.tectonic_cluster_name}-etcd-${count.index}"
-  records = ["${openstack_networking_port_v2.etcd.*.all_fixed_ips[count.index]}"]
-  zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
+  etcd_count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count}"
+  etcd_ips = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
+  etcd_tls_enabled = "${var.tectonic_etcd_tls_enabled}"
 }

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -23,7 +23,8 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_endpoints   = ["${aws_route53_record.etc_a_nodes.*.fqdn}"]
+  # hack. see https://github.com/hashicorp/terraform/issues/12453
+  etcd_endpoints   = ["${split(",", var.tectonic_route53_dns_enabled ? join(",", module.route53.etc_a_nodes) : join(",", module.designate.etc_a_nodes))}"]
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -23,8 +23,7 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  # hack. see https://github.com/hashicorp/terraform/issues/12453
-  etcd_endpoints   = ["${split(",", var.tectonic_route53_dns_enabled ? join(",", module.route53.etc_a_nodes) : join(",", module.designate.etc_a_nodes))}"]
+  etcd_endpoints   = "${openstack_networking_port_v2.etcd.*.all_fixed_ips}"
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"

--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -122,8 +122,6 @@ resource "null_resource" "tectonic" {
     "openstack_compute_instance_v2.master_node",
     "openstack_networking_port_v2.master",
     "openstack_networking_floatingip_v2.master",
-    "aws_route53_record.worker_nodes",
-    "aws_route53_record.master_nodes",
   ]
 
   connection {

--- a/platforms/openstack/neutron/variables.tf
+++ b/platforms/openstack/neutron/variables.tf
@@ -134,19 +134,3 @@ variable "tectonic_openstack_dns_nameservers" {
 The DNS servers assigned to the generated OpenStack subnet resource.
 EOF
 }
-
-variable "tectonic_route53_dns_enabled" {
-  default = false
-
-  description = <<EOF
-Whether to use AWS Route53 as a DNS provider. You can only use one DNS provider.
-EOF
-}
-
-variable "tectonic_designate_dns_enabled" {
-  default = true
-
-  description = <<EOF
-Whether to use OpenStack Designate as a DNS provider. You can only use one DNS provider.
-EOF
-}

--- a/platforms/openstack/neutron/variables.tf
+++ b/platforms/openstack/neutron/variables.tf
@@ -134,3 +134,19 @@ variable "tectonic_openstack_dns_nameservers" {
 The DNS servers assigned to the generated OpenStack subnet resource.
 EOF
 }
+
+variable "tectonic_route53_dns_enabled" {
+  default = false
+
+  description = <<EOF
+Whether to use AWS Route53 as a DNS provider. You can only use one DNS provider.
+EOF
+}
+
+variable "tectonic_designate_dns_enabled" {
+  default = true
+
+  description = <<EOF
+Whether to use OpenStack Designate as a DNS provider. You can only use one DNS provider.
+EOF
+}


### PR DESCRIPTION
Fixes #9. This PR does a few things:

- Makes DNS pluggable by introducing `designate` and `route53` drivers
- Refactors openstack/neutron to use module for DNS

This still needs to be tested; we're still in the process of setting up an testing cluster with Designate installed.