### PR TITLE
Make prometheus-k8s limits and requests configurable

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -32,6 +32,10 @@ This document gives an overview of variables used in all platforms of the Tecton
 | tectonic_image_re | (internal) Regular expression used to extract repo and tag components | string | `/^([^/]+/[^/]+/[^/]+):(.*)$/` |
 | tectonic_license_path | The path to the tectonic licence file.<br><br>Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`. | string | `` |
 | tectonic_master_count | The number of master nodes to be created. This applies only to cloud platforms. | string | `1` |
+| tectonic_prometheus_k8s_limit_cpu | (optional) Amount of cpu, enforce by cgroups, prometheus may consume. | string | `` |
+| tectonic_prometheus_k8s_limit_mem | (optional) Amount of memory, enforce by cgroups, prometheus may consume. | string | `` |
+| tectonic_prometheus_k8s_request_cpu | (optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus. | string | `` |
+| tectonic_prometheus_k8s_request_mem | (optional) Amount of memory requested by the scheduler when attempting to deploy prometheus. | string | `` |
 | tectonic_pull_secret_path | The path the pull secret file in JSON format.<br><br>Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`. | string | `` |
 | tectonic_service_cidr | This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation. The maximum size of this IP range is /12 | string | `10.3.0.0/16` |
 | tectonic_stats_url | The Tectonic statistics collection URL to which to report. | string | `https://stats-collector.tectonic.com` |

--- a/config.tf
+++ b/config.tf
@@ -396,3 +396,35 @@ WARNING: Enabling an alpha feature means that future updates may become unsuppor
 This should only be enabled on clusters that are meant to be short-lived to begin validating the alpha feature.
 EOF
 }
+
+variable "tectonic_prometheus_k8s_request_cpu" {
+  default = "100m"
+
+  description = <<EOF
+(optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus.
+EOF
+}
+
+variable "tectonic_prometheus_k8s_request_mem" {
+  default = "500Mi"
+
+  description = <<EOF
+(optional) Amount of memory requested by the scheduler when attempting to deploy prometheus.
+EOF
+}
+
+variable "tectonic_prometheus_k8s_limit_cpu" {
+  default = "400m"
+
+  description = <<EOF
+(optional) Amount of cpu, enforce by cgroups, prometheus may consume.
+EOF
+}
+
+variable "tectonic_prometheus_k8s_limit_mem" {
+  default = "2000Mi"
+
+  description = <<EOF
+(optional) Amount of memory, enforce by cgroups, prometheus may consume.
+EOF
+}

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -255,6 +255,18 @@ tectonic_license_path = ""
 // This applies only to cloud platforms.
 tectonic_master_count = "1"
 
+// (optional) Amount of cpu, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_cpu = ""
+
+// (optional) Amount of memory, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_mem = ""
+
+// (optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_cpu = ""
+
+// (optional) Amount of memory requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_mem = ""
+
 // The path the pull secret file in JSON format.
 // 
 // Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -248,6 +248,18 @@ tectonic_license_path = ""
 // This applies only to cloud platforms.
 tectonic_master_count = "1"
 
+// (optional) Amount of cpu, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_cpu = ""
+
+// (optional) Amount of memory, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_mem = ""
+
+// (optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_cpu = ""
+
+// (optional) Amount of memory requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_mem = ""
+
 // The path the pull secret file in JSON format.
 // 
 // Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -225,6 +225,18 @@ tectonic_metal_worker_macs = ""
 // Example: `["node2", "node3"]`
 tectonic_metal_worker_names = ""
 
+// (optional) Amount of cpu, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_cpu = ""
+
+// (optional) Amount of memory, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_mem = ""
+
+// (optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_cpu = ""
+
+// (optional) Amount of memory requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_mem = ""
+
 // The path the pull secret file in JSON format.
 // 
 // Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -183,6 +183,18 @@ tectonic_openstack_worker_flavor_id = ""
 // Note: Set either tectonic_openstack_worker_flavor_name or tectonic_openstack_worker_flavor_id.
 tectonic_openstack_worker_flavor_name = ""
 
+// (optional) Amount of cpu, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_cpu = ""
+
+// (optional) Amount of memory, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_mem = ""
+
+// (optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_cpu = ""
+
+// (optional) Amount of memory requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_mem = ""
+
 // The path the pull secret file in JSON format.
 // 
 // Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -126,6 +126,18 @@ tectonic_license_path = ""
 // This applies only to cloud platforms.
 tectonic_master_count = "1"
 
+// (optional) Amount of cpu, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_cpu = ""
+
+// (optional) Amount of memory, enforce by cgroups, prometheus may consume.
+// tectonic_prometheus_k8s_limit_mem = ""
+
+// (optional) Amount of cpu requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_cpu = ""
+
+// (optional) Amount of memory requested by the scheduler when attempting to deploy prometheus.
+// tectonic_prometheus_k8s_request_mem = ""
+
 // The path the pull secret file in JSON format.
 // 
 // Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -39,6 +39,10 @@ resource "template_dir" "tectonic" {
     tectonic_version               = "${var.versions["tectonic"]}"
     etcd_version                   = "${var.versions["etcd"]}"
     tectonic_etcd_operator_version = "${var.versions["tectonic-etcd"]}"
+    prometheus_request_cpu         = "${var.prometheus_k8s_request_cpu}"
+    prometheus_request_mem         = "${var.prometheus_k8s_request_mem}"
+    prometheus_limit_cpu           = "${var.prometheus_k8s_limit_cpu}"
+    prometheus_limit_mem           = "${var.prometheus_k8s_limit_mem}"
 
     etcd_cluster_size = "${var.master_count > 2 ? 3 : 1}"
 

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
@@ -26,8 +26,8 @@ spec:
       port: web
   resources:
     limits:
-      cpu: 400m
-      memory: 2000Mi
+      cpu: ${prometheus_limit_cpu}
+      memory: ${prometheus_limit_mem}
     requests:
-      cpu: 100m
-      memory: 500Mi
+      cpu: ${prometheus_request_cpu}
+      memory: ${prometheus_request_mem}

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -11,6 +11,13 @@ data:
       configReloaderBaseImage: ${replace(config_reload_image,image_re,"$1")}
     prometheusK8s:
       baseImage: ${replace(prometheus_image,image_re,"$1")}
+      resources: 
+        limits: 
+          cpu: ${prometheus_limit_cpu}
+          memory: ${prometheus_limit_mem}
+        requests:
+          cpu: ${prometheus_request_cpu}
+          memory: ${prometheus_request_mem}
     alertmanagerMain:
       baseImage: ${replace(alertmanager_image,image_re,"$1")}
     ingress:

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -129,3 +129,27 @@ EOF
 
   type = "string"
 }
