### PR TITLE
frontend: fixes #1328...

### DIFF
--- a/installer/frontend/components/aws-submit-keys.jsx
+++ b/installer/frontend/components/aws-submit-keys.jsx
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { validate } from '../validate';
 import { Connect, Selector } from './ui';
 import { Field, Form } from '../form';
 
 import * as awsActions from '../aws-actions';
-import { AWS_SSH, AWS_REGION_FORM } from '../cluster-config';
+import { AWS_SSH, AWS_REGION_FORM, AWS_REGION } from '../cluster-config';
 
 const awsSshForm = new Form('AWSSSHForm', [
   new Field(AWS_SSH, {
@@ -25,6 +26,12 @@ const awsSshForm = new Form('AWSSSHForm', [
   }
 );
 
+const Title = connect(
+  ({clusterConfig}) => ({region: clusterConfig[AWS_REGION]})
+)(
+  ({region}) => <h4>SSH Keys in {region}</h4>
+);
+
 export const AWS_SubmitKeys = () => <div>
   <div className="row form-group">
     <div className="col-xs-12">
@@ -33,9 +40,9 @@ export const AWS_SubmitKeys = () => <div>
   </div>
   <div className="row form-group">
     <div className="col-xs-12">
-      <h4>SSH Key</h4>
+      <Title />
       <Connect field={AWS_SSH}>
-        <Selector refreshBtn={true} disabledValue="Please select SSH Key Pair" />
+        <Selector refreshBtn={true} disabledValue="Please select a SSH Key Pair from this region." />
       </Connect>
       <awsSshForm.Errors />
     </div>


### PR DESCRIPTION
Adds region to SSH key prompt.

![screen shot 2017-07-07 at 4 18 24 pm](https://user-images.githubusercontent.com/986627/27980095-343e4148-6330-11e7-8e1f-017239ada56c.png)

-----

> Add the region to the drop down / placeholder text as:

This is a bit too much work atm, so I changed the text to read:
 `Please select a SSH Key Pair from this region.` 

---
Note also, the title actually reads [SSH Keys in {region}](https://github.com/coreos/tectonic-installer/pull/1333/files#diff-114938a9df5b9ff1d15d8fd8f4515690R32)

---
fixes #1328 