### PR TITLE
Changed hardcoded value of IOPS to 100

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -78,7 +78,7 @@ resource "aws_launch_configuration" "master_conf" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
   }
 }
 

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -43,7 +43,7 @@ resource "aws_launch_configuration" "worker_conf" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 0}"
+    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
   }
 }
 


### PR DESCRIPTION
This is to prevent Terraform from re-creating the master and worker nodes right away after a deployment where root_volume_type is not io1.

Issue #1035 is reproduced exactly the same for master and worker nodes.

###### References
- https://github.com/coreos/tectonic-installer/issues/1035
- https://github.com/coreos/tectonic-installer/pull/1166
- https://github.com/coreos/tectonic-installer/commit/93d485d9