+
+variable "prometheus_k8s_request_cpu" {
+  description = "Amount of cpu requested by the scheduler when attempting to deploy prometheus."
+  type        = "string"
+  default     = "100m"
+}
+
+variable "prometheus_k8s_request_mem" {
+  description = "Amount of memory requested by the scheduler when attempting to deploy prometheus."
+  type        = "string"
+  default     = "500Mi"
+}
+
+variable "prometheus_k8s_limit_cpu" {
+  description = "Amount of cpu, enforce by cgroups, prometheus may consume."
+  type        = "string"
+  default     = "400m"
+}
+
+variable "prometheus_k8s_limit_mem" {
+  description = "Amount of memory, enforce by cgroups, prometheus may consume."
+  type        = "string"
+  default     = "2000Mi"
+}

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -103,6 +103,11 @@ module "tectonic" {
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
 
+  prometheus_k8s_request_cpu = "${var.tectonic_prometheus_k8s_request_cpu}"
+  prometheus_k8s_request_mem = "${var.tectonic_prometheus_k8s_request_mem}"
+  prometheus_k8s_limit_cpu   = "${var.tectonic_prometheus_k8s_limit_cpu}"
+  prometheus_k8s_limit_mem   = "${var.tectonic_prometheus_k8s_limit_mem}"
+
   image_re = "${var.tectonic_image_re}"
 }
 

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -74,6 +74,11 @@ module "tectonic" {
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
 
+  prometheus_k8s_request_cpu = "${var.tectonic_prometheus_k8s_request_cpu}"
+  prometheus_k8s_request_mem = "${var.tectonic_prometheus_k8s_request_mem}"
+  prometheus_k8s_limit_cpu   = "${var.tectonic_prometheus_k8s_limit_cpu}"
+  prometheus_k8s_limit_mem   = "${var.tectonic_prometheus_k8s_limit_mem}"
+
   image_re = "${var.tectonic_image_re}"
 }
 

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -81,6 +81,11 @@ module "tectonic" {
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
 
+  prometheus_k8s_request_cpu = "${var.tectonic_prometheus_k8s_request_cpu}"
+  prometheus_k8s_request_mem = "${var.tectonic_prometheus_k8s_request_mem}"
+  prometheus_k8s_limit_cpu   = "${var.tectonic_prometheus_k8s_limit_cpu}"
+  prometheus_k8s_limit_mem   = "${var.tectonic_prometheus_k8s_limit_mem}"
+
   image_re = "${var.tectonic_image_re}"
 }
 

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -84,6 +84,11 @@ module "tectonic" {
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
 
+  prometheus_k8s_request_cpu = "${var.tectonic_prometheus_k8s_request_cpu}"
+  prometheus_k8s_request_mem = "${var.tectonic_prometheus_k8s_request_mem}"
+  prometheus_k8s_limit_cpu   = "${var.tectonic_prometheus_k8s_limit_cpu}"
+  prometheus_k8s_limit_mem   = "${var.tectonic_prometheus_k8s_limit_mem}"
+
   image_re = "${var.tectonic_image_re}"
 }
 


### PR DESCRIPTION
- Provides more flexibility in what cluster resource allocations are
provided for prometheus during a Tectonic cluster install.

Issue: https://github.com/coreos/tectonic-installer/issues/1515