### PR TITLE
Cherry pick Bump kvo to v1.6.7.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -22,7 +22,7 @@ variable "tectonic_container_images" {
     console                         = "quay.io/coreos/tectonic-console:v1.7.4"
     identity                        = "quay.io/coreos/dex:v2.4.1"
     container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.1"
-    kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.6.6"
+    kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.6.7"
     tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.3.6"
     node_agent                      = "quay.io/coreos/node-agent:787844277099e8c10d617c3c807244fc9f873e46"
     prometheus_operator             = "quay.io/coreos/prometheus-operator:v0.10.2"
@@ -59,12 +59,12 @@ variable "tectonic_versions" {
   type        = "map"
 
   default = {
-    etcd         = "3.1.8"
-    prometheus   = "v1.7.1"
-    alertmanager = "v0.7.1"
-    monitoring   = "1.3.0"
-    kubernetes   = "1.6.6+tectonic.1"
-    tectonic     = "1.6.6-tectonic.1"
+    etcd          = "3.1.8"
+    prometheus    = "v1.7.1"
+    alertmanager  = "v0.7.1"
+    monitoring    = "1.3.0"
+    kubernetes    = "1.6.7+tectonic.1"
+    tectonic      = "1.6.7-tectonic.1"
   }
 }
 

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.6-tectonic.1",
+  "version": "1.6.7-tectonic.1",
   "deployments": [
     {
       "apiVersion": "extensions/v1beta1",
@@ -83,7 +83,7 @@
                   "--cache-images=true",
                   "--version-mapping=/upgrade-spec.json"
                 ],
-                "image": "quay.io/coreos/kube-version-operator:v1.6.6",
+                "image": "quay.io/coreos/kube-version-operator:v1.6.7",
                 "name": "kube-version-operator"
               }
             ],
@@ -305,7 +305,7 @@
   "desiredVersions": [
     {
       "name": "kubernetes",
-      "version": "1.6.6+tectonic.1"
+      "version": "1.6.7+tectonic.1"
     },
     {
       "name": "tectonic-etcd",


### PR DESCRIPTION
Cherry pick
#1309 config.tf/payload.json: Bump kvo to v1.6.7. 