### PR TITLE
frontend: Success.canNavigateForward() should just return false

### DIFF
--- a/installer/frontend/components/success.jsx
+++ b/installer/frontend/components/success.jsx
@@ -63,6 +63,4 @@ export const Success = connect(stateToProps)(
   <button onClick={navigatePrevious} className="btn btn-link">Back</button> <button onClick={window.reset} className="btn btn-link pull-right">Start Over</button>
 </div>);
 
-Success.canNavigateForward = ({allDone}) => {
-  return allDone;
-};
+Success.canNavigateForward = () => false;


### PR DESCRIPTION
This is the last screen of the wizard, so `canNavigateForward()` should always return `false`. `allDone` appears to never be defined anyway.