### PR TITLE
Removing extra "[]" from AWS templates 

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -136,7 +136,7 @@ Example: `["etcd1", "etcd2", "etcd3"]`
 EOF
 
   type    = "list"
-  default = [""]
+  default = []
 }
 
 variable "tectonic_etcd_tls_enabled" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -11,8 +11,8 @@ module "vpc" {
   cluster_name = "${var.tectonic_cluster_name}"
 
   external_vpc_id         = "${var.tectonic_aws_external_vpc_id}"
-  external_master_subnets = ["${compact(var.tectonic_aws_external_master_subnet_ids)}"]
-  external_worker_subnets = ["${compact(var.tectonic_aws_external_worker_subnet_ids)}"]
+  external_master_subnets = "${compact(var.tectonic_aws_external_master_subnet_ids)}"
+  external_worker_subnets = "${compact(var.tectonic_aws_external_worker_subnet_ids)}"
   cluster_id              = "${module.tectonic.cluster_id}"
   extra_tags              = "${var.tectonic_aws_extra_tags}"
   enable_etcd_sg          = "${!var.tectonic_experimental && length(compact(var.tectonic_etcd_servers)) == 0 ? 1 : 0}"
@@ -40,14 +40,14 @@ module "vpc" {
   worker_subnets = "${concat(values(var.tectonic_aws_worker_custom_subnets),list("padding"))}"
   # The split() / join() trick works around the limitation of ternary operator expressions 
   # only being able to return strings.
-  master_azs = ["${ split("|", "${length(keys(var.tectonic_aws_master_custom_subnets))}" > 0 ?
+  master_azs = "${ split("|", "${length(keys(var.tectonic_aws_master_custom_subnets))}" > 0 ?
     join("|", keys(var.tectonic_aws_master_custom_subnets)) :
     join("|", data.aws_availability_zones.azs.names)
-  )}"]
-  worker_azs = ["${ split("|", "${length(keys(var.tectonic_aws_worker_custom_subnets))}" > 0 ?
+  )}"
+  worker_azs = "${ split("|", "${length(keys(var.tectonic_aws_worker_custom_subnets))}" > 0 ?
     join("|", keys(var.tectonic_aws_worker_custom_subnets)) :
     join("|", data.aws_availability_zones.azs.names)
-  )}"]
+  )}"
 }
 
 module "etcd" {
@@ -61,13 +61,13 @@ module "etcd" {
   cl_channel      = "${var.tectonic_cl_channel}"
   container_image = "${var.tectonic_container_images["etcd"]}"
 
-  subnets = ["${module.vpc.worker_subnet_ids}"]
+  subnets = "${module.vpc.worker_subnet_ids}"
 
   dns_zone_id  = "${var.tectonic_aws_external_private_zone == "" ? join("", aws_route53_zone.tectonic-int.*.zone_id) : var.tectonic_aws_external_private_zone}"
   base_domain  = "${var.tectonic_base_domain}"
   cluster_name = "${var.tectonic_cluster_name}"
 
-  external_endpoints = ["${compact(var.tectonic_etcd_servers)}"]
+  external_endpoints = "${compact(var.tectonic_etcd_servers)}"
   cluster_id         = "${module.tectonic.cluster_id}"
   extra_tags         = "${var.tectonic_aws_extra_tags}"
 
@@ -106,7 +106,7 @@ module "masters" {
   cluster_name    = "${var.tectonic_cluster_name}"
   master_iam_role = "${var.tectonic_aws_master_iam_role_name}"
 
-  subnet_ids = ["${module.vpc.master_subnet_ids}"]
+  subnet_ids = "${module.vpc.master_subnet_ids}"
 
   master_sg_ids  = "${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
   api_sg_ids     = ["${module.vpc.api_sg_id}"]
@@ -155,7 +155,7 @@ module "workers" {
   worker_iam_role = "${var.tectonic_aws_worker_iam_role_name}"
 
   vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = ["${module.vpc.worker_subnet_ids}"]
+  subnet_ids = "${module.vpc.worker_subnet_ids}"
   sg_ids     = "${concat(var.tectonic_aws_worker_extra_sg_ids, list(module.vpc.worker_sg_id))}"
 
   ssh_key                      = "${var.tectonic_aws_ssh_key}"

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -23,7 +23,7 @@ module "bootkube" {
   oidc_groups_claim   = "groups"
   oidc_client_id      = "tectonic-kubectl"
 
-  etcd_endpoints   = ["${module.etcd.endpoints}"]
+  etcd_endpoints   = "${module.etcd.endpoints}"
   etcd_ca_cert     = "${var.tectonic_etcd_ca_cert_path}"
   etcd_client_cert = "${var.tectonic_etcd_client_cert_path}"
   etcd_client_key  = "${var.tectonic_etcd_client_key_path}"

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -121,7 +121,7 @@ Required to use an existing VPC and the list must match the AZ count.
 Example: `["subnet-111111", "subnet-222222", "subnet-333333"]`
 EOF
 
-  default = [""]
+  default = []
 }
 
 variable "tectonic_aws_external_worker_subnet_ids" {
@@ -134,7 +134,7 @@ Required to use an existing VPC and the list must match the AZ count.
 Example: `["subnet-111111", "subnet-222222", "subnet-333333"]`
 EOF
 
-  default = [""]
+  default = []
 }
 
 variable "tectonic_aws_extra_tags" {


### PR DESCRIPTION
#1071 This is addressing request for clean up. 

I was able to test this successfully.

According to Hashicorp with Terraform 0.11.0 one way of assigning values to lists/maps will be introduced, and the old way which required having `[]` will be removed. 

