### PR TITLE
modules/tectonic/resources moves ingress installation earlier...

### DIFF
--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -128,6 +128,23 @@ kubectl create -f secrets/ca-cert.yaml
 kubectl create -f secrets/identity-grpc-client.yaml
 kubectl create -f secrets/identity-grpc-server.yaml
 
+echo "Creating Ingress"
+kubectl create -f ingress/default-backend/configmap.yaml
+kubectl create -f ingress/default-backend/service.yaml
+kubectl create -f ingress/default-backend/deployment.yaml
+kubectl create -f ingress/ingress.yaml
+
+# shellcheck disable=SC2154
+if [ "${ingress_kind}" = "HostPort" ]; then
+  kubectl create -f ingress/hostport/service.yaml
+  kubectl create -f ingress/hostport/daemonset.yaml
+elif [ "${ingress_kind}" = "NodePort" ]; then
+  kubectl create -f ingress/nodeport/service.yaml
+  kubectl create -f ingress/nodeport/deployment.yaml
+else
+  echo "Unrecognized Ingress Kind: ${ingress_kind}"
+fi
+
 echo "Creating Tectonic Identity"
 kubectl create -f identity/configmap.yaml
 kubectl create -f identity/services.yaml
@@ -182,23 +199,6 @@ kubectl create -f monitoring/tectonic-monitoring-auth-alertmanager-svc.yaml
 kubectl create -f monitoring/tectonic-monitoring-auth-prometheus-deployment.yaml
 kubectl create -f monitoring/tectonic-monitoring-auth-prometheus-svc.yaml
 kubectl create -f monitoring/tectonic-monitoring-ingress.yaml
-
-echo "Creating Ingress"
-kubectl create -f ingress/default-backend/configmap.yaml
-kubectl create -f ingress/default-backend/service.yaml
-kubectl create -f ingress/default-backend/deployment.yaml
-kubectl create -f ingress/ingress.yaml
-
-# shellcheck disable=SC2154
-if [ "${ingress_kind}" = "HostPort" ]; then
-  kubectl create -f ingress/hostport/service.yaml
-  kubectl create -f ingress/hostport/daemonset.yaml
-elif [ "${ingress_kind}" = "NodePort" ]; then
-  kubectl create -f ingress/nodeport/service.yaml
-  kubectl create -f ingress/nodeport/deployment.yaml
-else
-  echo "Unrecognized Ingress Kind: ${ingress_kind}"
-fi
 
 echo "Creating Heapster / Stats Emitter"
 kubectl create -f heapster/service.yaml


### PR DESCRIPTION
so you can console and stuff while other operators are coming up.  This probably saves a few minutes.