### PR TITLE
modules/tectonic/resources: make console service ClusterIP

### DIFF
--- a/modules/tectonic/resources/manifests/console/service.yaml
+++ b/modules/tectonic/resources/manifests/console/service.yaml
@@ -10,7 +10,6 @@ spec:
   selector:
     k8s-app: tectonic-console
     component: ui
-  type: NodePort
   ports:
   - name: tectonic-console
     protocol: TCP


### PR DESCRIPTION
This commit removes the NodePort type from the Tectonic Console Service
so that the service takes the default type, ClusterIP. The rationale for
this change is that without a hardcoded NodePort port, the Tectonic
Console could randomly be assigned one of the ports that Tectonic
reserves for ingress. This causes tectonic.service unit to fail to
deploy the ingress service since the NodePorts it requests are already
assigned. The Tectonic Console service does not need to be assigned a
NodePort, in fact, that configuration is likely vestigial from before
Tectonic used an ingress controller to manage access to the console.

cc @s-urbaniak @Quentin-M 