### PR TITLE
modules/openstack: Disable tectonic.service for vanilla

### DIFF
--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -123,5 +123,6 @@ data "ignition_systemd_unit" "bootkube" {
 
 data "ignition_systemd_unit" "tectonic" {
   name    = "tectonic.service"
+  enable  = "${var.tectonic_service_disabled == 0 ? true : false}"
   content = "${var.tectonic_service}"
 }

--- a/modules/openstack/nodes/variables.tf
+++ b/modules/openstack/nodes/variables.tf
@@ -61,3 +61,8 @@ variable "tectonic_service" {
 variable "tectonic_experimental" {
   default = false
 }
+
+variable "tectonic_service_disabled" {
+  description = "Specifies whether the tectonic installer systemd unit will be disabled. If true, no tectonic assets will be deployed"
+  default     = false
+}

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -134,6 +134,7 @@ EOF
   node_labels                  = "node-role.kubernetes.io/master"
   node_taints                  = "node-role.kubernetes.io/master=:NoSchedule"
   tectonic_experimental        = "${var.tectonic_experimental}"
+  tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 }
 
 module "worker_nodes" {
@@ -157,6 +158,7 @@ EOF
   hostname_infix               = "worker"
   node_labels                  = "node-role.kubernetes.io/node"
   node_taints                  = ""
+  tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 }
 
 module "secrets" {


### PR DESCRIPTION
The tectonic service was not started initially, but the systemd
unit was still enabled, so it would start and fail after a reboot.

/cc @s-urbaniak 