### PR TITLE
modules/update-payload: Add an option to enforce payload.

### DIFF
--- a/modules/update-payload/make-update-payload.sh
+++ b/modules/update-payload/make-update-payload.sh
@@ -87,13 +87,26 @@ if [[ ${#tmpfiles[*]} > 0 ]]; then
     rm ${tmpfiles[*]}
 fi
 
+echo "Is this payload enforced? (y/N)" >&2
+
+read -r payload_enforced
+
+PAYLOAD_ENFORCED=false
+if [[ ${payload_enforced} == "y" ]]; then
+    echo "Payload will be enforced!" >&2
+    PAYLOAD_ENFORCED=true
+else
+    echo "Payload will NOT be enforced" >&2
+fi
+
 # Create the final payload.
 # shellcheck disable=SC2086
 cat <<EOF | jq . > ${DIR}/payload.json
 {
   "version": ${VERSION},
   "deployments": ${DEPLOYMENTS},
-  "desiredVersions": ${DESIRED_VERSIONS}
+  "desiredVersions": ${DESIRED_VERSIONS},
+  "enforced": ${PAYLOAD_ENFORCED}
 }
 EOF
 


### PR DESCRIPTION
Be default, when upgrading from an old version (several releases behind),
the intermediate payloads will be skipped unless they are "enforced".

The "enforced" field tells tco NOT to skip this payload during
the upgrade.