### PR TITLE
modules/bootkube: generate flannel manifests in its own directory

### DIFF
--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -9,6 +9,8 @@ mkdir -p /etc/kubernetes/manifests/
 # Move optional experimental manifests into bootkube friendly locations
 [ -d /opt/tectonic/experimental ] && mv /opt/tectonic/experimental/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/experimental
 [ -d /opt/tectonic/bootstrap-experimental ] && mv /opt/tectonic/bootstrap-experimental/* /opt/tectonic/bootstrap-manifests/ && rm -r /opt/tectonic/bootstrap-experimental
+# Move network related manifests into bootkube friendly locations
+[ -d /opt/tectonic/net-manifests ] && mv /opt/tectonic/net-manifests/* /opt/tectonic/manifests/ && rm -r /opt/tectonic/net-manifests
 
 # shellcheck disable=SC2154
 /usr/bin/rkt run \

--- a/modules/net/calico-network-policy/assets.tf
+++ b/modules/net/calico-network-policy/assets.tf
@@ -9,14 +9,12 @@ data "template_file" "calico_network_policy" {
     calico_cni_image   = "${var.calico_cni_image}"
     cluster_cidr       = "${var.cluster_cidr}"
     host_cni_bin       = "/var/lib/cni/bin"
-
-    bootkube_id = "${var.bootkube_id}"
   }
 }
 
 resource "local_file" "calico_network_policy" {
-  count = "${ var.enabled ? 1 : 0 }"
+  count = "${var.enabled ? 1 : 0}"
 
   content  = "${data.template_file.calico_network_policy.rendered}"
-  filename = "./generated/manifests/kube-calico.yaml"
+  filename = "./generated/net-manifests/kube-calico.yaml"
 }

--- a/modules/net/calico-network-policy/outputs.tf
+++ b/modules/net/calico-network-policy/outputs.tf
@@ -1,5 +1,5 @@
 output "id" {
-  value = "${ var.enabled ? "${sha1("${join(" ", local_file.calico_network_policy.*.id)}")}" : "# calico policy disabled" }"
+  value = "${var.enabled ? "${sha1("${join(" ", local_file.calico_network_policy.*.id)}")}" : "# calico policy disabled"}"
 }
 
 output "name" {

--- a/modules/net/calico-network-policy/variables.tf
+++ b/modules/net/calico-network-policy/variables.tf
@@ -1,7 +1,3 @@
-variable "bootkube_id" {
-  type = "string"
-}
-
 variable "calico_image" {
   description = "Container image for calico node"
   type        = "string"

--- a/modules/net/flannel-vxlan/assets.tf
+++ b/modules/net/flannel-vxlan/assets.tf
@@ -6,8 +6,6 @@ data "template_file" "flannel" {
     flannel_cni_image = "${var.flannel_cni_image}"
     cluster_cidr      = "${var.cluster_cidr}"
     host_cni_bin      = "/var/lib/cni/bin"
-
-    bootkube_id = "${var.bootkube_id}"
   }
 }
 
@@ -15,5 +13,5 @@ resource "local_file" "flannel" {
   count = "${ var.enabled ? 1 : 0 }"
 
   content  = "${data.template_file.flannel.rendered}"
-  filename = "./generated/manifests/kube-flannel.yaml"
+  filename = "./generated/net-manifests/kube-flannel.yaml"
 }

--- a/modules/net/flannel-vxlan/outputs.tf
+++ b/modules/net/flannel-vxlan/outputs.tf
@@ -1,5 +1,5 @@
 output "id" {
-  value = "${ var.enabled ? "${sha1("${join(" ", local_file.flannel.*.id)}")}" : "# flannel disabled"}"
+  value = "${var.enabled ? "${sha1("${join(" ", local_file.flannel.*.id)}")}" : "# flannel disabled"}"
 }
 
 output "name" {

--- a/modules/net/flannel-vxlan/variables.tf
+++ b/modules/net/flannel-vxlan/variables.tf
@@ -1,7 +1,3 @@
-variable "bootkube_id" {
-  type = "string"
-}
-
 variable "flannel_image" {
   description = "Container image for flanneld"
   type        = "string"

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -114,8 +114,6 @@ module "flannel-vxlan" {
   flannel_image     = "${var.tectonic_container_images["flannel"]}"
   flannel_cni_image = "${var.tectonic_container_images["flannel_cni"]}"
   cluster_cidr      = "${var.tectonic_cluster_cidr}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 module "calico-network-policy" {
@@ -126,8 +124,6 @@ module "calico-network-policy" {
   calico_cni_image   = "${var.tectonic_container_images["calico_cni"]}"
   cluster_cidr       = "${var.tectonic_cluster_cidr}"
   enabled            = "${var.tectonic_calico_network_policy}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -85,8 +85,6 @@ module "flannel-vxlan" {
   flannel_image     = "${var.tectonic_container_images["flannel"]}"
   flannel_cni_image = "${var.tectonic_container_images["flannel_cni"]}"
   cluster_cidr      = "${var.tectonic_cluster_cidr}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 module "calico-network-policy" {
@@ -97,8 +95,6 @@ module "calico-network-policy" {
   calico_cni_image   = "${var.tectonic_container_images["calico_cni"]}"
   cluster_cidr       = "${var.tectonic_cluster_cidr}"
   enabled            = "${var.tectonic_calico_network_policy}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 resource "null_resource" "tectonic" {

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -93,8 +93,6 @@ module "flannel_vxlan" {
   flannel_image     = "${var.tectonic_container_images["flannel"]}"
   flannel_cni_image = "${var.tectonic_container_images["flannel_cni"]}"
   cluster_cidr      = "${var.tectonic_cluster_cidr}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 module "calico_network_policy" {
@@ -105,8 +103,6 @@ module "calico_network_policy" {
   calico_cni_image   = "${var.tectonic_container_images["calico_cni"]}"
   cluster_cidr       = "${var.tectonic_cluster_cidr}"
   enabled            = "${var.tectonic_calico_network_policy}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -230,8 +230,6 @@ module "flannel_vxlan" {
   flannel_image     = "${var.tectonic_container_images["flannel"]}"
   flannel_cni_image = "${var.tectonic_container_images["flannel_cni"]}"
   cluster_cidr      = "${var.tectonic_cluster_cidr}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 module "calico_network_policy" {
@@ -242,6 +240,4 @@ module "calico_network_policy" {
   calico_cni_image   = "${var.tectonic_container_images["calico_cni"]}"
   cluster_cidr       = "${var.tectonic_cluster_cidr}"
   enabled            = "${var.tectonic_calico_network_policy}"
-
-  bootkube_id = "${module.bootkube.id}"
 }

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -95,8 +95,6 @@ module "flannel-vxlan" {
   flannel_image     = "${var.tectonic_container_images["flannel"]}"
   flannel_cni_image = "${var.tectonic_container_images["flannel_cni"]}"
   cluster_cidr      = "${var.tectonic_cluster_cidr}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 module "calico-network-policy" {
@@ -107,8 +105,6 @@ module "calico-network-policy" {
   calico_cni_image   = "${var.tectonic_container_images["calico_cni"]}"
   cluster_cidr       = "${var.tectonic_cluster_cidr}"
   enabled            = "${var.tectonic_calico_network_policy}"
-
-  bootkube_id = "${module.bootkube.id}"
 }
 
 data "archive_file" "assets" {


### PR DESCRIPTION
... to prevent conflicts with the bootkube module and idempotency
issues.

Fixes #1446

/cc @mxinden