### PR TITLE
Configurable monitoring images

### DIFF
--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -19,3 +19,5 @@ data:
       baseImage: ${replace(tectonic_monitoring_auth_image,image_re,"$1")}
     nodeExporter:
       baseImage: ${replace(node_exporter_image,image_re,"$1")}
+    kubeStateMetrics:
+      baseImage: ${replace(kube_state_metrics_image,image_re,"$1")}

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -15,3 +15,7 @@ data:
       baseImage: ${replace(alertmanager_image,image_re,"$1")}
     ingress:
       baseAddress: ${console_base_address}
+    auth:
+      baseImage: ${replace(tectonic_monitoring_auth_image,image_re,"$1")}
+    nodeExporter:
+      baseImage: ${replace(node_exporter_image,image_re,"$1")}


### PR DESCRIPTION
Note: until https://github.com/coreos-inc/tectonic-prometheus-operator/pull/90 is merged and rolled into a release, `nodeExporter.baseImage` and `kubeStateMetrics.baseImage` will have no effect.

\cc @brancz 

