### PR TITLE
Makefile: add a structure check for the update payload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,6 +77,7 @@ pipeline {
               # TODO: Remove me.
               go get github.com/segmentio/terraform-docs
               go get github.com/s-urbaniak/terraform-examples
+              go get github.com/bronze1man/yaml2json
 
               cd $GO_PROJECT/
               make structure-check

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,7 @@ structure-check:
 
 	@if $(MAKE) docs && ! git diff --exit-code; then echo "outdated docs (run 'make docs' to fix)"; exit 1; fi
 	@if $(MAKE) examples && ! git diff --exit-code; then echo "outdated examples (run 'make examples' to fix)"; exit 1; fi
+	@if $(TOP_DIR)/modules/update-payload/make-update-payload.sh && ! git diff --exit-code; then echo "outdated payload (run '$(TOP_DIR)/modules/update-payload/make-update-payload.sh' to fix)"; exit 1; fi
 
 SMOKE_SOURCES := $(shell find $(TOP_DIR)/tests/smoke -name '*.go')
 .PHONY: bin/smoke


### PR DESCRIPTION
Yifan recently spotted inconsistencies between the state of the installer and the update payload, at a few different places, including in our most recent RC. 

This payload is a very critical part of Tectonic. I suggest we start considering the update payload as a first-class citizen by verifying its up to date status in every PR. Thus, every PR that would modify the update payload at the end of the chain, will be required to update it as part of the PR. Annoying conflicts might potentially appear, but it should be very limited as we rarely modify these managed manifests.

/cc @alexsomesan @s-urbaniak @sym3tri 