### PR TITLE
readme: fix broken step for running tests on local machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Tests can be run locally by:
 ```
 export PLATFORM="aws"
 export AWS_REGION="us-east-1"
-export TF_VAR_tectonic_cluster_name=my-smoke-test
+export {TF_VAR_tectonic_cluster_name,CLUSTER}=my-smoke-test
 export TF_VAR_tectonic_license_path=/path/to/license.txt
 export TF_VAR_tectonic_pull_secret_path=/path/to/pull-secret.json
 


### PR DESCRIPTION
Sets the CLUSTER value which is used by the Makefile to the same
value as TF_VAR_tectonic_cluster_name which is used in the symlink.