### PR TITLE
frontend: add AWS to field label

### DIFF
--- a/installer/frontend/components/aws-cluster-info.jsx
+++ b/installer/frontend/components/aws-cluster-info.jsx
@@ -66,7 +66,7 @@ export const AWS_ClusterInfo = () => <div>
 
   <div className="row form-group">
     <div className="col-xs-3">
-      <label htmlFor="tags">Tags</label>
+      <label htmlFor="tags">AWS Tags</label>
     </div>
     <div className="col-xs-9">
       <TagsWithPlaceholder />


### PR DESCRIPTION
During user testing, folks were unsure of how these tags were used. Adding AWS to this label should indicate a bit more that they show up on AWS resources.