### PR TITLE
images/tectonic-builder: Added 'grafiti' build step to image

### DIFF
--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -19,6 +19,13 @@ RUN go get github.com/jstemmer/go-junit-report
 ### License parser
 RUN go get github.com/coreos/license-bill-of-materials
 
+### 'grafiti' for cluster cleanup
+ENV GRAFITI_VERSION "v0.1.1"
+RUN git clone -q https://github.com/coreos/grafiti.git ${GOPATH}/src/github.com/coreos/grafiti \
+    && cd ${GOPATH}/src/github.com/coreos/grafiti \
+    && git checkout -q tags/${GRAFITI_VERSION} \
+    && make install
+
 # /go needs to be writable by jenkins user like it is in the upstream golang image
 RUN chmod 777 -R /go
 


### PR DESCRIPTION
tectonic-builder image should have grafiti installed for cluster cleanup.

Required for #1263 