### PR TITLE
aws: remove worker access from etcd nodes

### DIFF
--- a/modules/aws/vpc/sg-etcd.tf
+++ b/modules/aws/vpc/sg-etcd.tf
@@ -38,10 +38,7 @@ resource "aws_security_group" "etcd" {
     to_port   = 2379
     self      = true
 
-    security_groups = [
-      "${aws_security_group.master.id}",
-      "${aws_security_group.worker.id}",
-    ]
+    security_groups = ["${aws_security_group.master.id}"]
   }
 
   ingress {


### PR DESCRIPTION
Worker nodes should not have direct access to etcd, and should
only be accessing the api services on the master nodes. This
change removes the worker security group from etcd access.