### PR TITLE
modules/dns/designate: Define admin_email variable

### DIFF
--- a/modules/dns/designate/variables.tf
+++ b/modules/dns/designate/variables.tf
@@ -14,6 +14,11 @@ variable "base_domain" {
   type        = "string"
 }
 
+variable "admin_email" {
+  description = "The admin email for the DNS zone"
+  type        = "string"
+}
+
 variable "master_count" {
   description = "The number of masters"
   type        = "string"


### PR DESCRIPTION
The `admin_email` variable was used, but not defined