### PR TITLE
frontend: Clean up GUI tests.

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -4,7 +4,9 @@ OS=$(shell uname | tr A-Z a-z)
 LD_FLAGS="-w"
 INSTALLER_OPTS=--address=127.0.0.1:4444 --open-browser=false --log-level=debug --dev
 TLS_CERTS=../tests/smoke/bare-metal/fake-creds
-MATCHBOX_OPTS=-data-path=/tmp/images -assets-path=/tmp/assets -cert-file=$(TLS_CERTS)/server.crt -key-file=$(TLS_CERTS)/server.key -ca-file=$(TLS_CERTS)/ca.crt
+MATCHBOX_ASSETS_PATH=/tmp/assets
+MATCHBOX_IMAGES_PATH=/tmp/images
+MATCHBOX_OPTS=-data-path=$(MATCHBOX_IMAGES_PATH) -assets-path=$(MATCHBOX_ASSETS_PATH) -cert-file=$(TLS_CERTS)/server.crt -key-file=$(TLS_CERTS)/server.key -ca-file=$(TLS_CERTS)/ca.crt
 COREOS_VERSION=1353.8.0
 REPO=github.com/coreos/tectonic-installer/installer
 
@@ -107,14 +109,13 @@ bin/go-bindata:
 
 .PHONY: launch-installer
 launch-installer:
-	mkdir -p frontend/ui-tests/reports/
-	./bin/$(OS)/installer $(INSTALLER_OPTS) & echo $$! > frontend/ui-tests/reports/installer.pid
+	./bin/$(OS)/installer $(INSTALLER_OPTS) & echo $$! > /tmp/installer.pid
 
 .PHONY: launch-matchbox
 launch-matchbox:
-	chmod +x frontend/ui-tests/utils/addMatchboxHosts.sh  && ./frontend/ui-tests/utils/addMatchboxHosts.sh > /dev/null
-	mkdir -p /tmp/images /tmp/assets/coreos/$(COREOS_VERSION)
-	/usr/local/bin/matchbox $(MATCHBOX_OPTS) & echo $$! > frontend/ui-tests/reports/matchbox.pid
+	./scripts/add_matchbox_hosts.sh
+	mkdir -p $(MATCHBOX_IMAGES_PATH) $(MATCHBOX_ASSETS_PATH)/coreos/$(COREOS_VERSION)
+	/usr/local/bin/matchbox $(MATCHBOX_OPTS) & echo $$! > /tmp/matchbox.pid
 
 .PHONY: launch-aws-installer-guitests
 launch-aws-installer-guitests: launch-installer
@@ -122,19 +123,19 @@ launch-aws-installer-guitests: launch-installer
 
 .PHONY: launch-baremetal-installer-guitests
 launch-baremetal-installer-guitests: launch-installer launch-matchbox
-	cd frontend && xvfb-run -a yarn baremetal-installer-tests
+	cd frontend && xvfb-run -a yarn run baremetal-installer-tests
+
+.PHONY: gui-tests-cleanup
+gui-tests-cleanup:
+	kill `cat /tmp/installer.pid`
 
 .PHONY: gui-aws-tests-cleanup
-gui-aws-tests-cleanup:
-	kill `cat frontend/ui-tests/reports/installer.pid`
-	rm -fr frontend/ui-tests/reports/
+gui-aws-tests-cleanup: gui-tests-cleanup
 
 .PHONY: gui-baremetal-tests-cleanup
-gui-baremetal-tests-cleanup:
-		kill `cat frontend/ui-tests/reports/installer.pid`
-		kill `cat frontend/ui-tests/reports/matchbox.pid`
-		rm -fr frontend/ui-tests/reports/
-		rm -fr /tmp/images /tmp/assets/coreos/$(COREOS_VERSION)
+gui-baremetal-tests-cleanup: gui-tests-cleanup
+	kill `cat /tmp/matchbox.pid`
+	rm -fr $(MATCHBOX_IMAGES_PATH) $(MATCHBOX_ASSETS_PATH)/coreos/$(COREOS_VERSION)
 
 .PHONY: clean
 clean:

--- a/installer/frontend/nightwatch.json
+++ b/installer/frontend/nightwatch.json
@@ -4,7 +4,6 @@
     "ui-tests/tests"
   ],
   "page_objects_path": "ui-tests/pages",
-  "output_folder": "ui-tests/reports",
   "selenium": {
     "start_process": false
   },

--- a/installer/scripts/add_matchbox_hosts.sh
+++ b/installer/scripts/add_matchbox_hosts.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -ex
+
 {
   echo "172.18.0.10 node1 node1.example.com"
   echo "172.18.0.11 node2 node2.example.com"


### PR DESCRIPTION
- Use variables instead of duplicating paths.
- Add a Makefile rule for common cleanup code instead of duplicating it.
- Fix indentation.
- Move frontend/ui-tests/utils/addMatchboxHosts.sh to scripts/add_matchbox_hosts.sh so it's shellchecked.
- Don't needlessly chmod +x add_matchbox_hosts.sh
- Die on errors in add_matchbox_hosts.sh
- Use `yarn run baremetal-installer-tests` instead of `yarn baremetal-installer-tests`. I'm surprised this even worked.
- Remove output_folder from nightwatch. We weren't using it.
- Put pid files in /tmp, not ui-tests/reports/.
