### PR TITLE
Destroy cluster disable next step

### DIFF
--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -268,7 +268,7 @@ TF_PowerOn.canNavigateForward = ({cluster}) => {
   ready = ready || (
     _.get(cluster, 'status.tectonic.console.success') === true
     && _.get(cluster, 'status.tectonic.tectonicSystem.success') === true
-    && _.get(cluster, 'status.status') !== 'running');
+    && _.toLower(_.get(cluster, 'status.status')) !== 'running');
 
   return ready;
 };

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -265,10 +265,14 @@ class TF_PowerOn extends React.Component {
 let ready = false;
 
 TF_PowerOn.canNavigateForward = ({cluster}) => {
+  const {tectonic, terraform} = _.get(cluster, 'status') || {};
+  if (_.get(terraform, 'action') === 'destroy') {
+    return false;
+  }
   ready = ready || (
-    _.get(cluster, 'status.tectonic.console.success') === true
-    && _.get(cluster, 'status.tectonic.tectonicSystem.success') === true
-    && _.toLower(_.get(cluster, 'status.status')) !== 'running');
+    _.get(tectonic, 'console.success') === true
+    && _.get(tectonic, 'tectonicSystem.success') === true
+    && _.toLower(_.get(terraform, 'status')) !== 'running');
 
   return ready;
 };


### PR DESCRIPTION
Disables the Next Step button as soon as the destroy action begins (rather than waiting for the destroy action to complete). This avoids the situation where you could be viewing the Installation Complete page while the destroy is running and then be unexpectedly thrown back to the Start Installation page when the destroy action completes.

Also fixes a bug in the logic that should leave the Next Button disabled while `status` is `"Running" `.

Fixes: #1311 

![screenshot-1](https://user-images.githubusercontent.com/460802/28603514-a2b63a6c-71ff-11e7-9a1e-6b638e59da93.png)