### PR TITLE
tests/aws: Remove tectonic_admin_password_hash/email from the tfvars to use jenkins env variables

### DIFF
--- a/tests/smoke/aws/vars/aws-ca.tfvars
+++ b/tests/smoke/aws/vars/aws-ca.tfvars
@@ -10,10 +10,6 @@ tectonic_base_domain = "tectonic.dev.coreos.systems"
 
 tectonic_cl_channel = "stable"
 
-tectonic_admin_email = "example@coreos.com"
-
-tectonic_admin_password_hash = "$2a$12$T8hTe.NlOPDP0SS3DxNeDuVhHSFbdGXZEhGps/W.BG4QC7.1/nDaG"
-
 tectonic_ca_cert = "../../examples/fake-creds/ca.crt"
 
 tectonic_ca_key = "../../examples/fake-creds/ca.key"

--- a/tests/smoke/aws/vars/aws-exp-np.tfvars
+++ b/tests/smoke/aws/vars/aws-exp-np.tfvars
@@ -6,10 +6,6 @@ tectonic_base_domain = "tectonic.dev.coreos.systems"
 
 tectonic_cl_channel = "stable"
 
-tectonic_admin_email = "example@coreos.com"
-
-tectonic_admin_password_hash = "$2a$12$T8hTe.NlOPDP0SS3DxNeDuVhHSFbdGXZEhGps/W.BG4QC7.1/nDaG"
-
 tectonic_ca_cert = ""
 
 tectonic_ca_key = ""

--- a/tests/smoke/aws/vars/aws-exp.tfvars
+++ b/tests/smoke/aws/vars/aws-exp.tfvars
@@ -6,10 +6,6 @@ tectonic_base_domain = "tectonic.dev.coreos.systems"
 
 tectonic_cl_channel = "stable"
 
-tectonic_admin_email = "example@coreos.com"
-
-tectonic_admin_password_hash = "$2a$12$T8hTe.NlOPDP0SS3DxNeDuVhHSFbdGXZEhGps/W.BG4QC7.1/nDaG"
-
 tectonic_ca_cert = ""
 
 tectonic_ca_key = ""

--- a/tests/smoke/aws/vars/aws-tls.tfvars
+++ b/tests/smoke/aws/vars/aws-tls.tfvars
@@ -10,10 +10,6 @@ tectonic_base_domain = "tectonic.dev.coreos.systems"
 
 tectonic_cl_channel = "stable"
 
-tectonic_admin_email = "example@coreos.com"
-
-tectonic_admin_password_hash = "$2a$12$T8hTe.NlOPDP0SS3DxNeDuVhHSFbdGXZEhGps/W.BG4QC7.1/nDaG"
-
 tectonic_ca_cert = ""
 
 tectonic_ca_key = ""

--- a/tests/smoke/aws/vars/aws-vpc.tfvars
+++ b/tests/smoke/aws/vars/aws-vpc.tfvars
@@ -10,10 +10,6 @@ tectonic_base_domain = "tectonic.dev.coreos.systems"
 
 tectonic_cl_channel = "stable"
 
-tectonic_admin_email = "example@coreos.com"
-
-tectonic_admin_password_hash = "$2a$12$T8hTe.NlOPDP0SS3DxNeDuVhHSFbdGXZEhGps/W.BG4QC7.1/nDaG"
-
 tectonic_ca_cert = ""
 
 tectonic_ca_key = ""

--- a/tests/smoke/aws/vars/aws.tfvars
+++ b/tests/smoke/aws/vars/aws.tfvars
@@ -10,10 +10,6 @@ tectonic_base_domain = "tectonic.dev.coreos.systems"
 
 tectonic_cl_channel = "stable"
 
-tectonic_admin_email = "example@coreos.com"
-
-tectonic_admin_password_hash = "$2a$12$T8hTe.NlOPDP0SS3DxNeDuVhHSFbdGXZEhGps/W.BG4QC7.1/nDaG"
-
 tectonic_ca_cert = ""
 
 tectonic_ca_key = ""


### PR DESCRIPTION
Fixes #1367 