### PR TITLE
kvo: disable image pre-warming.

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/kube-version-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/kube-version-operator.yaml
@@ -22,7 +22,7 @@ spec:
         image: ${kube_version_operator_image}
         command:
         - /kube-version-operator
-        - --cache-images=true
+        - --cache-images=false  # TODO: re-enable in 1.7.2+
         - --version-mapping=/upgrade-spec.json
       imagePullSecrets:
       - name: coreos-pull-secret


### PR DESCRIPTION
This is broken for people upgrading from previous versions, so turn it
off until it is fixed.