### PR TITLE
*: enable debug logging for etcd-operator by default

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -55,7 +55,7 @@ variable "tectonic_container_images" {
     flannel                         = "quay.io/coreos/flannel:v0.7.1-amd64"
     flannel_cni                     = "quay.io/coreos/flannel-cni:0.1.0"
     etcd                            = "quay.io/coreos/etcd:v3.1.8"
-    etcd_operator                   = "quay.io/coreos/etcd-operator:v0.4.0"
+    etcd_operator                   = "quay.io/coreos/etcd-operator:v0.4.2"
     kenc                            = "quay.io/coreos/kenc:8f6e2e885f790030fbbb0496ea2a2d8830e58b8f"
     calico                          = "quay.io/calico/node:v1.3.0"
     calico_cni                      = "quay.io/calico/cni:v1.9.1-4-g23fcd5f"

--- a/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
+++ b/modules/bootkube/resources/experimental/manifests/etcd-operator.yaml
@@ -16,7 +16,11 @@ spec:
     metadata: 
       labels: 
         k8s-app: etcd-operator
-    spec: 
+    spec:
+      volumes:
+      - name: debug-volume
+        hostPath:
+          path: /var/tmp
       containers: 
         - env: 
             - name: MY_POD_NAMESPACE
@@ -31,6 +35,12 @@ spec:
               value: /tmp
           image: ${etcd_operator_image}
           name: etcd-operator
+          command:
+          - /usr/local/bin/etcd-operator
+          - --debug-logfile-path=/var/tmp/etcd-operator/debug/debug.log
+          volumeMounts:
+          - mountPath: /var/tmp/etcd-operator/debug
+            name: debug-volume
       nodeSelector:
         node-role.kubernetes.io/master: ""
       securityContext:


### PR DESCRIPTION
This PR enables the debug logging feature introduced in etcd-operator 0.4.2.
https://github.com/coreos/etcd-operator/pull/1232

The operator will now write logs for certain critical actions(like pod creation/deletion) to a logfile, which will be persisted to an underlying hostPath volume on the node where the operator pod happens to run. 

This logfile helps in debugging failed clusters where the logs for Kubernetes pods are no longer available. The logfile can be retrieved if the nodes of the failed cluster are still accessible by ssh.

/cc @xiang90 @hongchaodeng @coresolve 