### PR TITLE
Update tectonic-builder in release and conformance scripts

### DIFF
--- a/release.groovy
+++ b/release.groovy
@@ -20,7 +20,7 @@ def creds = [
   ]
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.22'
+def builder_image = 'quay.io/coreos/tectonic-builder:v1.31'
 
 pipeline {
   agent none

--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -7,7 +7,7 @@ export PLATFORM=aws
 export CLUSTER="tf-${PLATFORM}-${BUILD_ID}"
 export TF_VAR_tectonic_pull_secret_path=${TF_VAR_tectonic_pull_secret_path}
 export TF_VAR_tectonic_license_path=${TF_VAR_tectonic_license_path}
-export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.22
+export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.31
 export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.6.6_coreos.0
 
 # Create an env var file


### PR DESCRIPTION
This updates the tectonic-builder image in the `release.groovy` pipeline
script and the `tests/conformance/conformance.sh` script to v1.31.

This image contains our patched version of [terraform](https://github.com/coreos/terraform). @rithujohn191 and @amrutac Can you confirm that this is acceptable for the conformance test and release process? Otherwise I will prepare a separate image.

@gopilal Thanks for pointing this out to me!