### PR TITLE
config.tf: re-bump kubernetes/tectonic version to 1.6.7

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -73,8 +73,8 @@ variable "tectonic_versions" {
     prometheus      = "v1.7.1"
     alertmanager    = "v0.7.1"
     monitoring      = "1.3.0"
-    kubernetes      = "1.6.6+tectonic.1"
-    tectonic        = "1.6.6-tectonic.1"
+    kubernetes      = "1.6.7+tectonic.1"
+    tectonic        = "1.6.7-tectonic.1"
     tectonic-etcd   = "0.0.1"
   }
 }


### PR DESCRIPTION
This is a regression introduced in https://github.com/coreos/tectonic-installer/pull/1154.