### PR TITLE
fix condition where both flannel and calico drop same binaries

### DIFF
--- a/modules/net/calico-network-policy/resources/manifests/kube-calico.yaml
+++ b/modules/net/calico-network-policy/resources/manifests/kube-calico.yaml
@@ -228,6 +228,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # Set list of cni binaries that flannel-cni installs and calico should skip.
+            - name: SKIP_CNI_BINARIES
+              value: "bridge,cnitool,dhcp,flannel,host-local,ipvlan,loopback,macvlan,noop,portmap,ptp,tuning"
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: host-cni-bin


### PR DESCRIPTION
Both calico install-cni & flannel install-cni drop cni binaries. [this](https://github.com/projectcalico/cni-plugin/commit/23fcd5ff1990b1c9a33c7d1f6f4c437d0e6100e5) allows us to prevent calico drop binaries that flannel already does.

PR on [projectcalico/cni-plugin](https://github.com/projectcalico/cni-plugin/pull/341)