### PR TITLE
ci/tests: add nightly jenkins job to run the tests for tectonic-installer

### DIFF
--- a/tests/jenkins-jobs/README.md
+++ b/tests/jenkins-jobs/README.md
@@ -16,9 +16,9 @@ This job has 3 input parameters:
 If you don't set the `TERRAFORM_UPSTREAM_URL` it will build the image using the tectonic custom terraform version.
 
 
-## Tectonic Installer Nightly Build
+## Tectonic Installer Nightly Trigger
 
-This file creates a Jenkins job called `tectonic-installer-nightly` to run the tests against the `Tectonic Installer` in the `master` branch.
+This file creates a Jenkins job called `tectonic-installer-nightly-trigger` to run the tests against the `Tectonic Installer` in the `master` branch.
 This job will run everyday around 3AM UTC time.
 
 Parameters:

--- a/tests/jenkins-jobs/README.md
+++ b/tests/jenkins-jobs/README.md
@@ -14,3 +14,13 @@ This job has 3 input parameters:
 * `DRY_RUN`: Just to build the image.
 
 If you don't set the `TERRAFORM_UPSTREAM_URL` it will build the image using the tectonic custom terraform version.
+
+
+## Tectonic Installer Nightly Build
+
+This file creates a Jenkins job called `tectonic-installer-nightly` to run the tests against the `Tectonic Installer` in the `master` branch.
+This job will run everyday around 3AM UTC time.
+
+Parameters:
+
+* No input parameters are required.

--- a/tests/jenkins-jobs/tectonic-installer-nightly-build.groovy
+++ b/tests/jenkins-jobs/tectonic-installer-nightly-build.groovy
@@ -1,0 +1,43 @@
+#!/bin/env groovy​
+
+job("tectonic-installer-nightly") {
+  logRotator(10, 10)
+  description('Tectonic Installer nightly builds against master. Changes here will be reverted automatically.')
+
+  wrappers {
+    colorizeOutput()
+    timestamps()
+  }
+
+  triggers {
+    cron('H 3 * * *')
+  }
+
+  steps {
+    triggerBuilder {
+      configs {
+        blockableBuildTriggerConfig {
+          projects("tectonic-installer/master")
+          block {
+            buildStepFailureThreshold("FAILURE")
+            unstableThreshold("UNSTABLE")
+            failureThreshold("FAILURE")
+          }
+        }
+      }
+    }
+  }
+
+  publishers {
+    wsCleanup()
+    slackNotifier {
+      authTokenCredentialId('tectonic-slack-token')
+      customMessage("Tectonic Installer Nightly Build")
+      includeCustomMessage(true)
+      notifyBackToNormal(true)
+      notifyFailure(true)
+      room('#tectonic-installer-ci')
+      teamDomain('coreos')
+    }
+  }
+}

--- a/tests/jenkins-jobs/tectonic-installer-nightly-trigger.groovy
+++ b/tests/jenkins-jobs/tectonic-installer-nightly-trigger.groovy
@@ -1,6 +1,6 @@
 #!/bin/env groovy​
 
-job("tectonic-installer-nightly") {
+job("tectonic-installer-nightly-trigger") {
   logRotator(10, 10)
   description('Tectonic Installer nightly builds against master. Changes here will be reverted automatically.')
 


### PR DESCRIPTION
This fixes the Jira Issue: TECTEST-13

This job will trigger the tectonic-installer pipeline against master to test the changes in the master branch. the job will run every day around 3 AM UTC time.