### PR TITLE
vmware - cloud-provider support

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -25,10 +25,12 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_master_vcpu | Master node(s) vCPU count | string | `1` |
 | tectonic_vmware_network | Portgroup to attach the cluster nodes | string | - |
 | tectonic_vmware_node_dns | DNS Server to be used by Virtual Machine(s). Multiple DNS servers can be separated by whitespace. Example: `"192.168.1.1 192.168.2.1"` | string | - |
+| tectonic_vmware_password | Password to use to configure Kubernetes - VMware vSphere Cloud provider. https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider | string | - |
 | tectonic_vmware_server | vCenter Server IP/FQDN | string | - |
 | tectonic_vmware_ssh_authorized_key | SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."` | string | - |
 | tectonic_vmware_ssh_private_key_path | SSH private key file in .pem format corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used. | string | `` |
 | tectonic_vmware_sslselfsigned | Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"` | string | - |
+| tectonic_vmware_username | Username to use to configure Kubernetes - VMware vSphere Cloud provider. https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider | string | - |
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_worker_datastore | The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -227,6 +227,9 @@ tectonic_vmware_network = ""
 // DNS Server to be used by Virtual Machine(s). Multiple DNS servers can be separated by whitespace. Example: `"192.168.1.1 192.168.2.1"`
 tectonic_vmware_node_dns = ""
 
+// Password to use to configure Kubernetes - VMware vSphere Cloud provider. https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider
+tectonic_vmware_password = ""
+
 // vCenter Server IP/FQDN
 tectonic_vmware_server = ""
 
@@ -238,6 +241,9 @@ tectonic_vmware_ssh_private_key_path = ""
 
 // Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"`
 tectonic_vmware_sslselfsigned = ""
