### PR TITLE
vmware: calico network policy support fixes

### DIFF
--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -79,6 +79,7 @@ module "workers" {
 
   kubelet_node_label  = "node-role.kubernetes.io/node"
   kubelet_node_taints = ""
+  kubelet_cni_bin_dir = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kube_dns_service_ip = "${module.bootkube.kube_dns_service_ip}"
   container_images    = "${var.tectonic_container_images}"
   bootkube_service    = ""
@@ -98,5 +99,4 @@ module "workers" {
   kubeconfig              = "${module.bootkube.kubeconfig}"
   private_key             = "${var.tectonic_vmware_ssh_private_key_path}"
   image_re                = "${var.tectonic_image_re}"
-  kubelet_cni_bin_dir     = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
 }

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -98,4 +98,5 @@ module "workers" {
   kubeconfig              = "${module.bootkube.kubeconfig}"
   private_key             = "${var.tectonic_vmware_ssh_private_key_path}"
   image_re                = "${var.tectonic_image_re}"
+  kubelet_cni_bin_dir     = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
 }

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -116,6 +116,6 @@ data "archive_file" "assets" {
   #
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
-  # folder, we write it in the TerraForm managed hidden folder `.terraform`.
-  output_path = "${path.cwd}/.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id} ${module.flannel-vxlan.id} ${module.calico-network-policy.id})}.zip"
+  # folder, we write it in the TerraForm managed hidden folder `.terraform`.  
+  output_path = "./.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id} ${module.flannel-vxlan.id} ${module.calico-network-policy.id}")}.zip"
 }


### PR DESCRIPTION
Follow up on https://github.com/coreos/tectonic-installer/pull/780

fixes:
- syntax error for archive_file resource for assets (copy pasted from AWS; https://github.com/coreos/tectonic-installer/blob/master/platforms/aws/tectonic.tf#L139
- add `kubelet_cni_bin_dir` missing variable to workers https://github.com/coreos/tectonic-installer/blob/master/platforms/aws/main.tf#L138

/cc : @abhinavdahiya