### PR TITLE
Full permissions for $WORKSPACE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,17 +69,18 @@ pipeline {
           withDockerContainer(params.builder_image) {
             checkout scm
             sh """#!/bin/bash -ex
-            mkdir -p \$(dirname $GO_PROJECT) && ln -sf $WORKSPACE $GO_PROJECT
+            chmod -R 777 "$WORKSPACE"
+            mkdir -p \$(dirname "$GO_PROJECT") && ln -sf "$WORKSPACE" "$GO_PROJECT"
 
             # TODO: Remove me.
             go get github.com/segmentio/terraform-docs
             go get github.com/s-urbaniak/terraform-examples
 
-            cd $GO_PROJECT/
+            cd "$GO_PROJECT"/
             make structure-check
             make bin/smoke
 
-            cd $GO_PROJECT/installer
+            cd "$GO_PROJECT"/installer
             make clean
             make tools
             make build
@@ -111,10 +112,10 @@ pipeline {
                   unstash 'smoke'
                   timeout(45) {
                     sh """#!/bin/bash -ex
-                    . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-tls.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws-tls.tfvars
+                    . "${WORKSPACE}"/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh create vars/aws-tls.tfvars
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh test vars/aws-tls.tfvars
                     """
                   }
                   catchError {
@@ -122,8 +123,8 @@ pipeline {
                       sshagent(['aws-smoke-test-ssh-key']) {
                         sh """#!/bin/bash
                         # Running without -ex because we don't care if this fails
-                        . ${WORKSPACE}/tests/smoke/aws/smoke.sh common vars/aws-tls.tfvars
-                        ${WORKSPACE}/tests/smoke/aws/cluster-foreach.sh ${WORKSPACE}/tests/smoke/forensics.sh
+                        . "${WORKSPACE}"/tests/smoke/aws/smoke.sh common vars/aws-tls.tfvars
+                        "${WORKSPACE}"/tests/smoke/aws/cluster-foreach.sh "${WORKSPACE}"/tests/smoke/forensics.sh
                         """
                       }
                     }
@@ -131,8 +132,8 @@ pipeline {
                   retry(3) {
                     timeout(15) {
                       sh """#!/bin/bash -ex
-                      . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                      ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-tls.tfvars
+                      . "${WORKSPACE}"/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                      "${WORKSPACE}"/tests/smoke/aws/smoke.sh destroy vars/aws-tls.tfvars
                       """
                     }
                   }
@@ -148,8 +149,8 @@ pipeline {
                   unstash 'installer'
                   timeout(5) {
                     sh """#!/bin/bash -ex
-                    . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws.tfvars
+                    . "${WORKSPACE}"/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh plan vars/aws.tfvars
                     """
                   }
                 }
@@ -164,8 +165,8 @@ pipeline {
                   unstash 'installer'
                   timeout(5) {
                     sh """#!/bin/bash -ex
-                    . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-exp.tfvars
+                    . "${WORKSPACE}"/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh plan vars/aws-exp.tfvars
                     """
                   }
                 }
@@ -180,8 +181,8 @@ pipeline {
                   unstash 'installer'
                   timeout(5) {
                     sh """#!/bin/bash -ex
-                    . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-ca.tfvars
+                    . "${WORKSPACE}"/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh plan vars/aws-ca.tfvars
                     """
                   }
                 }
@@ -197,15 +198,15 @@ pipeline {
                   unstash 'smoke'
                   timeout(45) {
                     sh """#!/bin/bash -ex
-                    . ${WORKSPACE}/tests/smoke/aws/smoke.sh create-vpc
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-vpc.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-vpc.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws-vpc.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
-                    ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
+                    . "${WORKSPACE}"/tests/smoke/aws/smoke.sh create-vpc
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh plan vars/aws-vpc.tfvars
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh create vars/aws-vpc.tfvars
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh test vars/aws-vpc.tfvars
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
+                    "${WORKSPACE}"/tests/smoke/aws/smoke.sh destroy-vpc
                     # As /build is created by root, make sure to remove it again
                     # so non-root can create it later.
-                    rm -r ${WORKSPACE}/build
+                    rm -r "${WORKSPACE}"/build
                     """
                   }
                 }
@@ -224,9 +225,9 @@ pipeline {
                       try {
                         timeout(45) {
                           sh """#!/bin/bash -ex
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh plan vars/basic.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh create vars/basic.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh test vars/basic.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh plan vars/basic.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh create vars/basic.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh test vars/basic.tfvars
                         """
                         }
                       }
@@ -237,7 +238,7 @@ pipeline {
                         retry(3) {
                           timeout(15) {
                               sh """#!/bin/bash -ex
-                              ${WORKSPACE}/tests/smoke/azure/smoke.sh destroy vars/basic.tfvars
+                              "${WORKSPACE}"/tests/smoke/azure/smoke.sh destroy vars/basic.tfvars
                               """
                           }
                         }
@@ -260,9 +261,9 @@ pipeline {
                       try {
                         timeout(45) {
                           sh """#!/bin/bash -ex
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh plan vars/exper.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh create vars/exper.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh test vars/exper.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh plan vars/exper.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh create vars/exper.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh test vars/exper.tfvars
                         """
                         }
                       }
@@ -273,7 +274,7 @@ pipeline {
                         retry(3) {
                           timeout(15) {
                               sh """#!/bin/bash -ex
-                              ${WORKSPACE}/tests/smoke/azure/smoke.sh destroy vars/exper.tfvars
+                              "${WORKSPACE}"/tests/smoke/azure/smoke.sh destroy vars/exper.tfvars
                               """
                           }
                         }
@@ -299,9 +300,9 @@ pipeline {
                       try {
                         timeout(45) {
                           sh """#!/bin/bash -ex
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh plan vars/dns.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh create vars/dns.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh test vars/dns.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh plan vars/dns.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh create vars/dns.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh test vars/dns.tfvars
                         """
                         }
                       }
@@ -312,7 +313,7 @@ pipeline {
                         retry(3) {
                           timeout(15) {
                               sh """#!/bin/bash -ex
-                              ${WORKSPACE}/tests/smoke/azure/smoke.sh destroy vars/dns.tfvars
+                              "${WORKSPACE}"/tests/smoke/azure/smoke.sh destroy vars/dns.tfvars
                               """
                           }
                         }
@@ -336,9 +337,9 @@ pipeline {
                       try {
                         timeout(45) {
                           sh """#!/bin/bash -ex
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh plan vars/extern.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh create vars/extern.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh test vars/extern.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh plan vars/extern.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh create vars/extern.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh test vars/extern.tfvars
                         """
                         }
                       }
@@ -349,7 +350,7 @@ pipeline {
                         retry(3) {
                           timeout(15) {
                               sh """#!/bin/bash -ex
-                              ${WORKSPACE}/tests/smoke/azure/smoke.sh destroy vars/extern.tfvars
+                              "${WORKSPACE}"/tests/smoke/azure/smoke.sh destroy vars/extern.tfvars
                               """
                           }
                         }
@@ -372,9 +373,9 @@ pipeline {
                       try {
                         timeout(45) {
                           sh """#!/bin/bash -ex
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh plan vars/extern-exper.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh create vars/extern-exper.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh test vars/extern-exper.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh plan vars/extern-exper.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh create vars/extern-exper.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh test vars/extern-exper.tfvars
                         """
                         }
                       }
@@ -385,7 +386,7 @@ pipeline {
                         retry(3) {
                           timeout(15) {
                               sh """#!/bin/bash -ex
-                              ${WORKSPACE}/tests/smoke/azure/smoke.sh destroy vars/extern-exper.tfvars
+                              "${WORKSPACE}"/tests/smoke/azure/smoke.sh destroy vars/extern-exper.tfvars
                               """
                           }
                         }
@@ -408,9 +409,9 @@ pipeline {
                       try {
                         timeout(45) {
                           sh """#!/bin/bash -ex
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh plan vars/example.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh create vars/example.tfvars
-                          ${WORKSPACE}/tests/smoke/azure/smoke.sh test vars/example.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh plan vars/example.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh create vars/example.tfvars
+                          "${WORKSPACE}"/tests/smoke/azure/smoke.sh test vars/example.tfvars
                         """
                         }
                       }
@@ -421,7 +422,7 @@ pipeline {
                         retry(3) {
                           timeout(15) {
                               sh """#!/bin/bash -ex
-                              ${WORKSPACE}/tests/smoke/azure/smoke.sh destroy vars/example.tfvars
+                              "${WORKSPACE}"/tests/smoke/azure/smoke.sh destroy vars/example.tfvars
                               """
                           }
                         }
@@ -440,7 +441,7 @@ pipeline {
               withCredentials(creds) {
                 timeout(35) {
                   sh """#!/bin/bash -ex
-                  ${WORKSPACE}/tests/smoke/bare-metal/smoke.sh vars/metal.tfvars
+                  "${WORKSPACE}"/tests/smoke/bare-metal/smoke.sh vars/metal.tfvars
                   """
                 }
               }
@@ -489,20 +490,20 @@ pipeline {
                 unstash 'installer'
                 timeout(15) {
                   sh """#!/bin/bash -x
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
+                  "${WORKSPACE}"/tests/smoke/aws/smoke.sh destroy vars/aws.tfvars
                   """
                 }
                 timeout(20) {
                   sh """#!/bin/bash -x
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy-vpc
+                  "${WORKSPACE}"/tests/smoke/aws/smoke.sh destroy vars/aws-vpc.tfvars
+                  "${WORKSPACE}"/tests/smoke/aws/smoke.sh destroy-vpc
                   """
                 }
                 timeout(10) {
                   sh """#!/bin/bash -x
                   docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws.tfvars
-                  ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-vpc.tfvars
+                  "${WORKSPACE}"/tests/smoke/aws/smoke.sh grafiti-clean vars/aws.tfvars
+                  "${WORKSPACE}"/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-vpc.tfvars
                   """
                 }
               }

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ structure-check:
 	$(eval FMT_ERR := $(shell terraform fmt -list -write=false .))
 	@if [ "$(FMT_ERR)" != "" ]; then echo "misformatted files (run 'terraform fmt .' to fix):" $(FMT_ERR); exit 1; fi
 
-	@if make docs && ! git diff --exit-code; then echo "outdated docs (run 'make docs' to fix)"; exit 1; fi
-	@if make examples && ! git diff --exit-code; then echo "outdated examples (run 'make examples' to fix)"; exit 1; fi
+	@if make docs && ! git diff -G. --exit-code; then echo "outdated docs (run 'make docs' to fix)"; exit 1; fi
+	@if make examples && ! git diff -G. --exit-code; then echo "outdated examples (run 'make examples' to fix)"; exit 1; fi
 
 SMOKE_SOURCES := $(shell find $(TOP_DIR)/tests/smoke -name '*.go')
 bin/smoke: $(SMOKE_SOURCES)

--- a/git-version
+++ b/git-version
@@ -13,7 +13,7 @@ if [ -z "$TAG" ]; then
 fi
 
 # check for changed files (not untracked files)
-if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
+if [ -n "$(git diff -G. --shortstat 2> /dev/null | tail -n1)" ]; then
 	VERSION="${VERSION}_dirty"
 fi
 

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -68,7 +68,7 @@ shellcheck: $(SHELL_FILES)
 
 .PHONY: dirtycheck
 dirtycheck:
-	@if git status --short | grep 'yarn.lock' > /dev/null; then echo "outdated yarn.lock (commit it to fix)"; exit 1; fi
+	@if git diff -G. | grep 'yarn.lock' > /dev/null; then echo "outdated yarn.lock (commit it to fix)"; exit 1; fi
 
 .PHONY: dist
 dist: release-bins

--- a/tests/smoke/aws/smoke.sh
+++ b/tests/smoke/aws/smoke.sh
@@ -5,6 +5,7 @@ shopt -s expand_aliases
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Allow smoke.sh to work off jenkins.
 WORKSPACE=${WORKSPACE:-"$(cd "$DIR"/../../.. && pwd)"}
+chmod -R 777 "$WORKSPACE"
 BUILD_ID=${BUILD_ID:-1}
 BRANCH_NAME=${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}
 


### PR DESCRIPTION
tests/smoke/aws: full permissions for `$WORKSPACE`

Jenkins smoke tests flake randomly due to permissions errors, likely due to the Docker user not having full access to the `$WORKSPACE` directory. Opening permissions to that dir should solve this issue.

Tests: none