+
+// Username to use to configure Kubernetes - VMware vSphere Cloud provider. https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider
+tectonic_vmware_username = ""
 
 // Virtual Machine template of CoreOS Container Linux.
 tectonic_vmware_vm_template = ""

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -77,8 +77,8 @@ resource "template_dir" "bootkube" {
     cloud_provider             = "${var.cloud_provider}"
     cloud_provider_config      = "${var.cloud_provider_config}"
     cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
-    cloud_provider_volume      = "${var.cloud_provider == "vsphere" ? "- name: vspheredmi \n        hostPath: \n          path: /sys/class/dmi/id/product_serial" : ""}"
-    cloud_provider_volumemount = "${var.cloud_provider == "vsphere" ? "- mountPath: /sys/class/dmi/id/product_serial \n          name: vspheredmi" : ""}"
+    cloud_provider_volume      = "${var.volume_name == "" ? "" : "- name: ${var.volume_name} \n        hostPath: \n          path: ${var.volume_host_path}" }"
+    cloud_provider_volumemount = "${var.volume_name == "" ? "" : "- mountPath: ${var.volume_mount_path} \n          name: ${var.volume_name}" }"
 
     cluster_cidr        = "${var.cluster_cidr}"
     service_cidr        = "${var.service_cidr}"
@@ -137,8 +137,8 @@ resource "template_dir" "bootkube_bootstrap" {
     cloud_provider             = "${var.cloud_provider}"
     cloud_provider_config      = "${var.cloud_provider_config}"
     cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
-    cloud_provider_volume      = "${var.cloud_provider == "vsphere" ? "- name: vspheredmi \n    hostPath: \n      path: /sys/class/dmi/id/product_serial" : ""}"
-    cloud_provider_volumemount = "${var.cloud_provider == "vsphere" ? "- mountPath: /sys/class/dmi/id/product_serial \n      name: vspheredmi" : ""}"
+    cloud_provider_volume      = "${var.volume_name == "" ? "" : "- name: ${var.volume_name} \n    hostPath: \n      path: ${var.volume_host_path}" }"
+    cloud_provider_volumemount = "${var.volume_name == "" ? "" : "- mountPath: ${var.volume_mount_path} \n      name: ${var.volume_name}" }"
 
     advertise_address = "${var.advertise_address}"
     cluster_cidr      = "${var.cluster_cidr}"

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -77,6 +77,8 @@ resource "template_dir" "bootkube" {
     cloud_provider             = "${var.cloud_provider}"
     cloud_provider_config      = "${var.cloud_provider_config}"
     cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
+    cloud_provider_volume      = "${var.cloud_provider == "vsphere" ? "- name: vspheredmi \n        hostPath: \n          path: /sys/class/dmi/id/product_serial" : ""}"
+    cloud_provider_volumemount = "${var.cloud_provider == "vsphere" ? "- mountPath: /sys/class/dmi/id/product_serial \n          name: vspheredmi" : ""}"
 
     cluster_cidr        = "${var.cluster_cidr}"
     service_cidr        = "${var.service_cidr}"
@@ -135,6 +137,8 @@ resource "template_dir" "bootkube_bootstrap" {
     cloud_provider             = "${var.cloud_provider}"
     cloud_provider_config      = "${var.cloud_provider_config}"
     cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
+    cloud_provider_volume      = "${var.cloud_provider == "vsphere" ? "- name: vspheredmi \n    hostPath: \n      path: /sys/class/dmi/id/product_serial" : ""}"
+    cloud_provider_volumemount = "${var.cloud_provider == "vsphere" ? "- mountPath: /sys/class/dmi/id/product_serial \n      name: vspheredmi" : ""}"
 
     advertise_address = "${var.advertise_address}"
     cluster_cidr      = "${var.cluster_cidr}"

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -48,6 +48,7 @@ spec:
     - mountPath: /var/lock
       name: var-lock
       readOnly: false
+    ${cloud_provider_volumemount}
   hostNetwork: true
   volumes:
   - name: secrets
@@ -62,6 +63,7 @@ spec:
   - name: var-lock
     hostPath:
       path: /var/lock
+  ${cloud_provider_volume}
   updateStrategy:
     rollingUpdate:
     maxUnavailable: 1

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -26,6 +26,7 @@ spec:
     - name: ssl-host
       mountPath: /etc/ssl/certs
       readOnly: true
+    ${cloud_provider_volumemount}
   hostNetwork: true
   volumes:
   - name: etc-kubernetes
@@ -34,3 +35,4 @@ spec:
   - name: ssl-host
     hostPath:
       path: /usr/share/ca-certificates
+  ${cloud_provider_volume} 

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -77,6 +77,7 @@ spec:
         - mountPath: /var/log/kubernetes
           name: var-log-kubernetes
           readOnly: false
+        ${cloud_provider_volumemount}
       hostNetwork: true
       tolerations:
       - key: "CriticalAddonsOnly"
@@ -102,3 +103,4 @@ spec:
       - name: var-log-kubernetes
         hostPath:
           path: /var/log/kubernetes
+      ${cloud_provider_volume}

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -66,6 +66,7 @@ spec:
         - name: ssl-host
           mountPath: /etc/ssl/certs
           readOnly: true
+        ${cloud_provider_volumemount}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       securityContext:
@@ -87,4 +88,5 @@ spec:
       - name: ssl-host
         hostPath:
           path: /usr/share/ca-certificates
+      ${cloud_provider_volume}
       dnsPolicy: Default # Don't use cluster DNS.

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -129,3 +129,21 @@ variable "pod_eviction_timeout" {
   type        = "string"
   default     = "5m"
 }
+
+variable "volume_name" {
+  description = "Volume name to mount on API Server and Controller Manager pods."
+  type        = "string"
+  default     = ""
+}
+
+variable "volume_mount_path" {
+  description = "Pod Volume path to mount in API Server and Controller Manager pods."
+  type        = "string"
+  default     = ""
+}
+
+variable "volume_host_path" {
+  description = "Host pad to mount on API Server and Controller Manager pods."
+  type        = "string"
+  default     = ""
+}

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -48,13 +48,14 @@ EOF
     },
   ]
 }
+
 data "ignition_file" "cloud-provider-config" {
   filesystem = "root"
   path       = "/etc/kubernetes/cloud/config"
   mode       = 0600
-  content {
-  }
-    content = "${var.cloud_provider_config}"
+  content    = {}
+
+  content = "${var.cloud_provider_config}"
 }
 
 data "ignition_systemd_unit" "bootkube" {

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -39,8 +39,12 @@ data "ignition_systemd_unit" "vmtoolsd" {
 
   dropin = [
     {
-      content = "[Service]\nExecStartPost=/bin/chmod 444 /sys/class/dmi/id/product_serial"
-      name    = "10-vmtools-perm.conf"
+      name = "10-vmtools-perm.conf"
+
+      content = <<EOF
+[Service]
+ExecStartPost=/bin/chmod 444 /sys/class/dmi/id/product_serial
+EOF
     },
   ]
 }

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -53,9 +53,9 @@ data "ignition_file" "cloud-provider-config" {
   filesystem = "root"
   path       = "/etc/kubernetes/cloud/config"
   mode       = 0600
-  content    = {}
-
-  content = "${var.cloud_provider_config}"
+  content    = {
+    content = "${var.cloud_provider_config}"
+  }
 }
 
 data "ignition_systemd_unit" "bootkube" {

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -8,6 +8,7 @@ data "ignition_config" "node" {
   files = [
     "${var.ign_max_user_watches_id}",
     "${data.ignition_file.node_hostname.*.id[count.index]}",
+    "${data.ignition_file.cloud-provider-config.id}",
     "${var.ign_kubelet_env_id}",
   ]
 
@@ -18,6 +19,7 @@ data "ignition_config" "node" {
     "${var.ign_kubelet_env_service_id}",
     "${data.ignition_systemd_unit.bootkube.id}",
     "${data.ignition_systemd_unit.tectonic.id}",
+    "${data.ignition_systemd_unit.vmtoolsd.id}",
   ]
 
   networkd = [
@@ -28,6 +30,27 @@ data "ignition_config" "node" {
 data "ignition_user" "core" {
   name                = "core"
   ssh_authorized_keys = ["${var.core_public_keys}"]
+}
+
+# Grant read access to /sys/class/dmi/id/product_serial all users.
+# This is required since kubernetes controller-manager running as "nobody" needs read permissions to the sysfs path
+data "ignition_systemd_unit" "vmtoolsd" {
+  name = "vmtoolsd.service"
+
+  dropin = [
+    {
+      content = "[Service]\nExecStartPost=/bin/chmod 444 /sys/class/dmi/id/product_serial"
+      name    = "10-vmtools-perm.conf"
+    },
+  ]
+}
+data "ignition_file" "cloud-provider-config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+  content {
+  }
+    content = "${var.cloud_provider_config}"
 }
 
 data "ignition_systemd_unit" "bootkube" {

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -21,6 +21,7 @@ resource "vsphere_virtual_machine" "node" {
   custom_configuration_parameters {
     guestinfo.coreos.config.data.encoding = "base64"
     guestinfo.coreos.config.data          = "${base64encode(data.ignition_config.node.*.rendered[count.index])}"
+    disk.enableUUID                       = "1"
   }
 
   connection {

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -121,3 +121,8 @@ variable "ign_kubelet_env_service_id" {
   type        = "string"
   description = "The kubelet env service to use"
 }
+
+variable "cloud_provider_config" {
+  description = "Content of cloud provider config"
+  type        = "string"
+}

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -47,13 +47,13 @@ data "template_file" "cloud-provider" {
   template = "${file("${path.module}/resources/cloud-config.ini")}"
 
   vars {
-    cloud-config-username     = "${var.tectonic_vmware_username}"
-    cloud-config-password     = "${var.tectonic_vmware_password}"
-    cloud-config-server       = "${var.tectonic_vmware_server}"
-    cloud-config-insecureflag = "${var.tectonic_vmware_sslselfsigned}"
-    cloud-config-datacenter   = "${var.tectonic_vmware_datacenter}"
-    cloud-config-datastore    = "${var.tectonic_vmware_datastore}"
-    cloud-config-workingdir   = "${vsphere_folder.tectonic_vsphere_folder.path}"
+    cloud_config_username     = "${var.tectonic_vmware_username}"
+    cloud_config_password     = "${var.tectonic_vmware_password}"
+    cloud_config_server       = "${var.tectonic_vmware_server}"
+    cloud_config_insecureflag = "${var.tectonic_vmware_sslselfsigned}"
+    cloud_config_datacenter   = "${var.tectonic_vmware_datacenter}"
+    cloud_config_datastore    = "${var.tectonic_vmware_datastore}"
+    cloud_config_workingdir   = "${vsphere_folder.tectonic_vsphere_folder.path}"
   }
 }
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -91,7 +91,7 @@ module "masters" {
   ign_kubelet_service_id     = "${module.ignition_masters.kubelet_service_id}"
   ign_locksmithd_service_id  = "${module.ignition_masters.locksmithd_service_id}"
   ign_max_user_watches_id    = "${module.ignition_masters.max_user_watches_id}"
-  cloud_provider_config   = "${data.template_file.cloud-provider.rendered}"
+  cloud_provider_config      = "${data.template_file.cloud-provider.rendered}"
 }
 
 module "ignition_workers" {
@@ -138,5 +138,5 @@ module "workers" {
   ign_kubelet_service_id     = "${module.ignition_workers.kubelet_service_id}"
   ign_locksmithd_service_id  = "${module.ignition_workers.locksmithd_service_id}"
   ign_max_user_watches_id    = "${module.ignition_workers.max_user_watches_id}"
-  cloud_provider_config   = "${data.template_file.cloud-provider.rendered}"
+  cloud_provider_config      = "${data.template_file.cloud-provider.rendered}"
 }

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -41,6 +41,8 @@ module "ignition_masters" {
   kubelet_cni_bin_dir = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kubelet_node_label  = "node-role.kubernetes.io/master"
   kubelet_node_taints = "node-role.kubernetes.io/master=:NoSchedule"
+  cloud_provider        = "vsphere"
+  cloud_provider_config = "${data.template_file.cloud-provider.rendered}"
 }
 
 data "template_file" "cloud-provider" {
@@ -51,8 +53,7 @@ data "template_file" "cloud-provider" {
     cloud_config_password     = "${var.tectonic_vmware_password}"
     cloud_config_server       = "${var.tectonic_vmware_server}"
     cloud_config_insecureflag = "${var.tectonic_vmware_sslselfsigned}"
-    cloud_config_datacenter   = "${var.tectonic_vmware_datacenter}"
-    cloud_config_datastore    = "${var.tectonic_vmware_datastore}"
+    cloud_config_datacenter   = "${var.tectonic_vmware_datacenter}"    
     cloud_config_workingdir   = "${vsphere_folder.tectonic_vsphere_folder.path}"
   }
 }
@@ -103,6 +104,8 @@ module "ignition_workers" {
   kubelet_cni_bin_dir = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kubelet_node_label  = "node-role.kubernetes.io/node"
   kubelet_node_taints = ""
+  cloud_provider        = "vsphere"
+  cloud_provider_config = "${data.template_file.cloud-provider.rendered}"
 }
 
 module "workers" {

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -43,6 +43,20 @@ module "ignition_masters" {
   kubelet_node_taints = "node-role.kubernetes.io/master=:NoSchedule"
 }
 
+data "template_file" "cloud-provider" {
+  template = "${file("${path.module}/resources/cloud-config.ini")}"
+
+  vars {
+    cloud-config-username     = "${var.tectonic_vmware_username}"
+    cloud-config-password     = "${var.tectonic_vmware_password}"
+    cloud-config-server       = "${var.tectonic_vmware_server}"
+    cloud-config-insecureflag = "${var.tectonic_vmware_sslselfsigned}"
+    cloud-config-datacenter   = "${var.tectonic_vmware_datacenter}"
+    cloud-config-datastore    = "${var.tectonic_vmware_datastore}"
+    cloud-config-workingdir   = "${vsphere_folder.tectonic_vsphere_folder.path}"
+  }
+}
+
 module "masters" {
   source           = "../../modules/vmware/node"
   instance_count   = "${var.tectonic_master_count}"
@@ -77,6 +91,7 @@ module "masters" {
   ign_kubelet_service_id     = "${module.ignition_masters.kubelet_service_id}"
   ign_locksmithd_service_id  = "${module.ignition_masters.locksmithd_service_id}"
   ign_max_user_watches_id    = "${module.ignition_masters.max_user_watches_id}"
+  cloud_provider_config   = "${data.template_file.cloud-provider.rendered}"
 }
 
 module "ignition_workers" {
@@ -123,4 +138,5 @@ module "workers" {
   ign_kubelet_service_id     = "${module.ignition_workers.kubelet_service_id}"
   ign_locksmithd_service_id  = "${module.ignition_workers.locksmithd_service_id}"
   ign_max_user_watches_id    = "${module.ignition_workers.max_user_watches_id}"
+  cloud_provider_config   = "${data.template_file.cloud-provider.rendered}"
 }

--- a/platforms/vmware/resources/cloud-config.ini
+++ b/platforms/vmware/resources/cloud-config.ini
@@ -1,0 +1,10 @@
+[Global]
+    user = ${cloud-config-username}
+    password = ${cloud-config-password}
+    server = ${cloud-config-server}
+    insecure-flag = ${cloud-config-insecureflag}
+    datacenter = ${cloud-config-datacenter}
+    datastore = ${cloud-config-datastore}
+    working-dir = ${cloud-config-workingdir}
+[Disk]
+    scsicontrollertype = pvscsi

--- a/platforms/vmware/resources/cloud-config.ini
+++ b/platforms/vmware/resources/cloud-config.ini
@@ -3,8 +3,7 @@
     password = ${cloud_config_password}
     server = ${cloud_config_server}
     insecure-flag = ${cloud_config_insecureflag}
-    datacenter = ${cloud_config_datacenter}
-    datastore = ${cloud_config_datastore}
+    datacenter = ${cloud_config_datacenter}    
     working-dir = ${cloud_config_workingdir}
 [Disk]
     scsicontrollertype = pvscsi

--- a/platforms/vmware/resources/cloud-config.ini
+++ b/platforms/vmware/resources/cloud-config.ini
@@ -1,10 +1,10 @@
 [Global]
-    user = ${cloud-config-username}
-    password = ${cloud-config-password}
-    server = ${cloud-config-server}
-    insecure-flag = ${cloud-config-insecureflag}
-    datacenter = ${cloud-config-datacenter}
-    datastore = ${cloud-config-datastore}
-    working-dir = ${cloud-config-workingdir}
+    user = ${cloud_config_username}
+    password = ${cloud_config_password}
+    server = ${cloud_config_server}
+    insecure-flag = ${cloud_config_insecureflag}
+    datacenter = ${cloud_config_datacenter}
+    datastore = ${cloud_config_datastore}
+    working-dir = ${cloud_config_workingdir}
 [Disk]
     scsicontrollertype = pvscsi

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -2,6 +2,9 @@ module "bootkube" {
   source                = "../../modules/bootkube"
   cloud_provider        = "vsphere"
   cloud_provider_config = "${data.template_file.cloud-provider.rendered}"
+  volume_name           = "vspheredmi"
+  volume_host_path      = "/sys/class/dmi/id/product_serial"
+  volume_mount_path     = "/sys/class/dmi/id/product_serial"
 
   cluster_name = "${var.tectonic_cluster_name}"
 

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -1,6 +1,7 @@
 module "bootkube" {
-  source         = "../../modules/bootkube"
-  cloud_provider = ""
+  source                = "../../modules/bootkube"
+  cloud_provider        = "vsphere"
+  cloud_provider_config = "${data.template_file.cloud-provider.rendered}"
 
   cluster_name = "${var.tectonic_cluster_name}"
 

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -15,6 +15,16 @@ variable "tectonic_vmware_server" {
   description = "vCenter Server IP/FQDN"
 }
 
+variable "tectonic_vmware_username" {
+  type        = "string"
+  description = "Username to use to configure Kubernetes - VMware vSphere Cloud provider. https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider"
+}
+
+variable "tectonic_vmware_password" {
+  type        = "string"
+  description = "Password to use to configure Kubernetes - VMware vSphere Cloud provider. https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider "
+}
+
 variable "tectonic_vmware_sslselfsigned" {
   type        = "string"
   description = "Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = \"true\"` "


### PR DESCRIPTION
PR to support VMware Kubernetes integration, building on the Azure cloud-provider work.

**Background:**

Upstream VMware vSphere cloud-provider documentation is located in; https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider. 

At a high level:
- cloud-provider integration allows Storage Class/Dynamic storage provisioning in VMware environment
- Requires ini formatted cloud-provider configuration file to be available to; kubelet, api-server, controller-manager components.
- ini file contains variables mostly collected already with exceptions of; `tectonic_vmware_username` , `tectonic_vmware_password`. 
- [Upstream documentation](https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider) notes the use of `port` parameter. Per [upstream code](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/vsphere/vsphere.go#L335-L337) ; "port is a deprecated field in vsphere.conf and will be removed in future release.", thus not included in the configuration

**Changes**

- Introduces additional variables required for setting up cloud-provider, namely username/password. Currently, at runtime, user is prompted for username/password pairs require to provision the infrastructure. This set of credentials is different than the cloud-provider username/password. At provision time, end user will need additional rights in VMware infrastructure then [cloud-provider requirements](https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider) for cloud-provider credentials, which only need to provision disks and attach them.
- Uses a template_file under platforms/vmware in order to generate `/etc/kubernetes/cloud/config` file contents. 
- kubelet service is configured to use `cloud-provider` and `cloud-config` flags on all (non-etcd) nodes 
- `disk.enableUUID` is added to Virtual Machine provisioning per; https://kubernetes.io/docs/getting-started-guides/vsphere/#configuring-vsphere-cloud-provider

**Need Feedback**

VMware cloud provider requires variable `vm-uuid = <VM Instance UUID of virtual machine which can be retrieved from instanceUuid property in VmConfigInfo, or also set as vc.uuid in VMX file. If empty, will be retrieved from sysfs (requires root)>`

This requirement puts constrains to implementation such as;
- cannot use ignition to provision cloud-config file with `vm-uuid` statically, as this variable is generated once the machine is provisioned
- cannot use kubernetes secrets/configmaps to set `vm-uuid` as this would restrict control-manager pod's mobility (vm-uuid is bound per Virtual Machine/instance) to a single node.
- control-manager runs as user "nobody" introducing access denied issues to volume mount for `/sys/class/dmi/id/product_serial`

The implementation attempts to walk around these constrains via;
- using host mounts for api-server, controller-manager specifically to vmware environment, so `vm-uuid` can be dynamically retrieved from `/sys/class/dmi/id/product_serial`
- sets `/sys/class/dmi/id/product_serial` to readable by un-privileged user via systemd unit drop-in to VMware only systemd unit.

Would love to hear feedback from the team for cleaner implementation.

