### PR TITLE
tests: Update tectonic-builder to allow writes to coreos go folder 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def quay_creds = [
   )
 ]
 
-def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.25'
+def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.31'
 
 pipeline {
   agent none
@@ -172,7 +172,7 @@ pipeline {
           "SmokeTest TerraForm: AWS (private vpc)": {
             node('worker && ec2') {
               withCredentials(creds) {
-                withDockerContainer(image: params.builder_image, args: '--device=/dev/net/tun --cap-add=NET_ADMIN') {
+                withDockerContainer(image: params.builder_image, args: '--device=/dev/net/tun --cap-add=NET_ADMIN -u root') {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -19,6 +19,9 @@ RUN go get github.com/jstemmer/go-junit-report
 ### License parser
 RUN go get github.com/coreos/license-bill-of-materials
 
+# /go needs to be writable by jenkins user like it is in the upstream golang image
+RUN chmod 777 -R /go
+
 ### Install Shellcheck, Terraform, NodeJS and Yarn
 ENV SHELLCHECK_VERSION="v0.4.6"
 ENV TERRAFORM_VERSION="v0.9.11-coreos.2"


### PR DESCRIPTION
With this PR comes a new version of the tectonic-builder image (v1.29).