### PR TITLE
Document resource tagging issues

### DIFF
--- a/Documentation/install/aws/troubleshooting.md
+++ b/Documentation/install/aws/troubleshooting.md
@@ -12,6 +12,15 @@ The domain configured for Route 53 name service and the domain names selected fo
 
 Pod, Service, and Instance CIDRs may overlap with ranges of [peered VPCs](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-peering.html), but only if the `pcx` interface is *not* in the route table attached to the Kubernetes subnets. Be certain to configure these CIDRs appropriately.
 
+## Resource tagging
+
+Most resources in AWS support tagging, and the Tectonic installer tags as many of these resources as possible. Unfortunately certain resources are created implicitly by others, and no API exists to tag them, ex. EC2 instances create network interfaces that cannot be tagged by the `aws_instance` resource. The following notes describe which resources are not or are incompletely tagged.
+
+* Autoscaling Group-controlled instances are not tagged with user-defined tags, only with defaults
+* Autoscaling Group-controlled instance volumes are not tagged with any tags
+* Default EC2 Network ACLs are not tagged with any tags
+* EC2 Network Interfaces implicitly created by EC2 Instances are not tagged with any tags
+
 ## Community Support Forum
 
 Make sure to check out the [community support forum](https://github.com/coreos/tectonic-forum/issues) to work through issues, report bugs, identify documentation requirements, or add feature requests.


### PR DESCRIPTION
Documenation/install/aws: documented resource tagging

Certain resources are either not tagged with user-defined tags or at all. This update explains to what extent those resources are tagged, if at all