### PR TITLE
openstack: Configurable nameservers

### DIFF
--- a/Documentation/variables/openstack-neutron.md
+++ b/Documentation/variables/openstack-neutron.md
@@ -6,7 +6,8 @@ This document gives an overview of variables used in the Openstack/Neutron platf
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
-| tectonic_openstack_dns_nameservers | The DNS servers assigned to the generated OpenStack subnet resource. | list | `<list>` |
+| tectonic_openstack_dns_nameserver_1 | The first nameserver used by the nodes and the generated OpenStack subnet resource. | string | `8.8.8.8` |
+| tectonic_openstack_dns_nameserver_2 | The second nameserver used by the nodes and the generated OpenStack subnet resource. | string | `8.8.4.4` |
 | tectonic_openstack_etcd_flavor_id | (optional) The flavor id for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.<br><br>Note: Set either tectonic_openstack_etcd_flavor_name or tectonic_openstack_etcd_flavor_id. Note: This value is ignored for self-hosted etcd. | string | `` |
 | tectonic_openstack_etcd_flavor_name | (optional) The flavor name for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.<br><br>Note: Set either tectonic_openstack_etcd_flavor_name or tectonic_openstack_etcd_flavor_id. Note: This value is ignored for self-hosted etcd. | string | `` |
 | tectonic_openstack_external_gateway_id | The ID of the network to be used as the external internet gateway as given in `openstack network list`. | string | - |

--- a/Documentation/variables/openstack-neutron.md
+++ b/Documentation/variables/openstack-neutron.md
@@ -6,8 +6,7 @@ This document gives an overview of variables used in the Openstack/Neutron platf
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
-| tectonic_openstack_dns_nameserver_1 | The first nameserver used by the nodes and the generated OpenStack subnet resource. | string | `8.8.8.8` |
-| tectonic_openstack_dns_nameserver_2 | The second nameserver used by the nodes and the generated OpenStack subnet resource. | string | `8.8.4.4` |
+| tectonic_openstack_dns_nameservers | The nameservers used by the nodes and the generated OpenStack subnet resource.<br><br>Example: `["8.8.8.8", "8.8.4.4"]` | list | `<list>` |
 | tectonic_openstack_etcd_flavor_id | (optional) The flavor id for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.<br><br>Note: Set either tectonic_openstack_etcd_flavor_name or tectonic_openstack_etcd_flavor_id. Note: This value is ignored for self-hosted etcd. | string | `` |
 | tectonic_openstack_etcd_flavor_name | (optional) The flavor name for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.<br><br>Note: Set either tectonic_openstack_etcd_flavor_name or tectonic_openstack_etcd_flavor_id. Note: This value is ignored for self-hosted etcd. | string | `` |
 | tectonic_openstack_external_gateway_id | The ID of the network to be used as the external internet gateway as given in `openstack network list`. | string | - |

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -126,11 +126,10 @@ tectonic_license_path = ""
 // This applies only to cloud platforms.
 tectonic_master_count = "1"
 
-// The first nameserver used by the nodes and the generated OpenStack subnet resource.
-tectonic_openstack_dns_nameserver_1 = "8.8.8.8"
-
-// The second nameserver used by the nodes and the generated OpenStack subnet resource.
-tectonic_openstack_dns_nameserver_2 = "8.8.4.4"
+// The nameservers used by the nodes and the generated OpenStack subnet resource.
+// 
+// Example: `["8.8.8.8", "8.8.4.4"]`
+tectonic_openstack_dns_nameservers = ""
 
 // (optional) The flavor id for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.
 // 

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -127,10 +127,10 @@ tectonic_license_path = ""
 tectonic_master_count = "1"
 
 // The first nameserver used by the nodes and the generated OpenStack subnet resource.
-tectonic_openstack_dns_nameserver_1 = ""
+tectonic_openstack_dns_nameserver_1 = "8.8.8.8"
 
 // The second nameserver used by the nodes and the generated OpenStack subnet resource.
-tectonic_openstack_dns_nameserver_2 = ""
+tectonic_openstack_dns_nameserver_2 = "8.8.4.4"
 
 // (optional) The flavor id for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.
 // 

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -126,8 +126,11 @@ tectonic_license_path = ""
 // This applies only to cloud platforms.
 tectonic_master_count = "1"
 
