### PR TITLE
vmware: fix etcd vs master race condition

### DIFF
--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -26,7 +26,7 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_endpoints   = ["${module.etcd.endpoints}"]
+  etcd_endpoints   = "${formatlist("%s.%s", values(var.tectonic_vmware_etcd_hostnames), var.tectonic_base_domain)}"
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"


### PR DESCRIPTION
Intend to fix #1405 

**Background:**

Bootkube module requires a list of `etcd_endpoints`. In current implementation, list was generated thru modules.etcd output in platform/vmware. This creates implicit dependency for bootkube module on completion of module.etcd. On platform/vmware, all instances are (attempted to be) generated at the same time, constrained by the infrastructure  (vmware) provider's configuration limits. 

Consider a tectonic cluster with 3 etcd nodes, 2 masters and 2 works. All instance/VM generations are executed in parallel. If master nodes "win the race", bootkube module is not 100% completed (missing bootstrap assets as they depend on etcd nodes output) and `./generated` folder is SCP'ed without bootstrap manifests. If etcd nodes "win the race" of being provisioned first, module bootkube completes and all manifests are copied over to master to bootstrap the cluster succesfully.

**Change:**

Instead of relying on module.etcd output to generate bootkube assets, change transforms `tectonic_vmware_etcd_hostnames` map into fully qualified domain name list of etcd nodes. This removes the dependancy of module.bootkube-> module.etcd and ensures that bootkube assets get generated prior to etcd/master/worker nodes coming up online.

**Testing/Confirmation:**

To my best understanding, we've seen a prospect hit the issue. Working with @snsumner to confirm the issue and resolution.

