### PR TITLE
tests/conformance: update conformance script with tectonic admin credentials.

### DIFF
--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -11,7 +11,9 @@ export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.35
 export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.6.6_coreos.0
 
 # Create an env var file
-cat <<EOF >> env.list
+# shellcheck disable=SC2154
+{
+cat <<EOF > env.list
 PLATFORM=aws
 CLUSTER="tf-${PLATFORM}-${BUILD_ID}"
 TF_VAR_tectonic_cluster_name=$(echo "${CLUSTER}" | awk '{print tolower($0)}')
@@ -21,7 +23,10 @@ TF_VAR_tectonic_aws_region="us-west-2"
 TF_VAR_tectonic_pull_secret_path=${TF_VAR_tectonic_pull_secret_path}
 TF_VAR_tectonic_license_path=${TF_VAR_tectonic_license_path}
 TF_VAR_tectonic_aws_ssh_key="jenkins"
+TF_VAR_tectonic_admin_email=${TF_VAR_tectonic_admin_email}
+TF_VAR_tectonic_admin_password_hash=${TF_VAR_tectonic_admin_password_hash}
 EOF
+}
 
 # Mount secret command for docker run
 MNT_SECRETS="-v ${TF_VAR_tectonic_license_path}:${TF_VAR_tectonic_license_path} -v ${TF_VAR_tectonic_pull_secret_path}:${TF_VAR_tectonic_pull_secret_path}"


### PR DESCRIPTION
regression seen due to https://github.com/coreos/tectonic-installer/pull/1421