### PR TITLE
tests: Update tectonic-builder to allow writes to coreos go folder (#1350)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ def quay_creds = [
   )
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.20'
+def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.31'
 
 pipeline {
   agent none
@@ -154,7 +154,7 @@ pipeline {
           "SmokeTest TerraForm: AWS (private vpc)": {
             node('worker && ec2') {
               withCredentials(creds) {
-                withDockerContainer(image: builder_image, args: '--device=/dev/net/tun --cap-add=NET_ADMIN') {
+                withDockerContainer(image: params.builder_image, args: '--device=/dev/net/tun --cap-add=NET_ADMIN -u root') {
                   checkout scm
                   unstash 'installer'
                   unstash 'smoke'

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -19,6 +19,9 @@ RUN go get github.com/jstemmer/go-junit-report
 ### License parser
 RUN go get github.com/coreos/license-bill-of-materials
 
+# /go needs to be writable by jenkins user like it is in the upstream golang image
+RUN chmod 777 -R /go
+
 ### Install Terraform, NodeJS and Yarn
 ENV TERRAFORM_VERSION="0.9.6"
 ENV NODE_VERSION="v8.1.2"


### PR DESCRIPTION
Cherry picks a fix for Jenkins failure