### PR TITLE
platforms/aws: Compact master load balancers list

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -30,7 +30,7 @@ resource "aws_autoscaling_group" "masters" {
   launch_configuration = "${aws_launch_configuration.master_conf.id}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
-  load_balancers = ["${aws_elb.api-internal.id}", "${join("",aws_elb.api-external.*.id)}", "${aws_elb.console.id}"]
+  load_balancers = ["${compact(concat(list(aws_elb.api-internal.id), list(aws_elb.console.id), aws_elb.api-external.*.id))}"]
 
   tags = [
     {


### PR DESCRIPTION
After installing a cluster into an existing VPC without public endpoints, I always have changes reported to the load-balancers attached to the master ASG because of any empty string:

```
~ module.masters.aws_autoscaling_group.masters                                                                     
    load_balancers.#:          "2" => "3"                                                                                                                      
    load_balancers.0:          "" => ""                                                                                                                        
    load_balancers.204496288:  "cluster-int" => "cluster-int"                                                                                            
    load_balancers.3856535629: "cluster-con" => "cluster-con"
```

This change fixes it for me, but I haven't had a chance to test on a cluster with an external load-balancer.