### PR TITLE
Bump hyperkube to v1.6.7_coreos.0

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -16,7 +16,7 @@ variable "tectonic_container_images" {
   type        = "map"
 
   default = {
-    hyperkube                       = "quay.io/coreos/hyperkube:v1.6.6_coreos.1"
+    hyperkube                       = "quay.io/coreos/hyperkube:v1.6.7_coreos.0"
     pod_checkpointer                = "quay.io/coreos/pod-checkpointer:4e7a7dab10bc4d895b66c21656291c6e0b017248"
     bootkube                        = "quay.io/coreos/bootkube:v0.4.5"
     console                         = "quay.io/coreos/tectonic-console:v1.7.3"


### PR DESCRIPTION
This is a cherry-pick of https://github.com/coreos/tectonic-installer/pull/1299 into the 1.6.7 release branch.