### PR TITLE
AWS Volume tags

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -50,4 +50,10 @@ resource "aws_instance" "etcd_node" {
     volume_size = "${var.root_volume_size}"
     iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
   }
+
+  volume_tags = "${merge(map(
+    "Name", "${var.cluster_name}-etcd-${count.index}-vol",
+    "kubernetes.io/cluster/${var.cluster_name}", "owned",
+    "tectonicClusterID", "${var.cluster_id}"
+  ), var.extra_tags)}"
 }

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -85,8 +85,8 @@ resource "aws_launch_configuration" "master_conf" {
 resource "aws_iam_instance_profile" "master_profile" {
   name = "${var.cluster_name}-master-profile"
 
-  role = "${var.master_iam_role == "" ? 
-    join("|", aws_iam_role.master_role.*.name) : 
+  role = "${var.master_iam_role == "" ?
+    join("|", aws_iam_role.master_role.*.name) :
     join("|", data.aws_iam_role.master_role.*.role_name)
   }"
 }

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -82,8 +82,8 @@ resource "aws_autoscaling_group" "workers" {
 resource "aws_iam_instance_profile" "worker_profile" {
   name = "${var.cluster_name}-worker-profile"
 
-  role = "${var.worker_iam_role == "" ? 
-    join("|", aws_iam_role.worker_role.*.name) : 
+  role = "${var.worker_iam_role == "" ?
+    join("|", aws_iam_role.worker_role.*.name) :
     join("|", data.aws_iam_role.worker_role.*.role_name)
   }"
 }


### PR DESCRIPTION
modules/aws/: add tags to root volumes of instances

All volumes should get the same tags as all other resources.
**Note:** launch configuration volume declarations do not support tagging according to https://github.com/hashicorp/terraform/issues/14558

Applies to #1115 