### PR TITLE
openstack: Restrict security groups for insecure and internal ports

### DIFF
--- a/modules/openstack/secgroups/rules/etcd/secgroup.tf
+++ b/modules/openstack/secgroups/rules/etcd/secgroup.tf
@@ -4,7 +4,7 @@ resource "openstack_networking_secgroup_rule_v2" "etcd" {
   port_range_min    = 2379
   port_range_max    = 2380
   protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "${var.cluster_cidr}"
   security_group_id = "${var.secgroup_id}"
 }
 
@@ -15,6 +15,6 @@ resource "openstack_networking_secgroup_rule_v2" "bootstrap_etcd" {
   port_range_min    = 12379
   port_range_max    = 12380
   protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "${var.cluster_cidr}"
   security_group_id = "${var.secgroup_id}"
 }

--- a/modules/openstack/secgroups/rules/etcd/variables.tf
+++ b/modules/openstack/secgroups/rules/etcd/variables.tf
@@ -5,3 +5,7 @@ variable "secgroup_id" {
 variable "self_hosted" {
   default = false
 }
+
+variable "cluster_cidr" {
+  type = "string"
+}

--- a/modules/openstack/secgroups/rules/k8s/secgroup.tf
+++ b/modules/openstack/secgroups/rules/k8s/secgroup.tf
@@ -14,7 +14,7 @@ resource "openstack_networking_secgroup_rule_v2" "cAdvisor" {
   port_range_min    = 4194
   port_range_max    = 4194
   protocol          = "tcp"
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "${var.cluster_cidr}"
   security_group_id = "${var.secgroup_id}"
 }
 
@@ -24,7 +24,7 @@ resource "openstack_networking_secgroup_rule_v2" "flannel" {
   port_range_min    = 4789
   port_range_max    = 4789
   protocol          = "udp"
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "${var.cluster_cidr}"
   security_group_id = "${var.secgroup_id}"
 }
 

--- a/modules/openstack/secgroups/rules/k8s/variables.tf
+++ b/modules/openstack/secgroups/rules/k8s/variables.tf
@@ -1,3 +1,7 @@
 variable "secgroup_id" {
   type = "string"
 }
+
+variable "cluster_cidr" {
+  type = "string"
+}

--- a/modules/openstack/secgroups/secgroup.tf
+++ b/modules/openstack/secgroups/secgroup.tf
@@ -15,8 +15,9 @@ resource "openstack_networking_secgroup_v2" "k8s" {
 }
 
 module "k8s" {
-  source      = "rules/k8s"
-  secgroup_id = "${openstack_networking_secgroup_v2.k8s.id}"
+  source       = "rules/k8s"
+  secgroup_id  = "${openstack_networking_secgroup_v2.k8s.id}"
+  cluster_cidr = "${var.cluster_cidr}"
 }
 
 resource "openstack_networking_secgroup_v2" "etcd" {
@@ -26,7 +27,8 @@ resource "openstack_networking_secgroup_v2" "etcd" {
 }
 
 module "etcd" {
-  source      = "rules/etcd"
-  secgroup_id = "${openstack_networking_secgroup_v2.etcd.id}"
-  self_hosted = "${var.tectonic_experimental}"
+  source       = "rules/etcd"
+  secgroup_id  = "${openstack_networking_secgroup_v2.etcd.id}"
+  self_hosted  = "${var.tectonic_experimental}"
+  cluster_cidr = "${var.cluster_cidr}"
 }

--- a/modules/openstack/secgroups/variables.tf
+++ b/modules/openstack/secgroups/variables.tf
@@ -5,3 +5,7 @@ variable "cluster_name" {
 variable "tectonic_experimental" {
   default = false
 }
+
+variable "cluster_cidr" {
+  type = "string"
+}

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -177,6 +177,7 @@ module "secrets" {
 module "secgroups" {
   source                = "../../../modules/openstack/secgroups"
   cluster_name          = "${var.tectonic_cluster_name}"
+  cluster_cidr          = "${var.tectonic_openstack_subnet_cidr}"
   tectonic_experimental = "${var.tectonic_experimental}"
 }
 


### PR DESCRIPTION
The cAdvisor port is insecure and the others are only required internally.