### PR TITLE
kube-version-operator: update to v1.7.1-kvo.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ terraform.tfstate*
 terraform.tfvars
 build/
 bin/
+modules/update-payload/generated/

--- a/config.tf
+++ b/config.tf
@@ -49,7 +49,7 @@ variable "tectonic_container_images" {
     kubedns_sidecar                 = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4"
     kube_state_metrics              = "quay.io/coreos/kube-state-metrics:v0.5.0"
     kube_version                    = "quay.io/coreos/kube-version:0.1.0"
-    kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.7.1-kvo.1"
+    kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.7.1-kvo.2"
     node_agent                      = "quay.io/coreos/node-agent:61288ac4d06d304e6947c22cfec4caf1a10ddaa1"
     node_exporter                   = "quay.io/prometheus/node-exporter:v0.14.0"
     pod_checkpointer                = "quay.io/coreos/pod-checkpointer:980d1b4b4b8374240c240fb0f85e3a8d9c51663c"

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -86,7 +86,7 @@
                   "--cache-images=true",
                   "--version-mapping=/upgrade-spec.json"
                 ],
-                "image": "quay.io/coreos/kube-version-operator:v1.7.1-kvo.1",
+                "image": "quay.io/coreos/kube-version-operator:v1.7.1-kvo.2",
                 "name": "kube-version-operator"
               }
             ],


### PR DESCRIPTION
Changelog:
- 1.7.1: bump console to v1.8.4 (#208)
- 1.7.1: add dex configMap migration (#206)