### PR TITLE
modules/*/etcd: pass client certs to standalone etcd

### DIFF
--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -11,6 +11,8 @@ data "ignition_config" "etcd" {
     "${data.ignition_file.etcd_ca.id}",
     "${data.ignition_file.etcd_server_crt.id}",
     "${data.ignition_file.etcd_server_key.id}",
+    "${data.ignition_file.etcd_client_crt.id}",
+    "${data.ignition_file.etcd_client_key.id}",
     "${data.ignition_file.etcd_peer_crt.id}",
     "${data.ignition_file.etcd_peer_key.id}",
   ]
@@ -36,6 +38,30 @@ data "ignition_file" "etcd_ca" {
 
   content {
     content = "${var.tls_ca_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_key" {
+  path       = "/etc/ssl/etcd/client.key"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_crt" {
+  path       = "/etc/ssl/etcd/client.crt"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_crt_pem}"
   }
 }
 

--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -4,17 +4,12 @@ data "ignition_config" "etcd" {
   systemd = [
     "${data.ignition_systemd_unit.locksmithd.*.id[count.index]}",
     "${data.ignition_systemd_unit.etcd3.*.id[count.index]}",
+    "${data.ignition_systemd_unit.etcd_unzip_tls.id}",
   ]
 
   files = [
     "${data.ignition_file.node_hostname.*.id[count.index]}",
-    "${data.ignition_file.etcd_ca.id}",
-    "${data.ignition_file.etcd_server_crt.id}",
-    "${data.ignition_file.etcd_server_key.id}",
-    "${data.ignition_file.etcd_client_crt.id}",
-    "${data.ignition_file.etcd_client_key.id}",
-    "${data.ignition_file.etcd_peer_crt.id}",
-    "${data.ignition_file.etcd_peer_key.id}",
+    "${data.ignition_file.etcd_tls_zip.id}",
   ]
 }
 
@@ -29,88 +24,37 @@ data "ignition_file" "node_hostname" {
   }
 }
 
-data "ignition_file" "etcd_ca" {
-  path       = "/etc/ssl/etcd/ca.crt"
-  mode       = 0644
-  uid        = 232
-  gid        = 232
-  filesystem = "root"
-
-  content {
-    content = "${var.tls_ca_crt_pem}"
-  }
-}
-
-data "ignition_file" "etcd_client_key" {
-  path       = "/etc/ssl/etcd/client.key"
+data "ignition_file" "etcd_tls_zip" {
+  path       = "/etc/ssl/etcd/tls.zip"
   mode       = 0400
   uid        = 0
   gid        = 0
   filesystem = "root"
 
   content {
-    content = "${var.tls_client_key_pem}"
+    mime    = "application/octet-stream"
+    content = "${var.tls_zip}"
   }
 }
 
-data "ignition_file" "etcd_client_crt" {
-  path       = "/etc/ssl/etcd/client.crt"
-  mode       = 0400
-  uid        = 0
-  gid        = 0
-  filesystem = "root"
+data "ignition_systemd_unit" "etcd_unzip_tls" {
+  name   = "etcd-unzip-tls.service"
+  enable = true
 
-  content {
-    content = "${var.tls_client_crt_pem}"
-  }
-}
-
-data "ignition_file" "etcd_server_key" {
-  path       = "/etc/ssl/etcd/server.key"
-  mode       = 0400
-  uid        = 232
-  gid        = 232
-  filesystem = "root"
-
-  content {
-    content = "${var.tls_server_key_pem}"
-  }
-}
-
-data "ignition_file" "etcd_server_crt" {
-  path       = "/etc/ssl/etcd/server.crt"
-  mode       = 0400
-  uid        = 232
-  gid        = 232
-  filesystem = "root"
-
-  content {
-    content = "${var.tls_server_crt_pem}"
-  }
-}
-
-data "ignition_file" "etcd_peer_key" {
-  path       = "/etc/ssl/etcd/peer.key"
-  mode       = 0400
-  uid        = 232
-  gid        = 232
-  filesystem = "root"
-
-  content {
-    content = "${var.tls_peer_key_pem}"
-  }
-}
-
-data "ignition_file" "etcd_peer_crt" {
-  path       = "/etc/ssl/etcd/peer.crt"
-  mode       = 0400
-  uid        = 232
-  gid        = 232
-  filesystem = "root"
-
-  content {
-    content = "${var.tls_peer_crt_pem}"
-  }
+  content = <<EOF
+[Unit]
+ConditionPathExists=!/etc/ssl/etcd/ca.crt
+[Service]
+Type=oneshot
+WorkingDirectory=/etc/ssl/etcd
+ExecStart=/usr/bin/bash -c 'unzip /etc/ssl/etcd/tls.zip && \
+chown etcd:etcd /etc/ssl/etcd/peer.* && \
+chown etcd:etcd /etc/ssl/etcd/server.* && \
+chmod 0400 /etc/ssl/etcd/peer.* /etc/ssl/etcd/server.* /etc/ssl/etcd/client.*'
+[Install]
+WantedBy=multi-user.target
+RequiredBy=etcd-member.service locksmithd.service
+EOF
 }
 
 data "ignition_systemd_unit" "locksmithd" {

--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -79,30 +79,6 @@ variable "tls_enabled" {
   default = false
 }
 
-variable "tls_ca_crt_pem" {
-  default = ""
-}
-
-variable "tls_client_key_pem" {
-  default = ""
-}
-
-variable "tls_client_crt_pem" {
-  default = ""
-}
-
-variable "tls_server_key_pem" {
-  default = ""
-}
-
-variable "tls_server_crt_pem" {
-  default = ""
-}
-
-variable "tls_peer_key_pem" {
-  default = ""
-}
-
-variable "tls_peer_crt_pem" {
-  default = ""
+variable "tls_zip" {
+  type = "string"
 }

--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -83,6 +83,14 @@ variable "tls_ca_crt_pem" {
   default = ""
 }
 
+variable "tls_client_key_pem" {
+  default = ""
+}
+
+variable "tls_client_crt_pem" {
+  default = ""
+}
+
 variable "tls_server_key_pem" {
   default = ""
 }

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -238,3 +238,44 @@ resource "local_file" "etcd_peer_key" {
   content  = "${join("", tls_private_key.etcd_peer.*.private_key_pem)}"
   filename = "./generated/tls/etcd/peer.key"
 }
+
+data "archive_file" "etcd_tls_zip" {
+  type = "zip"
+
+  output_path = "./.terraform/etcd_tls.zip"
+
+  source {
+    filename = "ca.crt"
+    content  = "${data.template_file.etcd_ca_cert_pem.rendered}"
+  }
+
+  source {
+    filename = "server.crt"
+    content  = "${join("", tls_locally_signed_cert.etcd_server.*.cert_pem)}"
+  }
+
+  source {
+    filename = "server.key"
+    content  = "${join("", tls_private_key.etcd_server.*.private_key_pem)}"
+  }
+
+  source {
+    filename = "peer.crt"
+    content  = "${join("", tls_locally_signed_cert.etcd_peer.*.cert_pem)}"
+  }
+
+  source {
+    filename = "peer.key"
+    content  = "${join("", tls_private_key.etcd_peer.*.private_key_pem)}"
+  }
+
+  source {
+    filename = "client.crt"
+    content  = "${data.template_file.etcd_client_crt.rendered}"
+  }
+
+  source {
+    filename = "client.key"
+    content  = "${data.template_file.etcd_client_key.rendered}"
+  }
+}

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -17,6 +17,7 @@
 # interpolated once the assets have all been created.
 output "id" {
   value = "${sha1("
+  ${data.archive_file.etcd_tls_zip.id}
   ${local_file.kubeconfig.id}
   ${local_file.bootkube-sh.id}
   ${template_dir.bootkube.id} ${template_dir.bootkube-bootstrap.id}
@@ -33,6 +34,10 @@ output "id" {
     template_dir.etcd-experimental.*.id,
     )}
   ")}"
+}
+
+output "etcd_tls_zip" {
+  value = "${data.archive_file.etcd_tls_zip.id != "" ? file("./.terraform/etcd_tls.zip") : ""}"
 }
 
 output "kubeconfig" {

--- a/modules/openstack/etcd/ignition.tf
+++ b/modules/openstack/etcd/ignition.tf
@@ -10,6 +10,8 @@ data "ignition_config" "etcd" {
     "${data.ignition_file.etcd_ca.id}",
     "${data.ignition_file.etcd_server_crt.id}",
     "${data.ignition_file.etcd_server_key.id}",
+    "${data.ignition_file.etcd_client_crt.id}",
+    "${data.ignition_file.etcd_client_key.id}",
     "${data.ignition_file.etcd_peer_crt.id}",
     "${data.ignition_file.etcd_peer_key.id}",
   ]
@@ -27,6 +29,30 @@ data "ignition_file" "etcd_ca" {
 
   content {
     content = "${var.tls_ca_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_key" {
+  path       = "/etc/ssl/etcd/client.key"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_crt" {
+  path       = "/etc/ssl/etcd/client.crt"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_crt_pem}"
   }
 }
 
@@ -57,6 +83,8 @@ data "ignition_file" "etcd_server_crt" {
 data "ignition_file" "etcd_peer_key" {
   path       = "/etc/ssl/etcd/peer.key"
   mode       = 0400
+  uid        = 232
+  gid        = 232
   filesystem = "root"
 
   content {

--- a/modules/openstack/etcd/variables.tf
+++ b/modules/openstack/etcd/variables.tf
@@ -15,7 +15,7 @@ variable "container_image" {
   type = "string"
 }
 
-variable core_public_keys {
+variable "core_public_keys" {
   type = "list"
 }
 
@@ -40,6 +40,14 @@ variable "tls_server_key_pem" {
 }
 
 variable "tls_server_crt_pem" {
+  default = ""
+}
+
+variable "tls_client_key_pem" {
+  default = ""
+}
+
+variable "tls_client_crt_pem" {
   default = ""
 }
 

--- a/modules/vmware/etcd/ignition.tf
+++ b/modules/vmware/etcd/ignition.tf
@@ -13,6 +13,13 @@ data "ignition_config" "etcd" {
     "${data.ignition_systemd_unit.locksmithd.*.id[count.index]}",
     "${data.ignition_systemd_unit.etcd3.*.id[count.index]}",
     "${data.ignition_systemd_unit.vmtoolsd_member.id}",
+    "${data.ignition_file.etcd_ca.id}",
+    "${data.ignition_file.etcd_server_crt.id}",
+    "${data.ignition_file.etcd_server_key.id}",
+    "${data.ignition_file.etcd_client_crt.id}",
+    "${data.ignition_file.etcd_client_key.id}",
+    "${data.ignition_file.etcd_peer_crt.id}",
+    "${data.ignition_file.etcd_peer_key.id}",
   ]
 
   networkd = [
@@ -23,6 +30,90 @@ data "ignition_config" "etcd" {
 data "ignition_user" "core" {
   name                = "core"
   ssh_authorized_keys = ["${var.core_public_keys}"]
+}
+
+data "ignition_file" "etcd_ca" {
+  path       = "/etc/ssl/etcd/ca.crt"
+  mode       = 0644
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_ca_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_key" {
+  path       = "/etc/ssl/etcd/client.key"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_client_crt" {
+  path       = "/etc/ssl/etcd/client.crt"
+  mode       = 0400
+  uid        = 0
+  gid        = 0
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_client_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_server_key" {
+  path       = "/etc/ssl/etcd/server.key"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_server_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_server_crt" {
+  path       = "/etc/ssl/etcd/server.crt"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_server_crt_pem}"
+  }
+}
+
+data "ignition_file" "etcd_peer_key" {
+  path       = "/etc/ssl/etcd/peer.key"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_peer_key_pem}"
+  }
+}
+
+data "ignition_file" "etcd_peer_crt" {
+  path       = "/etc/ssl/etcd/peer.crt"
+  mode       = 0400
+  uid        = 232
+  gid        = 232
+  filesystem = "root"
+
+  content {
+    content = "${var.tls_peer_crt_pem}"
+  }
 }
 
 data "ignition_systemd_unit" "locksmithd" {
@@ -78,8 +169,8 @@ ExecStart=/usr/lib/coreos/etcd-wrapper \
 --name=${var.hostname["${count.index}"]} \
 --initial-cluster="${join("," , data.template_file.etcd-cluster.*.rendered)}" \
 --advertise-client-urls=https://${var.hostname["${count.index}"]}.${var.base_domain}:2379 \
---cert-file=/etc/ssl/etcd/client.crt \
---key-file=/etc/ssl/etcd/client.key \
+--cert-file=/etc/ssl/etcd/server.crt \
+--key-file=/etc/ssl/etcd/server.key \
 --peer-cert-file=/etc/ssl/etcd/peer.crt \
 --peer-key-file=/etc/ssl/etcd/peer.key \
 --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -94,6 +94,14 @@ variable "tls_ca_crt_pem" {
   default = ""
 }
 
+variable "tls_client_key_pem" {
+  default = ""
+}
+
+variable "tls_client_crt_pem" {
+  default = ""
+}
+
 variable "tls_server_key_pem" {
   default = ""
 }

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -81,6 +81,8 @@ module "etcd" {
   tls_ca_crt_pem     = "${module.bootkube.etcd_ca_crt_pem}"
   tls_server_crt_pem = "${module.bootkube.etcd_server_crt_pem}"
   tls_server_key_pem = "${module.bootkube.etcd_server_key_pem}"
+  tls_client_crt_pem = "${module.bootkube.etcd_client_crt_pem}"
+  tls_client_key_pem = "${module.bootkube.etcd_client_key_pem}"
   tls_peer_crt_pem   = "${module.bootkube.etcd_peer_crt_pem}"
   tls_peer_key_pem   = "${module.bootkube.etcd_peer_key_pem}"
 }

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -78,13 +78,7 @@ module "etcd" {
   dns_enabled = "${!var.tectonic_experimental && length(compact(var.tectonic_etcd_servers)) == 0}"
   tls_enabled = "${var.tectonic_etcd_tls_enabled}"
 
-  tls_ca_crt_pem     = "${module.bootkube.etcd_ca_crt_pem}"
-  tls_server_crt_pem = "${module.bootkube.etcd_server_crt_pem}"
-  tls_server_key_pem = "${module.bootkube.etcd_server_key_pem}"
-  tls_client_crt_pem = "${module.bootkube.etcd_client_crt_pem}"
-  tls_client_key_pem = "${module.bootkube.etcd_client_key_pem}"
-  tls_peer_crt_pem   = "${module.bootkube.etcd_peer_crt_pem}"
-  tls_peer_key_pem   = "${module.bootkube.etcd_peer_key_pem}"
+  tls_zip = "${module.bootkube.etcd_tls_zip}"
 }
 
 module "ignition-masters" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -97,6 +97,8 @@ EOF
   tls_ca_crt_pem     = "${module.bootkube.etcd_ca_crt_pem}"
   tls_server_crt_pem = "${module.bootkube.etcd_server_crt_pem}"
   tls_server_key_pem = "${module.bootkube.etcd_server_key_pem}"
+  tls_client_crt_pem = "${module.bootkube.etcd_client_crt_pem}"
+  tls_client_key_pem = "${module.bootkube.etcd_client_key_pem}"
   tls_peer_crt_pem   = "${module.bootkube.etcd_peer_crt_pem}"
   tls_peer_key_pem   = "${module.bootkube.etcd_peer_key_pem}"
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -11,6 +11,8 @@ module "etcd" {
   tls_ca_crt_pem     = "${module.bootkube.etcd_ca_crt_pem}"
   tls_server_crt_pem = "${module.bootkube.etcd_server_crt_pem}"
   tls_server_key_pem = "${module.bootkube.etcd_server_key_pem}"
+  tls_client_crt_pem = "${module.bootkube.etcd_client_crt_pem}"
+  tls_client_key_pem = "${module.bootkube.etcd_client_key_pem}"
   tls_peer_key_pem   = "${module.bootkube.etcd_peer_crt_pem}"
   tls_peer_crt_pem   = "${module.bootkube.etcd_peer_key_pem}"
 


### PR DESCRIPTION
The client certificates are still needed for locksmith to function
properly.