### PR TITLE
Revert "Merge pull request #1314 from estroz/autoscaling-group-tags"

### DIFF
--- a/installer/frontend/__tests__/examples/aws-vpc.json
+++ b/installer/frontend/__tests__/examples/aws-vpc.json
@@ -31,13 +31,6 @@
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },
-    "tectonic_autoscaling_group_extra_tags": [
-      {
-        "key": "test_tag",
-        "value": "testing",
-        "propagate_at_launch": true
-      }
-    ],
     "tectonic_aws_master_ec2_type": "t2.large",
     "tectonic_aws_master_root_volume_size": 33,
     "tectonic_aws_master_root_volume_type": "gp2",

--- a/installer/frontend/__tests__/examples/aws.json
+++ b/installer/frontend/__tests__/examples/aws.json
@@ -14,13 +14,6 @@
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },
-    "tectonic_autoscaling_group_extra_tags": [
-      {
-        "key": "test_tag",
-        "value": "testing",
-        "propagate_at_launch": true
-      }
-    ],
     "tectonic_aws_master_custom_subnets": {
       "us-west-1a": "10.0.0.0/19",
       "us-west-1c": "10.0.32.0/19"

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -217,11 +217,9 @@ export const toAWS_TF = (cc, FORMS, opts={}) => {
   }
 
   const extraTags = {};
-  const extraAutoScalingTags = [];
   _.each(cc[AWS_TAGS], ({key, value}) => {
     if(key && value) {
       extraTags[key] = value;
-      extraAutoScalingTags.push({key, value, propagate_at_launch: true});
     }
   });
 
@@ -274,10 +272,6 @@ export const toAWS_TF = (cc, FORMS, opts={}) => {
 
   if (_.size(extraTags) > 0) {
     ret.variables.tectonic_aws_extra_tags = extraTags;
-  }
-
-  if (_.size(extraAutoScalingTags) > 0) {
-    ret.variables.tectonic_autoscaling_group_extra_tags = extraAutoScalingTags;
   }
 
   if (cc[STS_ENABLED]) {


### PR DESCRIPTION
This reverts commit b018c80dc6c4c62fcc38ff9836d1f56e9917e8ce, reversing changes made to d684cca43d80fe92ce94186ccaee9ed7d590c5f6.

When running `terraform plan` to deploy a cluster, the following error message is received:
```
1 error(s) occurred:

* variable tectonic_autoscaling_group_extra_tags should be type list, got map
```

Comments like https://github.com/hashicorp/terraform/issues/7705#issuecomment-300564571 indicate that terraform cannot handle complicated data structures, such as lists of maps whose structures are not explicitly declared, i.e. user-created variables. Therefore the changes created by b018c80dc6c4c62fcc38ff9836d1f56e9917e8ce should be reverted until lists of arbitrary maps are supported. In the meantime a workaround will be created and merged.