### PR TITLE
modules/azure: bump eth0 MTU to 2000

### DIFF
--- a/modules/azure/master-as/ignition-master.tf
+++ b/modules/azure/master-as/ignition-master.tf
@@ -6,6 +6,10 @@ data "ignition_config" "master" {
     "${data.ignition_file.cloud-provider-config.id}",
   ]
 
+  networkd = [
+    "${data.ignition_networkd_unit.eth0.id}",
+  ]
+
   systemd = [
     "${data.ignition_systemd_unit.docker.id}",
     "${data.ignition_systemd_unit.locksmithd.id}",
@@ -114,4 +118,9 @@ data "ignition_systemd_unit" "tectonic" {
   name    = "tectonic.service"
   enable  = "${var.tectonic_service_disabled == 0 ? true : false}"
   content = "${var.tectonic_service}"
+}
+
+data "ignition_networkd_unit" "eth0" {
+  name    = "10_eth0.link"
+  content = "${file("${path.module}/resources/10_eth0.link")}"
 }

--- a/modules/azure/master-as/resources/10_eth0.link
+++ b/modules/azure/master-as/resources/10_eth0.link
@@ -1,0 +1,7 @@
+[Match]
+OriginalName=eth0
+
+[Link]
+NamePolicy=kernel database onboard slot path
+MACAddressPolicy=persistent
+MTUBytes=2000

--- a/modules/azure/worker-as/ignition-worker.tf
+++ b/modules/azure/worker-as/ignition-worker.tf
@@ -6,6 +6,10 @@ data "ignition_config" "worker" {
     "${data.ignition_file.cloud-provider-config.id}",
   ]
 
+  networkd = [
+    "${data.ignition_networkd_unit.eth0.id}",
+  ]
+
   systemd = [
     "${data.ignition_systemd_unit.docker.id}",
     "${data.ignition_systemd_unit.locksmithd.id}",
@@ -115,4 +119,9 @@ data "ignition_user" "core" {
   ssh_authorized_keys = [
     "${file(var.public_ssh_key)}",
   ]
+}
+
+data "ignition_networkd_unit" "eth0" {
+  name    = "10_eth0.link"
+  content = "${file("${path.module}/resources/10_eth0.link")}"
 }

--- a/modules/azure/worker-as/resources/10_eth0.link
+++ b/modules/azure/worker-as/resources/10_eth0.link
@@ -1,0 +1,7 @@
+[Match]
+OriginalName=eth0
+
+[Link]
+NamePolicy=kernel database onboard slot path
+MACAddressPolicy=persistent
+MTUBytes=2000


### PR DESCRIPTION
fixes: #1171 

A smoke test for this exact failure scenario is forthcoming; it requires a good amount of restructuring to get the cluster ingress URL, which is needed for this test, out of all the providers in a form that is easily consumable (e.g. terraform output) by the smoke test scripts. In the interest of time, that will come in a later PR.

cc @philips @crawford @Quentin-M 