### PR TITLE
Apply 'extra tags' to autoscaling groups

### DIFF
--- a/installer/frontend/__tests__/examples/aws-vpc.json
+++ b/installer/frontend/__tests__/examples/aws-vpc.json
@@ -31,6 +31,13 @@
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },
+    "tectonic_autoscaling_group_extra_tags": [
+      {
+        "key": "test_tag",
+        "value": "testing",
+        "propagate_at_launch": true
+      }
+    ],
     "tectonic_aws_master_ec2_type": "t2.large",
     "tectonic_aws_master_root_volume_size": 33,
     "tectonic_aws_master_root_volume_type": "gp2",

--- a/installer/frontend/__tests__/examples/aws.json
+++ b/installer/frontend/__tests__/examples/aws.json
@@ -14,6 +14,13 @@
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },
+    "tectonic_autoscaling_group_extra_tags": [
+      {
+        "key": "test_tag",
+        "value": "testing",
+        "propagate_at_launch": true
+      }
+    ],
     "tectonic_aws_master_custom_subnets": {
       "us-west-1a": "10.0.0.0/19",
       "us-west-1c": "10.0.32.0/19"

--- a/installer/frontend/__tests__/examples/tectonic-aws-vpc.progress
+++ b/installer/frontend/__tests__/examples/tectonic-aws-vpc.progress
@@ -1,7 +1,7 @@
 {
   "clusterConfig": {
     "platformType": "aws-tf",
-    "aws_ssh": "some-ssh-key", 
+    "aws_ssh": "some-ssh-key",
     "aws_etcds-numberOfInstances": 3,
     "aws_etcds-instanceType": "t2.large",
     "aws_etcds-storageSizeInGiB": 300,
@@ -28,7 +28,7 @@
     "extra": {
         "awsHostedZoneId": {
             "zoneToName": {
-                "asfd": "example.com"    
+                "asfd": "example.com"
             }
         }
     },

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -217,9 +217,11 @@ export const toAWS_TF = (cc, FORMS, opts={}) => {
   }
 
   const extraTags = {};
+  const extraAutoScalingTags = [];
   _.each(cc[AWS_TAGS], ({key, value}) => {
     if(key && value) {
       extraTags[key] = value;
+      extraAutoScalingTags.push({key, value, propagate_at_launch: true});
     }
   });
 
@@ -272,6 +274,10 @@ export const toAWS_TF = (cc, FORMS, opts={}) => {
 
   if (_.size(extraTags) > 0) {
     ret.variables.tectonic_aws_extra_tags = extraTags;
+  }
+
+  if (_.size(extraAutoScalingTags) > 0) {
+    ret.variables.tectonic_autoscaling_group_extra_tags = extraAutoScalingTags;
   }
 
   if (cc[STS_ENABLED]) {


### PR DESCRIPTION
installer/frontend/: 'tectonic_autoscaling_group_extra_tags' will be populated by data from user-provided tags.

User-defined 'extra' tags are not being applied to autoscaling groups because tag data doesn't populate `tectonic_autoscaling_group_extra_tags`.

Applies to #1115 