### PR TITLE
tests: Add upstream terraform trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ def quay_creds = [
   )
 ]
 
-def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.35'
+def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.36'
 def tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v2.0'
 
 pipeline {

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -4,10 +4,16 @@
 # Node install inspired by: https://github.com/dockerfile/nodejs/blob/master/Dockerfile
 #
 # Update the builder image manually by running:
+# (See README.md/##Upstream-and-CoreOS-Terraform)
 #
-# docker build -f builder/Dockerfile .
-# docker tag <resulting-image-id> quay.io/coreos/tectonic-builder:<next-semver>
+# docker build -t quay.io/coreos/tectonic-builder:<next-semver> -f images/builder/Dockerfile .
 # docker push quay.io/coreos/tectonic-builder:<next-semver>
+#
+# docker build \
+# --build-arg TERRAFORM_URL=<upstream terraform download url> \
+# -t quay.io/coreos/tectonic-builder:<next-semver>-upstream-terraform \
+# -f images/builder/Dockerfile .
+# docker push quay.io/coreos/tectonic-builder:<next-semver>-upstream-terraform
 ###
 
 FROM golang:1.8.3-stretch
@@ -46,7 +52,10 @@ RUN apt-get update && \
     openvpn xvfb xauth
 
 # Install Terraform
-RUN curl -L https://github.com/coreos/terraform/releases/download/${TERRAFORM_VERSION}/linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
+# TERRAFORM_URL enables us to build the upstream-terraform Tectonic builder
+# image (See README.md/##Upstream-and-CoreOS-Terraform)
+ARG TERRAFORM_URL=https://github.com/coreos/terraform/releases/download/${TERRAFORM_VERSION}/linux_amd64.zip
+RUN curl -L ${TERRAFORM_URL} | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
 
 # Install NodeJS
 RUN cd /tmp && \

--- a/images/tectonic-builder/README.md
+++ b/images/tectonic-builder/README.md
@@ -6,3 +6,19 @@ This container image contains the environment required to build and test the
 [Tectonic Installer](../installer) and aims at facilitating the implementation
 of CI/CD pipelines. More particularly, this image is used in several Jenkins
 jobs today for testing purposes.
+
+## Upstream and CoreOS Terraform
+
+The Tectonic CI is currently using a custom Terraform version for the default
+pipeline (See https://github.com/coreos/tectonic-installer/pull/1247). As end
+users of Tectonic installer use upstream Terraform we need to test with upstream
+Terraform as well. We are building and publishing the Tectonic builder image
+both with CoreOS Terraform as well as upstream Terraform. This is done via
+docker `--build-arg` `TERRAFORM_URL`. CoreOS Terraform is used for normal PR and
+branch tests, upstream Terraform is used once per day on master.
+
+Example:
+- CoreOS Terraform (default):
+`docker build -t quay.io/coreos/tectonic-builder:v1.33 -f images/tectonic-builder/Dockerfile .`
+- Upstream Terraform:
+`docker build -t quay.io/coreos/tectonic-builder:v1.33-upstream-terraform --build-arg TERRAFORM_URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip -f images/tectonic-builder/Dockerfile .`

--- a/release.groovy
+++ b/release.groovy
@@ -20,7 +20,7 @@ def creds = [
   ]
 ]
 
-def builder_image = 'quay.io/coreos/tectonic-builder:v1.35'
+def builder_image = 'quay.io/coreos/tectonic-builder:v1.36'
 
 pipeline {
   agent none

--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -7,7 +7,7 @@ export PLATFORM=aws
 export CLUSTER="tf-${PLATFORM}-${BUILD_ID}"
 export TF_VAR_tectonic_pull_secret_path=${TF_VAR_tectonic_pull_secret_path}
 export TF_VAR_tectonic_license_path=${TF_VAR_tectonic_license_path}
-export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.35
+export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.36
 export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.7.1_coreos.0
 
 # Create an env var file

--- a/upstream-terraform-trigger.groovy
+++ b/upstream-terraform-trigger.groovy
@@ -1,0 +1,9 @@
+node {
+    build job: 'tectonic-installer/master',
+    parameters: [
+        string(
+            name: 'builder_image',
+            value: 'quay.io/coreos/tectonic-builder:v1.36-upstream-terraform'
+        )
+    ]
+}


### PR DESCRIPTION
We are currently using a custom terraform version for our default CI
pipeline (See https://github.com/coreos/tectonic-installer/pull/1247).
As end users of Tectonic installer use upstream terraform we need to
test with upstream terraform as well. We are building and publishing the
Tectonic builder image both with CoreOS Terraform as well as upstream
Terraform. This is done via docker `--build-arg` `TERRAFORM_URL`. CoreOS
Terraform is used for normal PR and branch tests, upstream Terraform is
used once per day on master.

* Add `--build-arg` `TERRAFORM_URL` to Tectonic builder Docker file
* Update documentation in tectonic-builder/README.md
* Add upstream-terraform-trigger.groovy pipeline job

With this commit v1.36 and v1.36-upstream-terraform of the Tectonic
builder images are pushed to quay.io/coreos/tectonic-builder. There
are no functional changes, but changes to the build order in the Dockerfile.

You can find the Jenkins job [here](https://jenkins-tectonic-installer.prod.coreos.systems/job/upstream-terraform-trigger/).