### PR TITLE
modules/tectonic/resources: collect initial tectonic version

### DIFF
--- a/modules/tectonic/resources/manifests/stats-emitter.yaml
+++ b/modules/tectonic/resources/manifests/stats-emitter.yaml
@@ -28,6 +28,7 @@ spec:
         - --extension=installerPlatform:$(INSTALLER_PLATFORM)
         - --extension=tectonicUpdaterEnabled:$(TECTONIC_UPDATER_ENABLED)
         - --extension=certificatesStrategy:$(CERTIFICATES_STRATEGY)
+        - --extension=initialTectonicVersion:$(INITIAL_TECTONIC_VERSION)
         env:
         - name: INSTALLER_PLATFORM
           valueFrom:
@@ -44,6 +45,11 @@ spec:
             configMapKeyRef:
               name: tectonic-config
               key: tectonicUpdaterEnabled
+        - name: INITIAL_TECTONIC_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-config
+              key: tectonicVersion
         volumeMounts:
         - name: tectonic-license-secret
           mountPath: /etc/tectonic/licenses
@@ -80,6 +86,7 @@ spec:
           - --extension=installerPlatform:$(INSTALLER_PLATFORM)
           - --extension=tectonicUpdaterEnabled:$(TECTONIC_UPDATER_ENABLED)
           - --extension=certificatesStrategy:$(CERTIFICATES_STRATEGY)
+          - --extension=initialTectonicVersion:$(INITIAL_TECTONIC_VERSION)
         env:
         - name: INSTALLER_PLATFORM
           valueFrom:
@@ -96,6 +103,11 @@ spec:
             configMapKeyRef:
               name: tectonic-config
               key: tectonicUpdaterEnabled
+        - name: INITIAL_TECTONIC_VERSION
+          valueFrom:
+            configMapKeyRef:
+              name: tectonic-config
+              key: tectonicVersion
         volumeMounts:
         - mountPath: /etc/tectonic/licenses
           name: tectonic-license-secret


### PR DESCRIPTION
To provide better support and track any potential upgrade issues, we'd
like to begin tracking the version of Tectonic that was first installed
on a cluster using the variable `initialTectonicVersion`.

This commit uses the prefix `initial` since we will soon be also be collecting the currently installed version of Tectonic.
Fixes #445.

cc @sym3tri @s-urbaniak 