### PR TITLE
aws: create tectonic_aws_external_whitelisted_cidrs

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -17,6 +17,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_external_private_zone | (optional) If set, the given Route53 zone ID will be used as the internal (private) zone. This zone will be used to create etcd DNS records as well as internal API and internal Ingress records. If set, no additional private zone will be created.<br><br>Example: `"Z1ILINNUJGTAO1"` | string | `` |
 | tectonic_aws_external_vpc_id | (optional) ID of an existing VPC to launch nodes into. If unset a new VPC is created.<br><br>Example: `vpc-123456` | string | `` |
 | tectonic_aws_external_vpc_public | If set to true, create public facing ingress resources (ELB, A-records). If set to false, a "private" cluster will be created with an internal ELB only. | string | `true` |
+| tectonic_aws_external_whitelisted_cidrs | (optional) A list of CIDRs that are allowed access to the Tectonic Console and API. | list | `<list>` |
 | tectonic_aws_external_worker_subnet_ids | (optional) List of subnet IDs within an existing VPC to deploy worker nodes into. Required to use an existing VPC and the list must match the AZ count.<br><br>Example: `["subnet-111111", "subnet-222222", "subnet-333333"]` | list | `<list>` |
 | tectonic_aws_extra_tags | (optional) Extra AWS tags to be applied to created resources. | map | `<map>` |
 | tectonic_aws_master_custom_subnets | (optional) This configures master availability zones and their corresponding subnet CIDRs directly.<br><br>Example: `{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }` | map | `<map>` |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -58,6 +58,9 @@ tectonic_aws_etcd_root_volume_type = "gp2"
 // If set to false, a "private" cluster will be created with an internal ELB only.
 tectonic_aws_external_vpc_public = true
 
+// (optional) A list of CIDRs that are allowed access to the Tectonic Console and API.
+// tectonic_aws_external_whitelisted_cidrs = ""
+
 // (optional) List of subnet IDs within an existing VPC to deploy worker nodes into.
 // Required to use an existing VPC and the list must match the AZ count.
 // 

--- a/modules/aws/vpc/sg-elb.tf
+++ b/modules/aws/vpc/sg-elb.tf
@@ -17,7 +17,7 @@ resource "aws_security_group" "api" {
 
   ingress {
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.tectonic_aws_whitelisted_cidrs}"]
     from_port   = 443
     to_port     = 443
   }
@@ -42,14 +42,14 @@ resource "aws_security_group" "console" {
 
   ingress {
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.tectonic_aws_whitelisted_cidrs}"]
     from_port   = 80
     to_port     = 80
   }
 
   ingress {
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${var.tectonic_aws_whitelisted_cidrs}"]
     from_port   = 443
     to_port     = 443
   }

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -10,12 +10,13 @@ module "vpc" {
   cidr_block   = "${var.tectonic_aws_vpc_cidr_block}"
   cluster_name = "${var.tectonic_cluster_name}"
 
-  external_vpc_id         = "${var.tectonic_aws_external_vpc_id}"
-  external_master_subnets = "${compact(var.tectonic_aws_external_master_subnet_ids)}"
-  external_worker_subnets = "${compact(var.tectonic_aws_external_worker_subnet_ids)}"
-  cluster_id              = "${module.tectonic.cluster_id}"
-  extra_tags              = "${var.tectonic_aws_extra_tags}"
-  enable_etcd_sg          = "${!var.tectonic_experimental && length(compact(var.tectonic_etcd_servers)) == 0 ? 1 : 0}"
+  external_whitelisted_cidrs = ["${var.tectonic_aws_external_whitelisted_cidrs}"]
+  external_vpc_id            = "${var.tectonic_aws_external_vpc_id}"
+  external_master_subnets    = "${compact(var.tectonic_aws_external_master_subnet_ids)}"
+  external_worker_subnets    = "${compact(var.tectonic_aws_external_worker_subnet_ids)}"
+  cluster_id                 = "${module.tectonic.cluster_id}"
+  extra_tags                 = "${var.tectonic_aws_extra_tags}"
+  enable_etcd_sg             = "${!var.tectonic_experimental && length(compact(var.tectonic_etcd_servers)) == 0 ? 1 : 0}"
 
   # VPC layout settings.
   #
@@ -27,10 +28,10 @@ module "vpc" {
   # To enable mode A, configure a set of AZs + CIDRs for masters and workers using the
   # "tectonic_aws_master_custom_subnets" and "tectonic_aws_worker_custom_subnets" variables.
   #
-  # To enable mode B, make sure that "tectonic_aws_master_custom_subnets" and "tectonic_aws_worker_custom_subnets" 
+  # To enable mode B, make sure that "tectonic_aws_master_custom_subnets" and "tectonic_aws_worker_custom_subnets"
   # ARE NOT SET.
 
-  # These counts could be deducted by length(keys(var.tectonic_aws_master_custom_subnets)) 
+  # These counts could be deducted by length(keys(var.tectonic_aws_master_custom_subnets))
   # but there is a restriction on passing computed values as counts. This approach works around that.
   master_az_count = "${length(keys(var.tectonic_aws_master_custom_subnets)) > 0 ? "${length(keys(var.tectonic_aws_master_custom_subnets))}" : "${length(data.aws_availability_zones.azs.names)}"}"
   worker_az_count = "${length(keys(var.tectonic_aws_worker_custom_subnets)) > 0 ? "${length(keys(var.tectonic_aws_worker_custom_subnets))}" : "${length(data.aws_availability_zones.azs.names)}"}"
@@ -38,7 +39,7 @@ module "vpc" {
   # element() won't work on empty lists. See https://github.com/hashicorp/terraform/issues/11210
   master_subnets = "${concat(values(var.tectonic_aws_master_custom_subnets),list("padding"))}"
   worker_subnets = "${concat(values(var.tectonic_aws_worker_custom_subnets),list("padding"))}"
-  # The split() / join() trick works around the limitation of ternary operator expressions 
+  # The split() / join() trick works around the limitation of ternary operator expressions
   # only being able to return strings.
   master_azs = "${ split("|", "${length(keys(var.tectonic_aws_master_custom_subnets))}" > 0 ?
     join("|", keys(var.tectonic_aws_master_custom_subnets)) :

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -271,3 +271,12 @@ Example:
  * Role Name = tectonic-installer
 EOF
 }
+
+variable "tectonic_aws_external_whitelisted_cidrs" {
+  type    = "list"
+  default = ["0.0.0.0/0"]
+
+  description = <<EOF
+(optional) A list of CIDRs that are allowed access to the Tectonic Console and API.
+EOF
+}


### PR DESCRIPTION
This variable would allow users to specify a group of whitelisted IPs
that are allowed to connect to the API and Console ELB.

This was created so that tectonic clusters can be created without
exposing them to the internet outright, at a network level.