### PR TITLE
Support additive node labels

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -6,6 +6,8 @@ This document gives an overview of variables used in all platforms of the Tecton
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
+| tectonic_additional_master_node_labels | Specifies additional node labels to be added to master nodes. This correlates to the --node-labels  kubelet flag. All labels required by Tectonic will still be present.<br><br>Example: `["tier=app", "purpose=data"]` | list | `<list>` |
+| tectonic_additional_worker_node_labels | Specifies additional node labels to be added to worker nodes. This translates to the --node-labels  kubelet flag. All labels required by Tectonic will still be present.<br><br>Example: `["tier=app", "purpose=data"]` | list | `<list>` |
 | tectonic_admin_email | The e-mail address used to: 1. login as the admin user to the Tectonic Console. 2. generate DNS zones for some providers.<br><br>Note: This field MUST be in all lower-case e-mail address format and set manually prior to creating the cluster. | string | - |
 | tectonic_admin_password | The admin user password to login to the Tectonic Console.<br><br>Note: This field MUST be set manually prior to creating the cluster. Backslashes and double quotes must also be escaped. | string | - |
 | tectonic_aws_assets_s3_bucket_name | (optional) Unique name under which the Amazon S3 bucket will be created. Bucket name must start with a lower case name and is limited to 63 characters. The Tectonic Installer uses the bucket to store tectonic assets and kubeconfig.<br><br>If name is not provided the installer will construct the name using "tectonic_cluster_name", current AWS region and "tectonic_base_domain" | string | `` |

--- a/config.tf
+++ b/config.tf
@@ -482,3 +482,27 @@ variable "tectonic_bootstrap_upgrade_cl" {
   default     = "true"
   description = "(internal) Whether to trigger a ContainerLinux upgrade on node bootstrap."
 }
+
+variable "tectonic_additional_master_node_labels" {
+  type    = "list"
+  default = [""]
+
+  description = <<EOF
+Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+kubelet flag. All labels required by Tectonic will still be present.
+
+Example: `["tier=app", "purpose=data"]`
+EOF
+}
+
+variable "tectonic_additional_worker_node_labels" {
+  type    = "list"
+  default = [""]
+
+  description = <<EOF
+Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+kubelet flag. All labels required by Tectonic will still be present.
+
+Example: `["tier=app", "purpose=data"]`
+EOF
+}

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -1,4 +1,16 @@
 
+// Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_master_node_labels = ""
+
+// Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_worker_node_labels = ""
+
 // The e-mail address used to:
 // 1. login as the admin user to the Tectonic Console.
 // 2. generate DNS zones for some providers.

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -1,4 +1,16 @@
 
+// Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_master_node_labels = ""
+
+// Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_worker_node_labels = ""
+
 // The e-mail address used to:
 // 1. login as the admin user to the Tectonic Console.
 // 2. generate DNS zones for some providers.

--- a/examples/terraform.tfvars.gcp
+++ b/examples/terraform.tfvars.gcp
@@ -1,4 +1,16 @@
 
+// Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_master_node_labels = ""
+
+// Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_worker_node_labels = ""
+
 // The e-mail address used to:
 // 1. login as the admin user to the Tectonic Console.
 // 2. generate DNS zones for some providers.

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -1,4 +1,16 @@
 
+// Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_master_node_labels = ""
+
+// Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_worker_node_labels = ""
+
 // The e-mail address used to:
 // 1. login as the admin user to the Tectonic Console.
 // 2. generate DNS zones for some providers.

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -1,4 +1,16 @@
 
+// Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_master_node_labels = ""
+
+// Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_worker_node_labels = ""
+
 // The e-mail address used to:
 // 1. login as the admin user to the Tectonic Console.
 // 2. generate DNS zones for some providers.

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -1,4 +1,16 @@
 
+// Specifies additional node labels to be added to master nodes. This correlates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_master_node_labels = ""
+
+// Specifies additional node labels to be added to worker nodes. This translates to the --node-labels 
+// kubelet flag. All labels required by Tectonic will still be present.
+// 
+// Example: `["tier=app", "purpose=data"]`
+tectonic_additional_worker_node_labels = ""
+
 // The e-mail address used to:
 // 1. login as the admin user to the Tectonic Console.
 // 2. generate DNS zones for some providers.

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -102,7 +102,7 @@ module "ignition_masters" {
   kube_dns_service_ip       = "${module.bootkube.kube_dns_service_ip}"
   kubeconfig_fetch_cmd      = "/opt/s3-puller.sh ${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key} /etc/kubernetes/kubeconfig"
   kubelet_cni_bin_dir       = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label        = "node-role.kubernetes.io/master"
+  kubelet_node_label        = "${join(",", concat(var.tectonic_additional_master_node_labels, list("node-role.kubernetes.io/master")))}"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
 }
