### PR TITLE
modules/azure,modules/bootkube: add cloud-config support

### DIFF
--- a/Documentation/variables/azure.md
+++ b/Documentation/variables/azure.md
@@ -6,6 +6,8 @@ This document gives an overview of variables used in the Azure platform of the T
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
+| tectonic_azure_client_secret | The client secret to use. | string | - |
+| tectonic_azure_cloud_environment | (optional) Azure cloud environment to use. See https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13 for available environments. | string | `AZUREPUBLICCLOUD` |
 | tectonic_azure_config_version | (internal) This declares the version of the Azure configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.1` |
 | tectonic_azure_etcd_storage_account_type | (optional) Storage account type for the etcd node(s). Example: Premium_LRS. Using Premium storage is constrained by the of instance specified in 'tectonic_azure_etcd_vm_size'. See https://docs.microsoft.com/en-us/azure/storage/storage-premium-storage#supported-vms | string | `Premium_LRS` |
 | tectonic_azure_etcd_vm_size | (optional) Instance size for the etcd node(s). Example: Standard_DS2_v2. | string | `Standard_DS2_v2` |

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -10,6 +10,14 @@ tectonic_admin_email = ""
 // Note: This field MUST be set manually prior to creating the cluster.
 tectonic_admin_password_hash = ""
 
+// The client secret to use.
+tectonic_azure_client_secret = ""
+
+// (optional) Azure cloud environment to use. See
+// https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
+// for available environments.
+// tectonic_azure_cloud_environment = "AZUREPUBLICCLOUD"
+
 // (optional) Storage account type for the etcd node(s). Example: Premium_LRS.
 // Using Premium storage is constrained by the of instance specified in 'tectonic_azure_etcd_vm_size'.
 // See https://docs.microsoft.com/en-us/azure/storage/storage-premium-storage#supported-vms

--- a/modules/azure/master-as/ignition-master.tf
+++ b/modules/azure/master-as/ignition-master.tf
@@ -3,6 +3,7 @@ data "ignition_config" "master" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [
@@ -91,6 +92,16 @@ data "ignition_file" "max-user-watches" {
 
   content {
     content = "fs.inotify.max_user_watches=16184"
+  }
+}
+
+data "ignition_file" "cloud-provider-config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+
+  content {
+    content = "${var.cloud_provider_config}"
   }
 }
 

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -29,7 +29,7 @@ resource "azurerm_availability_set" "tectonic_masters" {
 
 resource "azurerm_virtual_machine" "tectonic_master" {
   count                 = "${var.master_count}"
-  name                  = "${var.cluster_name}-master${count.index}"
+  name                  = "${var.cluster_name}-master-${count.index}"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${var.network_interface_ids[count.index]}"]
@@ -48,7 +48,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
     caching       = "ReadWrite"
     create_option = "FromImage"
     os_type       = "linux"
-    vhd_uri       = "${azurerm_storage_account.tectonic_master.primary_blob_endpoint}${azurerm_storage_container.tectonic_master.name}/${var.cluster_name}-master${count.index}.vhd"
+    vhd_uri       = "${azurerm_storage_account.tectonic_master.primary_blob_endpoint}${azurerm_storage_container.tectonic_master.name}/${count.index}.vhd"
   }
 
   os_profile {

--- a/modules/azure/master-as/resources/master-kubelet.service
+++ b/modules/azure/master-as/resources/master-kubelet.service
@@ -34,8 +34,9 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_domain=cluster.local \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
-  --cloud-provider="${cloud_provider}"
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+  --cloud-provider="${cloud_provider}" \
+  --cloud-config=/etc/kubernetes/cloud/config
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always
 RestartSec=10
 

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -62,6 +62,11 @@ variable "cloud_provider" {
   default = "azure"
 }
 
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+}
+
 variable "kubelet_node_label" {
   type = "string"
 }

--- a/modules/azure/master-ss/master.tf
+++ b/modules/azure/master-ss/master.tf
@@ -10,7 +10,7 @@ resource "random_id" "tectonic_master_storage_name" {
 }
 
 resource "azurerm_storage_account" "tectonic_master" {
-  name                = "master${random_id.tectonic_master_storage_name.hex}"
+  name                = "master-${random_id.tectonic_master_storage_name.hex}"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/azure/vnet/nic-worker.tf
+++ b/modules/azure/vnet/nic-worker.tf
@@ -1,6 +1,6 @@
 resource "azurerm_network_interface" "tectonic_worker" {
   count               = "${var.worker_count}"
-  name                = "${var.cluster_name}-worker${count.index}"
+  name                = "${var.cluster_name}-worker-${count.index}"
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -10,6 +10,10 @@ output "worker_subnet" {
   value = "${var.external_vnet_id == "" ?  join(" ", azurerm_subnet.worker_subnet.*.id) : var.external_worker_subnet_id }"
 }
 
+output "worker_subnet_name" {
+  value = "${var.external_vnet_id == "" ?  join(" ", azurerm_subnet.worker_subnet.*.name) : replace(var.external_vnet_id, "${var.const_id_to_group_name_regex}", "$2") }"
+}
+
 # TODO: Allow user to provide their own network
 output "etcd_cidr" {
   value = "${azurerm_subnet.master_subnet.address_prefix}"

--- a/modules/azure/worker-as/ignition-worker.tf
+++ b/modules/azure/worker-as/ignition-worker.tf
@@ -3,6 +3,7 @@ data "ignition_config" "worker" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [
@@ -80,6 +81,16 @@ data "ignition_file" "max-user-watches" {
 
   content {
     content = "fs.inotify.max_user_watches=16184"
+  }
+}
+
+data "ignition_file" "cloud-provider-config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+
+  content {
+    content = "${var.cloud_provider_config}"
   }
 }
 

--- a/modules/azure/worker-as/output.tf
+++ b/modules/azure/worker-as/output.tf
@@ -1,0 +1,3 @@
+output "availability_set_name" {
+  value = "${azurerm_availability_set.tectonic_workers.name}"
+}

--- a/modules/azure/worker-as/resources/worker-kubelet.service
+++ b/modules/azure/worker-as/resources/worker-kubelet.service
@@ -33,8 +33,9 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_domain=cluster.local \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --anonymous-auth=false \
-  --cloud-provider="${cloud_provider}"
-ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+  --cloud-provider="${cloud_provider}" \
+  --cloud-config=/etc/kubernetes/cloud/config
+ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid
 Restart=always
 RestartSec=10
 

--- a/modules/azure/worker-as/variables.tf
+++ b/modules/azure/worker-as/variables.tf
@@ -57,6 +57,11 @@ variable "cloud_provider" {
   default = "azure"
 }
 
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+}
+
 variable "kubelet_node_label" {
   type = "string"
 }

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -29,7 +29,7 @@ resource "azurerm_availability_set" "tectonic_workers" {
 
 resource "azurerm_virtual_machine" "tectonic_worker" {
   count                 = "${var.worker_count}"
-  name                  = "${var.cluster_name}-worker${count.index}"
+  name                  = "${var.cluster_name}-worker-${count.index}"
   location              = "${var.location}"
   resource_group_name   = "${var.resource_group_name}"
   network_interface_ids = ["${var.network_interface_ids[count.index]}"]
@@ -52,7 +52,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
     caching       = "ReadWrite"
     create_option = "FromImage"
     os_type       = "linux"
-    vhd_uri       = "${azurerm_storage_account.tectonic_worker.primary_blob_endpoint}${azurerm_storage_container.tectonic_worker.name}/${var.cluster_name}-worker${count.index}.vhd"
+    vhd_uri       = "${azurerm_storage_account.tectonic_worker.primary_blob_endpoint}${azurerm_storage_container.tectonic_worker.name}/${count.index}.vhd"
   }
   os_profile {
     computer_name  = "${var.cluster_name}-worker-${count.index}"
@@ -70,5 +70,8 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   }
   tags {
     environment = "staging"
+  }
+  lifecycle {
+    ignore_changes = ["storage_data_disk"]
   }
 }

--- a/modules/azure/worker-ss/ignition-worker.tf
+++ b/modules/azure/worker-ss/ignition-worker.tf
@@ -3,6 +3,7 @@ data "ignition_config" "worker" {
     "${data.ignition_file.kubeconfig.id}",
     "${data.ignition_file.kubelet-env.id}",
     "${data.ignition_file.max-user-watches.id}",
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [

--- a/modules/azure/worker-ss/workers.tf
+++ b/modules/azure/worker-ss/workers.tf
@@ -7,7 +7,7 @@ resource "random_id" "tectonic_storage_name" {
 }
 
 resource "azurerm_storage_account" "tectonic_worker" {
-  name                = "worker${var.cluster_name}-${random_id.tectonic_storage_name.hex}"
+  name                = "worker-${var.cluster_name}-${random_id.tectonic_storage_name.hex}"
   resource_group_name = "${var.resource_group_name}"
   location            = "${var.location}"
   account_type        = "${var.storage_account_type}"

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -74,7 +74,9 @@ resource "template_dir" "bootkube" {
     etcd_service_ip           = "${cidrhost(var.service_cidr, 15)}"
     bootstrap_etcd_service_ip = "${cidrhost(var.service_cidr, 20)}"
 
-    cloud_provider = "${var.cloud_provider}"
+    cloud_provider             = "${var.cloud_provider}"
+    cloud_provider_config      = "${var.cloud_provider_config}"
+    cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
 
     cluster_cidr        = "${var.cluster_cidr}"
     service_cidr        = "${var.service_cidr}"
@@ -130,8 +132,11 @@ resource "template_dir" "bootkube-bootstrap" {
     etcd_cert_flag = "${data.template_file.etcd_client_crt.rendered != "" ? "- --etcd-certfile=/etc/kubernetes/secrets/etcd-client.crt" : "# no etcd-client.crt given" }"
     etcd_key_flag  = "${data.template_file.etcd_client_key.rendered != "" ? "- --etcd-keyfile=/etc/kubernetes/secrets/etcd-client.key" : "# no etcd-client.key given" }"
 
+    cloud_provider             = "${var.cloud_provider}"
+    cloud_provider_config      = "${var.cloud_provider_config}"
+    cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
+
     advertise_address = "${var.advertise_address}"
-    cloud_provider    = "${var.cloud_provider}"
     cluster_cidr      = "${var.cluster_cidr}"
     service_cidr      = "${var.service_cidr}"
   }

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -18,6 +18,7 @@ spec:
     - --bind-address=0.0.0.0
     - --client-ca-file=/etc/kubernetes/secrets/ca.crt
     - --cloud-provider=${cloud_provider}
+    ${cloud_provider_config_flag}
     - --etcd-servers=${etcd_servers}
     ${etcd_ca_flag}
     ${etcd_cert_flag}
@@ -40,6 +41,9 @@ spec:
     - mountPath: /etc/kubernetes/secrets
       name: secrets
       readOnly: true
+    - mountPath: /etc/kubernetes/cloud
+      name: etc-kubernetes-cloud
+      readOnly: true
     - mountPath: /var/lock
       name: var-lock
       readOnly: false
@@ -48,6 +52,9 @@ spec:
   - name: secrets
     hostPath:
       path: /etc/kubernetes/bootstrap-secrets
+  - name: etc-kubernetes-cloud
+    hostPath:
+      path: /etc/kubernetes/cloud
   - name: ssl-certs-host
     hostPath:
       path: /usr/share/ca-certificates

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -13,6 +13,7 @@ spec:
     - --allocate-node-cidrs=true
     - --cluster-cidr=${cluster_cidr}
     - --cloud-provider=${cloud_provider}
+    ${cloud_provider_config_flag}
     - --configure-cloud-routes=false
     - --leader-elect=true
     - --kubeconfig=/etc/kubernetes/kubeconfig

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -56,6 +56,7 @@ spec:
         - --oidc-groups-claim=${oidc_groups_claim}
         - --oidc-ca-file=/etc/kubernetes/secrets/ca.crt
         - --cloud-provider=${cloud_provider}
+        ${cloud_provider_config_flag}
         - --audit-log-path=/var/log/kubernetes/kube-apiserver-audit.log
         - --audit-log-maxage=30
         - --audit-log-maxbackup=3
@@ -66,6 +67,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubernetes/secrets
           name: secrets
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
           readOnly: true
         - mountPath: /var/lock
           name: var-lock
@@ -89,6 +93,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-apiserver
+      - name: cloud-config
+        secret:
+          secretName: kube-cloud-cfg
       - name: var-lock
         hostPath:
           path: /var/lock

--- a/modules/bootkube/resources/manifests/kube-cloud-config.yaml
+++ b/modules/bootkube/resources/manifests/kube-cloud-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-cloud-cfg
+  namespace: kube-system
+type: Opaque
+data:
+  config: ${base64encode(cloud_provider_config)}

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -45,6 +45,7 @@ spec:
         - --node-monitor-grace-period=${node_monitor_grace_period}
         - --pod-eviction-timeout=${pod_eviction_timeout}
         - --cloud-provider=${cloud_provider}
+        ${cloud_provider_config_flag}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -54,6 +55,9 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /etc/kubernetes/secrets
+          readOnly: true
+        - mountPath: /etc/kubernetes/cloud
+          name: cloud-config
           readOnly: true
         - name: ssl-host
           mountPath: /etc/ssl/certs
@@ -73,6 +77,9 @@ spec:
       - name: secrets
         secret:
           secretName: kube-controller-manager
+      - name: cloud-config
+        secret:
+          secretName: kube-cloud-cfg
       - name: ssl-host
         hostPath:
           path: /usr/share/ca-certificates

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -48,6 +48,12 @@ variable "cloud_provider" {
   type        = "string"
 }
 
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+  default     = ""
+}
+
 variable "service_cidr" {
   description = "A CIDR notation IP range from which to assign service cluster IPs"
   type        = "string"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -1,6 +1,8 @@
 module "bootkube" {
-  source         = "../../modules/bootkube"
-  cloud_provider = ""
+  source = "../../modules/bootkube"
+
+  cloud_provider        = "azure"
+  cloud_provider_config = "${jsonencode(data.null_data_source.cloud-provider.inputs)}"
 
   kube_apiserver_url = "https://${module.vnet.api_external_fqdn}:443"
   oidc_issuer_url    = "https://${module.vnet.ingress_internal_fqdn}/identity"

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -233,3 +233,21 @@ EOF
 
   default = ""
 }
+
+variable "tectonic_azure_cloud_environment" {
+  type = "string"
+
+  description = <<EOF
+(optional) Azure cloud environment to use. See
+https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
+for available environments.
+EOF
+
+  default = "AZUREPUBLICCLOUD"
+}
+
+variable "tectonic_azure_client_secret" {
+  type = "string"
+
+  description = "The client secret to use."
+}

--- a/tests/smoke/azure/smoke.sh
+++ b/tests/smoke/azure/smoke.sh
@@ -58,6 +58,9 @@ common() {
     export TF_VAR_tectonic_azure_ssh_key
     TF_VAR_tectonic_azure_ssh_key=$(realpath "$HOME/.ssh/id_rsa.pub")
 
+    export TF_VAR_tectonic_azure_client_secret
+    TF_VAR_tectonic_azure_client_secret="${ARM_CLIENT_SECRET}"
+
     # Create local config
     make localconfig
     # Use smoke test configuration for deployment


### PR DESCRIPTION
This adds support for the k8s cloud-config feature on Azure.
Generally this opens the possibility to configure cloud-configs for
other platforms too.

Credit goes to "fish", https://github.com/discordianfish

/cc @discordianfish I squashed the whole commit history into one
because it turned out to be rebase hell. I hope you don't mind. Also PTAL.

/cc @alexsomesan @metral

Supersedes #999