### PR TITLE
Console configmap takes cluster name

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -66,7 +66,7 @@ resource "template_dir" "bootkube" {
     # 3. Else (if etcd TLS certific are provided), then use the secure https
     # var.etcd_endpoints.
     etcd_servers = "${
-      var.experimental_enabled 
+      var.experimental_enabled
         ? format("https://%s:2379", cidrhost(var.service_cidr, 15))
         : data.template_file.etcd_ca_cert_pem.rendered == ""
           ? join(",", formatlist("http://%s:2379", var.etcd_endpoints))
@@ -121,7 +121,7 @@ resource "template_dir" "bootkube-bootstrap" {
     etcd_image      = "${var.container_images["etcd"]}"
 
     etcd_servers = "${
-      var.experimental_enabled 
+      var.experimental_enabled
         ? format("https://%s:2379,https://127.0.0.1:12379", cidrhost(var.service_cidr, 15))
         : data.template_file.etcd_ca_cert_pem.rendered == ""
           ? join(",", formatlist("http://%s:2379", var.etcd_endpoints))
@@ -148,6 +148,7 @@ data "template_file" "kubeconfig" {
     kubelet_cert = "${base64encode(tls_locally_signed_cert.kubelet.cert_pem)}"
     kubelet_key  = "${base64encode(tls_private_key.kubelet.private_key_pem)}"
     server       = "${var.kube_apiserver_url}"
+    cluster_name = "${var.cluster_name}"
   }
 }
 

--- a/modules/bootkube/resources/kubeconfig
+++ b/modules/bootkube/resources/kubeconfig
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Config
 clusters:
-- name: local
+- name: ${cluster_name}
   cluster:
     server: ${server}
     certificate-authority-data: ${ca_cert}
@@ -12,5 +12,5 @@ users:
     client-key-data: ${kubelet_key}
 contexts:
 - context:
-    cluster: local
+    cluster: ${cluster_name}
     user: kubelet

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -1,3 +1,7 @@
+variable "cluster_name" {
+  type = "string"
+}
+
 variable "container_images" {
   description = "Container images to use"
   type        = "map"

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -83,7 +83,8 @@ resource "template_dir" "tectonic" {
     stats_url          = "${var.stats_url}"
 
     # TODO: We could also patch https://www.terraform.io/docs/providers/random/ to add an UUID resource.
-    cluster_id = "${format("%s-%s-%s-%s-%s", substr(random_id.cluster_id.hex, 0, 8), substr(random_id.cluster_id.hex, 8, 4), substr(random_id.cluster_id.hex, 12, 4), substr(random_id.cluster_id.hex, 16, 4), substr(random_id.cluster_id.hex, 20, 12))}"
+    cluster_id   = "${format("%s-%s-%s-%s-%s", substr(random_id.cluster_id.hex, 0, 8), substr(random_id.cluster_id.hex, 8, 4), substr(random_id.cluster_id.hex, 12, 4), substr(random_id.cluster_id.hex, 16, 4), substr(random_id.cluster_id.hex, 20, 12))}"
+    cluster_name = "${var.cluster_name}"
 
     platform                 = "${var.platform}"
     certificates_strategy    = "${var.ca_generated == "true" ? "installerGeneratedCA" : "userProvidedCA"}"

--- a/modules/tectonic/resources/manifests/config.yaml
+++ b/modules/tectonic/resources/manifests/config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: tectonic-system
 data:
   clusterID: "${cluster_id}"
+  clusterName: "${cluster_name}"
   installerPlatform: "${platform}"
   certificatesStrategy: "${certificates_strategy}"
   tectonicUpdaterEnabled: "${tectonic_updater_enabled}"

--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -76,6 +76,11 @@ spec:
             configMapKeyRef:
               name: tectonic-identity
               key: kubectlSecret
+        - name: BRIDGE_TECTONIC_CLUSTER_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-config
+              key: clusterName
         - name: BRIDGE_TECTONIC_VERSION
           valueFrom:
             configMapKeyRef:

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -1,3 +1,7 @@
+variable "cluster_name" {
+  type = "string"
+}
+
 variable "container_images" {
   description = "Container images to use. Leave blank for defaults."
   type        = "map"

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -2,6 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = "aws"
 
+  cluster_name = "${var.tectonic_cluster_name}"
+
   kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"
   oidc_issuer_url    = "https://${module.masters.ingress_internal_fqdn}/identity"
 
@@ -69,6 +71,8 @@ module "bootkube" {
 module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "aws"
+
+  cluster_name = "${var.tectonic_cluster_name}"
 
   base_address       = "${module.masters.ingress_internal_fqdn}"
   kube_apiserver_url = "https://${module.masters.api_internal_fqdn}:443"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -2,6 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = ""
 
+  cluster_name = "${var.tectonic_cluster_name}"
+
   kube_apiserver_url = "https://${module.vnet.api_external_fqdn}:443"
   oidc_issuer_url    = "https://${module.vnet.ingress_internal_fqdn}/identity"
 
@@ -38,6 +40,8 @@ module "bootkube" {
 module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "azure"
+
+  cluster_name = "${var.tectonic_cluster_name}"
 
   base_address       = "${module.vnet.ingress_internal_fqdn}"
   kube_apiserver_url = "https://${module.vnet.api_external_fqdn}:443"

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -2,6 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = ""
 
+  cluster_name = "${var.tectonic_cluster_name}"
+
   # Address of kube-apiserver
   kube_apiserver_url = "https://${var.tectonic_metal_controller_domain}:443"
 
@@ -46,6 +48,8 @@ module "bootkube" {
 module "tectonic" {
   source   = "../../modules/tectonic"
   platform = ""
+
+  cluster_name = "${var.tectonic_cluster_name}"
 
   # Address of kube-apiserver
   kube_apiserver_url = "https://${var.tectonic_metal_controller_domain}:443"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -2,6 +2,8 @@ module "bootkube" {
   source         = "../../../modules/bootkube"
   cloud_provider = ""
 
+  cluster_name = "${var.tectonic_cluster_name}"
+
   kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
   oidc_issuer_url    = "https://${var.tectonic_cluster_name}.${var.tectonic_base_domain}/identity"
 
@@ -47,6 +49,8 @@ module "bootkube" {
 module "tectonic" {
   source   = "../../../modules/tectonic"
   platform = "aws"
+
+  cluster_name = "${var.tectonic_cluster_name}"
 
   base_address       = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}"
   kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -2,6 +2,8 @@ module "bootkube" {
   source         = "../../modules/bootkube"
   cloud_provider = ""
 
+  cluster_name = "${var.tectonic_cluster_name}"
+
   # Address of kube-apiserver
   kube_apiserver_url = "https://${var.tectonic_vmware_controller_domain}:443"
 
@@ -47,6 +49,8 @@ module "bootkube" {
 module "tectonic" {
   source   = "../../modules/tectonic"
   platform = "vsphere"
+
+  cluster_name = "${var.tectonic_cluster_name}"
 
   # Address of kube-apiserver
   kube_apiserver_url = "https://${var.tectonic_vmware_controller_domain}:443"


### PR DESCRIPTION
tectonic/resources/manifests/config.yaml: clusterName key holds user-defined cluster
name value to update kubeconfig

tectonic/resources/manifests/console/deployment.yaml: bridge cluster name env var takes
clusterName from configmap

Tests: incoming

Applies to #512 and complements #1360, https://github.com/coreos-inc/bridge/pull/1585

Merge after #1360 