### PR TITLE
frontend: Add progress bars to Start Installation page

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -653,7 +653,7 @@ span.spacer {
 
 .log-pane {
   color: #fff;
-  padding: 10px 0 10px 20px;
+  padding: 10px 0 10px 22px;
 }
 
 .log-pane__header {

--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -166,6 +166,19 @@ input[type="text"].wiz-node-field {
   margin: 0;
 }
 
+.wiz-launch-progress__bar {
+  background-color: #e5e5e5;
+  border-radius: 2px;
+  height: 4px;
+  margin: 10px 0px 15px 22px;
+}
+
+.wiz-launch-progress__bar-inner {
+  background-color: #2fc98e;
+  border-radius: 2px;
+  height: 4px;
+}
+
 ul.service-launch-progress__steps {
   margin: 10px 0 0 15px;
 }

--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -411,12 +411,20 @@ input.wiz-super-short-input {
   width: 72px;
 }
 
+.wiz-pending-fg {
+  color: #999;
+}
+
 .wiz-success-fg {
   color: #2FC98E;
 }
 
 .wiz-error-fg {
   color: #D64456;
+}
+
+.wiz-cancel-fg {
+  color: #999;
 }
 
 .wiz-running-fg {

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -39,7 +39,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
 class TF_PowerOn extends React.Component {
   constructor (props) {
     super(props);
-    this.state = {showLogs: null};
+    this.state = {showLogs: null, xhrError: null};
   }
 
   componentDidMount () {

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -209,35 +209,35 @@ class TF_PowerOn extends React.Component {
                 </div>
               }
             </WaitingLi>
-            <li style={{paddingLeft: 20, listStyle: 'none'}}>
-            { state.xhrError &&
-              <div className="row">
-                <div className="col-xs-12">
-                  <Alert severity="error">{state.xhrError}</Alert>
+            <li style={{paddingLeft: 22, listStyle: 'none'}}>
+              { state.xhrError &&
+                <div className="row">
+                  <div className="col-xs-12">
+                    <Alert severity="error">{state.xhrError}</Alert>
+                  </div>
                 </div>
-              </div>
-            }
-            { tfError && <Alert severity="error">{tfError.toString()}</Alert> }
-            { !terraformRunning && tfError &&
-              <Alert severity="error" noIcon>
-                <b>{_.startCase(action)} Failed</b>. Your installation is blocked. To continue:
-                <ol style={{ paddingLeft: 30, paddingTop: 10, paddingBottom: 10 }}>
-                  <li>Save your logs for debugging purposes.</li>
-                  <li>Destroy your cluster to clear anything that may have been created.</li>
-                  <li>Reapply Terraform.</li>
-                </ol>
-                {tfButtons}
-              </Alert>
-            }
-            { !terraformRunning && !tfError &&
-              <Alert severity="info" noIcon>
-                <b>{_.startCase(action)} Succeeded</b>.
-                <p>
-                  If you've changed your mind, you can {action === 'apply' ? 'destroy' : 'reapply'} your cluster.
-                </p>
-                {tfButtons}
-              </Alert>
-            }
+              }
+              { tfError && <Alert severity="error">{tfError.toString()}</Alert> }
+              { !terraformRunning && tfError &&
+                <Alert severity="error" noIcon>
+                  <b>{_.startCase(action)} Failed</b>. Your installation is blocked. To continue:
+                  <ol style={{ paddingLeft: 30, paddingTop: 10, paddingBottom: 10 }}>
+                    <li>Save your logs for debugging purposes.</li>
+                    <li>Destroy your cluster to clear anything that may have been created.</li>
+                    <li>Reapply Terraform.</li>
+                  </ol>
+                  {tfButtons}
+                </Alert>
+              }
+              { !terraformRunning && !tfError &&
+                <Alert severity="info" noIcon>
+                  <b>{_.startCase(action)} Succeeded</b>.
+                  <p>
+                    If you've changed your mind, you can {action === 'apply' ? 'destroy' : 'reapply'} your cluster.
+                  </p>
+                  {tfButtons}
+                </Alert>
+              }
             </li>
             { consoleSubsteps }
           </ul>

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -156,7 +156,7 @@ class TF_PowerOn extends React.Component {
 
       const dnsReady = tectonic.console.success || ((tectonic.console.message || '').search('no such host') === -1);
       consoleSubsteps.push(
-        <WaitingLi done={dnsReady && !terraformRunning} key="dnsReady">
+        <WaitingLi pending={terraformRunning} done={dnsReady && !terraformRunning} cancel={tfError} key="dnsReady">
           Resolving <a href={`https://${tectonicDomain}`} target="_blank">{tectonicDomain}</a>
         </WaitingLi>
       );
@@ -174,7 +174,7 @@ class TF_PowerOn extends React.Component {
       }
 
       consoleSubsteps.push(
-        <WaitingLi done={allDone} error={anyFailed} key="tectonicReady">
+        <WaitingLi pending={terraformRunning} done={allDone} error={anyFailed} cancel={tfError} key="tectonicReady">
           Starting Tectonic
           { tectonicRunning && <ProgressBar progress={state.tectonicProgress} /> }
           <ul className="service-launch-progress__steps">{ tectonicSubsteps }</ul>

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -13,6 +13,20 @@ import { CLUSTER_NAME, PLATFORM_TYPE, getTectonicDomain } from '../cluster-confi
 import { AWS_TF, BARE_METAL_TF } from '../platforms';
 import { commitToServer, observeClusterStatus } from '../server';
 
+const ProgressBar = ({progress}) => <div className="wiz-launch-progress__bar">
+  <div className="wiz-launch-progress__bar-inner" style={{width: `${progress * 100}%`}}></div>
+</div>;
+
+const estimateTerraformProgress = terraform => {
+  const {output = ''} = terraform;
+  const done = (output.match(/: Creation complete/g) || []).length;
+
+  // Approximate number of AWS resources we expect Terraform to create
+  const total = 145;
+
+  return done / total;
+};
+
 const stateToProps = ({cluster, clusterConfig}) => {
   const status = cluster.status || {terraform: {}};
   const { terraform, tectonic } = status;
@@ -24,7 +38,8 @@ const stateToProps = ({cluster, clusterConfig}) => {
       statusMsg: terraform.status ? terraform.status.toLowerCase() : '',
     },
     clusterName: clusterConfig[CLUSTER_NAME],
-    platformType: clusterConfig[PLATFORM_TYPE],
+    isAWS: clusterConfig[PLATFORM_TYPE] === AWS_TF,
+    isBareMetal: clusterConfig[PLATFORM_TYPE] === BARE_METAL_TF,
     tectonic: tectonic || {},
     tectonicDomain: getTectonicDomain(clusterConfig),
   };
@@ -39,7 +54,20 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
 class TF_PowerOn extends React.Component {
   constructor (props) {
     super(props);
-    this.state = {showLogs: null, xhrError: null};
+    this.state = {
+      services: [],
+      showLogs: null,
+      tectonicProgress: 0,
+      terraformProgress: 0,
+      xhrError: null,
+    };
+  }
+
+  isOutputSame (terraform) {
+    const oldOutput = _.get(this.props, 'terraform.output', '');
+    const newOutput = _.get(terraform, 'output', '');
+    // Output can be 10MB, so compare lengths first. Don't trust the JS engine to be smart.
+    return newOutput.length === oldOutput.length && newOutput === oldOutput;
   }
 
   componentDidMount () {
@@ -48,12 +76,36 @@ class TF_PowerOn extends React.Component {
     }
   }
 
+  componentWillReceiveProps ({tectonic, terraform}) {
+    if (terraform.action === 'apply') {
+      const services = (tectonic.isEtcdSelfHosted ? [{key: 'etcd', name: 'Etcd'}] : []).concat([
+        {key: 'kubernetes', name: 'Kubernetes'},
+        {key: 'identity', name: 'Tectonic Identity'},
+        {key: 'ingress', name: 'Tectonic Ingress Controller'},
+        {key: 'console', name: 'Tectonic Console'},
+        {key: 'tectonicSystem', name: 'other Tectonic services'},
+      ]);
+      this.setState({services});
+
+      const tectonicSucceeded = services.filter(s => _.get(tectonic[s.key], 'success')).length;
+      const tectonicProgress = tectonicSucceeded / services.length;
+
+      // Don't let progress bars go backwards (e.g. if a service flips back to incomplete)
+      if (tectonicProgress > this.state.tectonicProgress) {
+        this.setState({tectonicProgress});
+      }
+
+      if (this.props.isAWS && (this.state.terraformProgress === 0 || !this.isOutputSame(terraform))) {
+        const terraformProgress = estimateTerraformProgress(terraform);
+        if (terraformProgress > this.state.terraformProgress) {
+          this.setState({terraformProgress});
+        }
+      }
+    }
+  }
+
   componentWillUpdate ({terraform}) {
-    const output = _.get(terraform, 'output', '');
-    const oldOutput = _.get(this.props, 'terraform.output', '');
-    // Output can be 10MB, so compare lengths first. Don't trust the JS engine to be smart.
-    const sameOutput = output.length === oldOutput.length && output === oldOutput;
-    if (sameOutput || this.state.showLogs === false) {
+    if (this.isOutputSame(terraform) || this.state.showLogs === false) {
       this.shouldScroll = false;
       return;
     }
@@ -88,16 +140,17 @@ class TF_PowerOn extends React.Component {
   }
 
   render () {
-    const {clusterName, platformType, terraform, tectonic, tectonicDomain} = this.props;
+    const {clusterName, isAWS, isBareMetal, terraform, tectonic, tectonicDomain} = this.props;
     const {action, tfError, output, statusMsg} = terraform;
     const state = this.state;
     const showLogs = state.showLogs === null ? statusMsg !== 'success' : state.showLogs;
+    const isApply = action === 'apply';
     const terraformRunning = statusMsg === 'running';
 
     const consoleSubsteps = [];
 
-    if (action === 'apply' && tectonic.console) {
-      if (platformType === AWS_TF) {
+    if (isApply && tectonic.console) {
+      if (isAWS) {
         consoleSubsteps.push(<AWS_DomainValidation key="domain" />);
       }
 
@@ -108,25 +161,14 @@ class TF_PowerOn extends React.Component {
         </WaitingLi>
       );
 
-      const services = [
-        {key: 'etcd', name: 'Etcd'},
-        {key: 'kubernetes', name: 'Kubernetes'},
-        {key: 'identity', name: 'Tectonic Identity'},
-        {key: 'ingress', name: 'Tectonic Ingress Controller'},
-        {key: 'console', name: 'Tectonic Console'},
-        {key: 'tectonicSystem', name: 'other Tectonic services'},
-      ];
-
-      if (!tectonic.isEtcdSelfHosted) {
-        services.shift(0);
-      }
-
-      const anyFailed = _.some(services, s => tectonic[s.key].failed);
-      const allDone = _.every(services, s => tectonic[s.key].success);
+      const anyFailed = _.some(state.services, s => tectonic[s.key].failed);
+      const allDone = _.every(state.services, s => tectonic[s.key].success);
 
       let tectonicSubsteps = null;
-      if ((!allDone || anyFailed) && !terraformRunning) {
-        tectonicSubsteps = _.map(services, service => <WaitingLi done={tectonic[service.key].success} error={tectonic[service.key].failed} key={service.key} substep={true}>
+      const tectonicRunning = (!allDone || anyFailed) && !terraformRunning;
+
+      if (tectonicRunning) {
+        tectonicSubsteps = _.map(state.services, service => <WaitingLi done={tectonic[service.key].success} error={tectonic[service.key].failed} key={service.key} substep={true}>
           Starting {service.name}
         </WaitingLi>);
       }
@@ -134,7 +176,7 @@ class TF_PowerOn extends React.Component {
       consoleSubsteps.push(
         <WaitingLi done={allDone} error={anyFailed} key="tectonicReady">
           Starting Tectonic
-          <br />
+          { tectonicRunning && <ProgressBar progress={state.tectonicProgress} /> }
           <ul className="service-launch-progress__steps">{ tectonicSubsteps }</ul>
         </WaitingLi>
       );
@@ -153,14 +195,14 @@ class TF_PowerOn extends React.Component {
     </div>;
 
     return <div>
-      { platformType !== BARE_METAL_TF &&
+      { !isBareMetal &&
         <p>
           Kubernetes is starting up. We're committing your cluster details.
           Grab some tea and sit tight. This process can take up to 20 minutes.
           Status updates will appear below.
         </p>
       }
-      { platformType === BARE_METAL_TF &&
+      { isBareMetal &&
         <div>
           <div className="wiz-herotext">
             <i className="fa fa-power-off wiz-herotext-icon"></i> Power on the nodes
@@ -187,13 +229,14 @@ class TF_PowerOn extends React.Component {
               {output && <div className="pull-right" style={{fontSize: '13px'}}>
                 <a onClick={() => this.setState({showLogs: !showLogs})}>
                   { showLogs ? <span><i className="fa fa-angle-up"></i>&nbsp;&nbsp;Hide logs</span>
-                              : <span><i className="fa fa-angle-down"></i>&nbsp;&nbsp;Show logs</span> }
+                             : <span><i className="fa fa-angle-down"></i>&nbsp;&nbsp;Show logs</span> }
                 </a>
                 <span className="spacer"></span>
                 <a onClick={() => saveAs(new Blob([output], {type: 'text/plain'}), `tectonic-${clusterName}.log`)}>
                   <i className="fa fa-download"></i>&nbsp;&nbsp;Save log
                 </a>
               </div>}
+              { isAWS && isApply && statusMsg !== 'success' && <ProgressBar progress={state.terraformProgress} /> }
               { showLogs && output &&
                 <div className="log-pane">
                   <div className="log-pane__header">
@@ -233,7 +276,7 @@ class TF_PowerOn extends React.Component {
                 <Alert severity="info" noIcon>
                   <b>{_.startCase(action)} Succeeded</b>.
                   <p>
-                    If you've changed your mind, you can {action === 'apply' ? 'destroy' : 'reapply'} your cluster.
+                    If you've changed your mind, you can {isApply ? 'destroy' : 'reapply'} your cluster.
                   </p>
                   {tfButtons}
                 </Alert>

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -597,19 +597,22 @@ export const PrivateKeyArea = (props) => {
   return <FileArea {...areaProps} />;
 };
 
-export const WaitingLi = ({done, error, cancel, children, substep}) => {
+export const WaitingLi = ({pending, done, error, cancel, children, substep}) => {
   const progressClasses = classNames({
     'wiz-launch-progress__step': !substep,
     'wiz-launch-progress__substep': substep,
+    'wiz-pending-fg': pending,
     'wiz-error-fg': error,
     'wiz-success-fg': done && !error,
-    'wiz-running-fg': !done && !error,
+    'wiz-cancel-fg': !done && !error && cancel,
+    'wiz-running-fg': !done && !error && !cancel && !pending,
   });
   const iconClasses = classNames('fa', 'fa-fw', {
+    'fa-circle-o': pending,
     'fa-exclamation-circle': error,
     'fa-check-circle': done && !error,
     'fa-ban': !done && !error && cancel,
-    'fa-spin fa-circle-o-notch': !done && !error && !cancel,
+    'fa-spin fa-circle-o-notch': !done && !error && !cancel && !pending,
   });
 
   return <li className={progressClasses}>

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -613,7 +613,7 @@ export const WaitingLi = ({done, error, cancel, children, substep}) => {
   });
 
   return <li className={progressClasses}>
-    {!substep && <i className={iconClasses}></i>}&nbsp;{children}
+    {!substep && <i className={iconClasses} style={{margin: '0 3px 0 -3px'}}></i>}{children}
   </li>;
 };
 


### PR DESCRIPTION
Adds progress bars for both the AWS Terraform apply step and for the Starting Tectonic step for both AWS and bare metal.

The Terraform progress is estimated by parsing the log output. This PR uses a very simple approach with the intention of improving the progress bar accuracy in a future PR.

The Tectonic progress is based on the sub-steps, except that the progress bar will not move backwards of a sub-step flips off again.

Makes some CSS changes to improve horizontal alignment of the page elements.

Adds back the install step "cancel" state, introduced by #1274, which seems to have been
accidentally removed and changes its text color to match the pending state.

Fixes #562

![screenshot-1](https://user-images.githubusercontent.com/460802/28808018-0c030668-76b4-11e7-82c8-1b45f4b5e7e0.png)
<img width="732" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/28807766-302cee70-76b2-11e7-8b8f-47aee150f27e.png">
![screenshot-3](https://user-images.githubusercontent.com/460802/28779670-fc37d2c4-763e-11e7-8325-5ec1712219f6.png)
![screenshot-4](https://user-images.githubusercontent.com/460802/28779674-fe5ab83c-763e-11e7-96d6-84b72188daf3.png)
