### PR TITLE
ci/tests: add jenkins job to build tectonic-builder image

### DIFF
--- a/tests/jenkins-jobs/README.md
+++ b/tests/jenkins-jobs/README.md
@@ -1,0 +1,16 @@
+# Jenkins Jobs
+
+This folder contains Jenkins jobs which will be used to build, test and support the Tectonic Installer.
+
+
+## tectonic-builder Jenkins Job
+
+This file creates a Jenkins job called `tectonic-builder-docker-image` to build the `tectonic-builder` docker image which is used to execute our tests.
+
+This job has 3 input parameters:
+
+* `TERRAFORM_UPSTREAM_URL`: If you need to build the image using the upstream `Terraform`
+* `TECTONIC_BUILDER_VERSION`: The version of the `tectonic-builder` you are building.
+* `DRY_RUN`: Just to build the image.
+
+If you don't set the `TERRAFORM_UPSTREAM_URL` it will build the image using the tectonic custom terraform version.

--- a/tests/jenkins-jobs/builder_tectonic_builder_upstream_terraform.groovy
+++ b/tests/jenkins-jobs/builder_tectonic_builder_upstream_terraform.groovy
@@ -1,0 +1,68 @@
+#!groovy
+
+folder("builders")
+
+job("builders/builder-tectonic-builder-upstream-terraform") {
+  logRotator(-1, 10)
+  description('Build a custom docker image of the tectonic builder using the upstream terraform. Changes here will be reverted automaticaly')
+
+  label 'worker&&ec2'
+
+  parameters {
+    stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream terraform download url')
+    stringParam('TECTONIC_BUILDER_VERSION', '', 'TECTONIC BUILDER Docker version')
+    booleanParam('DRY_RUN', true, 'Just build the docker image')
+  }
+
+  wrappers {
+    colorizeOutput()
+    timestamps()
+    credentialsBinding {
+      usernamePassword("QUAY_USERNAME", "QUAY_PASSWD", "quay-robot")
+    }
+  }
+
+  scm {
+    git {
+      remote {
+        url('https://github.com/coreos/tectonic-installer')
+      }
+      branch('origin/master')
+    }
+  }
+
+
+  steps {
+    def cmd = """
+    #!/bin/bash -e
+
+    if [ -z "\${TERRAFORM_UPSTREAM_URL}" ]
+    then
+      export TECTONIC_BUILDER_NAME=quay.io/coreos/tectonic-builder:\${TECTONIC_BUILDER_VERSION}
+      docker build -t \${TECTONIC_BUILDER_NAME} -f images/tectonic-builder/Dockerfile .
+    else
+      export TECTONIC_BUILDER_NAME=quay.io/coreos/tectonic-builder:\${TECTONIC_BUILDER_VERSION}-upstream-terraform
+      docker build -t \${TECTONIC_BUILDER_NAME} --build-arg TERRAFORM_URL=\${TERRAFORM_UPSTREAM_URL} -f images/tectonic-builder/Dockerfile .
+    fi
+
+    if [ !\${DRY_RUN} = true  ] ; then
+      docker login quay.io -u \${QUAY_USERNAME} -p \${QUAY_PASSWD}
+      docker push \${TECTONIC_BUILDER_NAME}
+    fi
+  """.stripIndent()
+    shell(cmd)
+  }
+
+  publishers {
+    wsCleanup()
+    slackNotifier {
+      authTokenCredentialId('tectonic-slack-token')
+      customMessage("Jenkins Builder: tectonic-builder")
+      includeCustomMessage(true)
+      notifyBackToNormal(true)
+      notifyFailure(true)
+      room('#tectonic-installer-ci')
+      teamDomain('coreos')
+    }
+  }
+}

--- a/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
+++ b/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
@@ -1,16 +1,16 @@
-#!groovy
+#!/bin/env groovy​
 
 folder("builders")
 
-job("builders/builder-tectonic-builder-upstream-terraform") {
+job("builders/tectonic-builder-docker-image") {
   logRotator(-1, 10)
-  description('Build a custom docker image of the tectonic builder using the upstream terraform. Changes here will be reverted automaticaly')
+  description('Build quay.io/coreos/tectonic-builder Docker image. Changes here will be reverted automaticaly.')
 
   label 'worker&&ec2'
 
   parameters {
-    stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream terraform download url')
-    stringParam('TECTONIC_BUILDER_VERSION', '', 'TECTONIC BUILDER Docker version')
+    stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream Terraform download url, defaults to CoreOS custom Terraform release (github.com/coreos/terraform)')
+    stringParam('TECTONIC_BUILDER_TAG', '', 'Tectonic Builder Docker tag')
     booleanParam('DRY_RUN', true, 'Just build the docker image')
   }
 
@@ -38,16 +38,16 @@ job("builders/builder-tectonic-builder-upstream-terraform") {
 
     if [ -z "\${TERRAFORM_UPSTREAM_URL}" ]
     then
-      export TECTONIC_BUILDER_NAME=quay.io/coreos/tectonic-builder:\${TECTONIC_BUILDER_VERSION}
-      docker build -t \${TECTONIC_BUILDER_NAME} -f images/tectonic-builder/Dockerfile .
+      export TECTONIC_BUILDER_IMAGE=quay.io/coreos/tectonic-builder:\${TECTONIC_BUILDER_TAG}
+      docker build -t \${TECTONIC_BUILDER_IMAGE} -f images/tectonic-builder/Dockerfile .
     else
-      export TECTONIC_BUILDER_NAME=quay.io/coreos/tectonic-builder:\${TECTONIC_BUILDER_VERSION}-upstream-terraform
-      docker build -t \${TECTONIC_BUILDER_NAME} --build-arg TERRAFORM_URL=\${TERRAFORM_UPSTREAM_URL} -f images/tectonic-builder/Dockerfile .
+      export TECTONIC_BUILDER_IMAGE=quay.io/coreos/tectonic-builder:\${TECTONIC_BUILDER_TAG}-upstream-terraform
+      docker build -t \${TECTONIC_BUILDER_IMAGE} --build-arg TERRAFORM_URL=\${TERRAFORM_UPSTREAM_URL} -f images/tectonic-builder/Dockerfile .
     fi
 
     if [ !\${DRY_RUN} = true  ] ; then
       docker login quay.io -u \${QUAY_USERNAME} -p \${QUAY_PASSWD}
-      docker push \${TECTONIC_BUILDER_NAME}
+      docker push \${TECTONIC_BUILDER_IMAGE}
     fi
   """.stripIndent()
     shell(cmd)


### PR DESCRIPTION
This is a jenkins job that build the tectonic-builder.
Instead of build manually this job can trigger the build and push to the repo.

There is a jenkins seed job that will read the /tests/jenkins-jobs and create all jobs in this folder. For now just this will be created.