@@ -160,7 +160,7 @@ module "ignition_workers" {
   kube_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
   kubeconfig_fetch_cmd = "/opt/s3-puller.sh ${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key} /etc/kubernetes/kubeconfig"
   kubelet_cni_bin_dir  = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label   = "node-role.kubernetes.io/node"
+  kubelet_node_label   = "${join(",", concat(var.tectonic_additional_worker_node_labels, list("node-role.kubernetes.io/node")))}"
   kubelet_node_taints  = ""
   tectonic_vanilla_k8s = "${var.tectonic_vanilla_k8s}"
 }

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -170,7 +170,7 @@ module "ignition_workers" {
   image_re              = "${var.tectonic_image_re}"
   kube_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
   kubelet_cni_bin_dir   = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label    = "node-role.kubernetes.io/node"
+  kubelet_node_label    = "${join(",", concat(var.tectonic_additional_master_node_labels, list("node-role.kubernetes.io/master")))}"
   kubelet_node_taints   = ""
   tectonic_vanilla_k8s  = "${var.tectonic_vanilla_k8s}"
 }

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -38,7 +38,7 @@ module "ignition_masters" {
   image_re                  = "${var.tectonic_image_re}"
   kube_dns_service_ip       = "${module.bootkube.kube_dns_service_ip}"
   kubelet_cni_bin_dir       = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label        = "node-role.kubernetes.io/master"
+  kubelet_node_label        = "${join(",", concat(var.tectonic_additional_master_node_labels, list("node-role.kubernetes.io/master")))}"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
   use_metadata              = false
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
@@ -81,7 +81,7 @@ module "ignition_workers" {
   image_re             = "${var.tectonic_image_re}"
   kube_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
   kubelet_cni_bin_dir  = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label   = "node-role.kubernetes.io/node"
+  kubelet_node_label   = "${join(",", concat(var.tectonic_additional_worker_node_labels, list("node-role.kubernetes.io/node")))}"
   kubelet_node_taints  = ""
   tectonic_vanilla_k8s = "${var.tectonic_vanilla_k8s}"
 }

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -222,7 +222,7 @@ module "ignition_workers" {
   image_re             = "${var.tectonic_image_re}"
   kube_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
   kubelet_cni_bin_dir  = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label   = "node-role.kubernetes.io/node"
+  kubelet_node_label   = "${join(",", concat(var.tectonic_additional_master_node_labels, list("node-role.kubernetes.io/master")))}"
   kubelet_node_taints  = ""
   tectonic_vanilla_k8s = "${var.tectonic_vanilla_k8s}"
 }

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -50,7 +50,7 @@ module "ignition_masters" {
   image_re                 = "${var.tectonic_image_re}"
   kube_dns_service_ip      = "${module.bootkube.kube_dns_service_ip}"
   kubelet_cni_bin_dir      = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label       = "node-role.kubernetes.io/master"
+  kubelet_node_label       = "${join(",", concat(var.tectonic_additional_master_node_labels, list("node-role.kubernetes.io/master")))}"
   kubelet_node_taints      = "node-role.kubernetes.io/master=:NoSchedule"
   tectonic_vanilla_k8s     = "${var.tectonic_vanilla_k8s}"
 }
@@ -100,7 +100,7 @@ module "ignition_workers" {
   image_re             = "${var.tectonic_image_re}"
   kube_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
   kubelet_cni_bin_dir  = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label   = "node-role.kubernetes.io/node"
+  kubelet_node_label   = "${join(",", concat(var.tectonic_additional_master_node_labels, list("node-role.kubernetes.io/master")))}"
   kubelet_node_taints  = ""
   tectonic_vanilla_k8s = "${var.tectonic_vanilla_k8s}"
 }


### PR DESCRIPTION
This commit allows users to specify node labels to be added to workers
and masters on top of the existing label(s) added by Tectonic.

Solves #667 and partially impacts #1439 