### PR TITLE
modules/tectonic/resources: make tectonic scripts POSIX

### DIFF
--- a/modules/tectonic/resources/tectonic-rkt.sh
+++ b/modules/tectonic/resources/tectonic-rkt.sh
@@ -8,4 +8,4 @@
   ${hyperkube_image} \
   --net=host \
   --dns=host \
-  --exec=/bin/bash -- /assets/tectonic.sh /assets/auth/kubeconfig /assets ${experimental}
+  --exec=/bin/sh -- /assets/tectonic.sh /assets/auth/kubeconfig /assets ${experimental}


### PR DESCRIPTION
This commit makes the tectonic.sh script POSIX compliant. This is
necessary because the k8s base image for hyperkube will no longer have
bash installed once https://github.com/kubernetes/kubernetes/pull/48365
lands, so bash-specific syntax will cause cluster bootstrapping to fail.

cc @alexsomesan @sym3tri 