### PR TITLE
docs: print platform lines explictly

### DIFF
--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -23,13 +23,19 @@ cd tectonic
 
 Run the Tectonic Installer for your platform:
 
-```bash
-# macOS users
-$ ./tectonic-installer/darwin/installer
+For macOS users:
 
-# Linux users
+```bash
+$ ./tectonic-installer/darwin/installer
+```
+
+For Linux users:
+
+```
 $ ./tectonic-installer/linux/installer
 ```
+
+For Windows users, [see this guide][install-windows].
 
 A browser window will open to begin the GUI installation process.
 
@@ -75,3 +81,4 @@ For those new to Tectonic and Kubernetes, the [Tectonic Tutorials][tutorials] pr
 [latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.6.4-tectonic.1.tar.gz
 [install-aws-troubleshooting]: ../../troubleshooting/faq.md
 [tf-state]: https://www.terraform.io/docs/state/
+[install-windows]: ../installer-windows.md

--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -21,13 +21,15 @@ tar xzvf tectonic-1.6.4-tectonic.1.tar.gz
 cd tectonic
 ```
 
-Run the Tectonic Installer.
+Run the Tectonic Installer for your platform:
 
 ```bash
-./tectonic-installer/$PLATFORM/installer
-```
+# macOS users
+$ ./tectonic-installer/darwin/installer
 
-Where $PLATFORM is `linux` or `darwin`.
+# Linux users
+$ ./tectonic-installer/linux/installer
+```
 
 A browser window will open to begin the GUI installation process.
 

--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -169,10 +169,14 @@ tar xzvf tectonic-1.6.4-tectonic.1.tar.gz
 cd tectonic/tectonic-installer
 ```
 
-Run the Tectonic Installer that matches your platform (`linux` or `darwin`):
+Run the Tectonic Installer for your platform:
 
-```sh
-./$PLATFORM/installer
+```bash
+# macOS users
+$ ./tectonic-installer/darwin/installer
+
+# Linux users
+$ ./tectonic-installer/linux/installer
 ```
 
 A browser window will open to begin the GUI installation process, which will require the following information:

--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -171,13 +171,19 @@ cd tectonic/tectonic-installer
 
 Run the Tectonic Installer for your platform:
 
-```bash
-# macOS users
-$ ./tectonic-installer/darwin/installer
+For macOS users:
 
-# Linux users
+```bash
+$ ./tectonic-installer/darwin/installer
+```
+
+For Linux users:
+
+```
 $ ./tectonic-installer/linux/installer
 ```
+
+For Windows users, [see this guide][install-windows].
 
 A browser window will open to begin the GUI installation process, which will require the following information:
 * DNS: Domain names assigned for the master and worker nodes, which must exist before launching Tectonic Installer.
@@ -230,3 +236,4 @@ After the installer is complete, you'll have a Tectonic cluster and be able to a
 [dnsmasq]: https://quay.io/repository/coreos/dnsmasq
 [copy-paste-examples]: https://github.com/coreos/matchbox/blob/master/Documentation/network-setup.md#coreosdnsmasq
 [proxy-dhcp]: https://github.com/coreos/matchbox/blob/master/Documentation/network-setup.md#proxy-dhcp
+[install-windows]: ../installer-windows.md


### PR DESCRIPTION
During user testing, two things tripped people up that are very easy to fix:

1. The `$PLATFORM` variable is strange if you are not used to the command line, plus we don't actually do the variable interpolation.

2. Some users were unfamiliar with `darwin` = macOS, as this is not a way it is branded.

This change simply gives macOS and Linux users the command to run.

cc: @meghanschofield 