-// The DNS servers assigned to the generated OpenStack subnet resource.
-tectonic_openstack_dns_nameservers = ""
+// The first nameserver used by the nodes and the generated OpenStack subnet resource.
+tectonic_openstack_dns_nameserver_1 = ""
+
+// The second nameserver used by the nodes and the generated OpenStack subnet resource.
+tectonic_openstack_dns_nameserver_2 = ""
 
 // (optional) The flavor id for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.
 // 

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -89,8 +89,7 @@ module "etcd" {
 
   resolv_conf_content = <<EOF
 search ${var.tectonic_base_domain}
-nameserver ${var.tectonic_openstack_dns_nameserver_1}
-nameserver ${var.tectonic_openstack_dns_nameserver_2}
+${join("\n", formatlist("nameserver %s", var.tectonic_openstack_dns_nameservers))}
 EOF
 
   base_domain           = "${var.tectonic_base_domain}"
@@ -123,8 +122,7 @@ module "master_nodes" {
 
   resolv_conf_content = <<EOF
 search ${var.tectonic_base_domain}
-nameserver ${var.tectonic_openstack_dns_nameserver_1}
-nameserver ${var.tectonic_openstack_dns_nameserver_2}
+${join("\n", formatlist("nameserver %s", var.tectonic_openstack_dns_nameservers))}
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
@@ -149,8 +147,7 @@ module "worker_nodes" {
 
   resolv_conf_content = <<EOF
 search ${var.tectonic_base_domain}
-nameserver ${var.tectonic_openstack_dns_nameserver_1}
-nameserver ${var.tectonic_openstack_dns_nameserver_2}
+${join("\n", formatlist("nameserver %s", var.tectonic_openstack_dns_nameservers))}
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -89,8 +89,8 @@ module "etcd" {
 
   resolv_conf_content = <<EOF
 search ${var.tectonic_base_domain}
-nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver ${var.tectonic_openstack_dns_nameserver_1}
+nameserver ${var.tectonic_openstack_dns_nameserver_2}
 EOF
 
   base_domain           = "${var.tectonic_base_domain}"
@@ -123,8 +123,8 @@ module "master_nodes" {
 
   resolv_conf_content = <<EOF
 search ${var.tectonic_base_domain}
-nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver ${var.tectonic_openstack_dns_nameserver_1}
+nameserver ${var.tectonic_openstack_dns_nameserver_2}
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"
@@ -149,8 +149,8 @@ module "worker_nodes" {
 
   resolv_conf_content = <<EOF
 search ${var.tectonic_base_domain}
-nameserver 8.8.8.8
-nameserver 8.8.4.4
+nameserver ${var.tectonic_openstack_dns_nameserver_1}
+nameserver ${var.tectonic_openstack_dns_nameserver_2}
 EOF
 
   kubeconfig_content           = "${module.bootkube.kubeconfig}"

--- a/platforms/openstack/neutron/network.tf
+++ b/platforms/openstack/neutron/network.tf
@@ -15,7 +15,7 @@ resource "openstack_networking_subnet_v2" "subnet" {
   cidr       = "${var.tectonic_openstack_subnet_cidr}"
   ip_version = 4
 
-  dns_nameservers = ["${var.tectonic_openstack_dns_nameserver_1}", "${var.tectonic_openstack_dns_nameserver_2}"]
+  dns_nameservers = ["${var.tectonic_openstack_dns_nameservers}"]
 }
 
 resource "openstack_networking_router_interface_v2" "interface" {

--- a/platforms/openstack/neutron/network.tf
+++ b/platforms/openstack/neutron/network.tf
@@ -15,7 +15,7 @@ resource "openstack_networking_subnet_v2" "subnet" {
   cidr       = "${var.tectonic_openstack_subnet_cidr}"
   ip_version = 4
 
-  dns_nameservers = ["${var.tectonic_openstack_dns_nameservers}"]
+  dns_nameservers = ["${var.tectonic_openstack_dns_nameserver_1}", "${var.tectonic_openstack_dns_nameserver_2}"]
 }
 
 resource "openstack_networking_router_interface_v2" "interface" {

--- a/platforms/openstack/neutron/variables.tf
+++ b/platforms/openstack/neutron/variables.tf
@@ -126,20 +126,13 @@ This CIDR will also be assigned to the created the OpenStack subnet resource.
 EOF
 }
 
-variable "tectonic_openstack_dns_nameserver_1" {
-  type    = "string"
-  default = "8.8.8.8"
+variable "tectonic_openstack_dns_nameservers" {
+  type    = "list"
+  default = ["8.8.8.8", "8.8.4.4"]
 
   description = <<EOF
-The first nameserver used by the nodes and the generated OpenStack subnet resource.
-EOF
-}
+The nameservers used by the nodes and the generated OpenStack subnet resource.
 
-variable "tectonic_openstack_dns_nameserver_2" {
-  type    = "string"
-  default = "8.8.4.4"
-
-  description = <<EOF
-The second nameserver used by the nodes and the generated OpenStack subnet resource.
+Example: `["8.8.8.8", "8.8.4.4"]`
 EOF
 }

--- a/platforms/openstack/neutron/variables.tf
+++ b/platforms/openstack/neutron/variables.tf
@@ -126,11 +126,20 @@ This CIDR will also be assigned to the created the OpenStack subnet resource.
 EOF
 }
 
-variable "tectonic_openstack_dns_nameservers" {
-  type    = "list"
-  default = []
+variable "tectonic_openstack_dns_nameserver_1" {
+  type    = "string"
+  default = "8.8.8.8"
 
   description = <<EOF
-The DNS servers assigned to the generated OpenStack subnet resource.
+The first nameserver used by the nodes and the generated OpenStack subnet resource.
+EOF
+}
+
+variable "tectonic_openstack_dns_nameserver_2" {
+  type    = "string"
+  default = "8.8.4.4"
+
+  description = <<EOF
+The second nameserver used by the nodes and the generated OpenStack subnet resource.
 EOF
 }


### PR DESCRIPTION
Make the nameservers configurable so users can choose whatever nameservers
they need to use. Also makes the nameserver usage consistent for both
the nodes and the generated OpenStack subnet resource. The same defaults
of the Google nameservers are still used.