### PR TITLE
frontend: Add JS error reporting.

### DIFF
--- a/installer/frontend/app.jsx
+++ b/installer/frontend/app.jsx
@@ -114,3 +114,17 @@ store.dispatch(validateAllFields(() => {
     document.getElementById('application')
   );
 }));
+
+window.onerror = (message, source, lineno, colno, optError={}) => {
+  try {
+    const e = `${message} ${source} ${lineno} ${colno}`;
+    TectonicGA.sendError(e, optError.stack);
+  } catch(err) {
+    try {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    } catch (ignored) {
+      // ignore
+    }
+  }
+};

--- a/installer/frontend/tectonic-ga.js
+++ b/installer/frontend/tectonic-ga.js
@@ -7,15 +7,16 @@ const send = (obj) => {
 
   try {
     const ga = window[window.GoogleAnalyticsObject || 'ga'];
-    if (typeof ga === 'function') {
-      if (obj.type === 'pageview') {
-        ga('TectonicInstaller.send', 'pageview', obj.page);
-        ga('CoreOS.send', 'pageview', obj.page);
-      } else if (obj.type === 'event') {
-        const {category, action, label, value} = obj;
-        ga('TectonicInstaller.send', 'event', category, action, label, value);
-        ga('CoreOS.send', 'event', category, action, label, value);
-      }
+    if (typeof ga !== 'function') {
+      throw new Error('ga is not a function!');
+    }
+    if (obj.type === 'pageview') {
+      ga('TectonicInstaller.send', 'pageview', obj.page);
+      ga('CoreOS.send', 'pageview', obj.page);
+    } else if (obj.type === 'event') {
+      const {category, action, label, value} = obj;
+      ga('TectonicInstaller.send', 'event', category, action, label, value);
+      ga('CoreOS.send', 'event', category, action, label, value);
     }
   } catch(err) {
     console.error(`Failed to send GA event: ${err.message}`);
@@ -41,6 +42,14 @@ export const TectonicGA = {
 
   sendPageView: (page) => {
     send({ type: 'pageview', page});
+  },
+
+  sendError: (message, stack='') => {
+    send({
+      type: 'event',
+      category: 'installerError',
+      label: `${GIT_TAG} ${message} Stack: ${stack}`,
+    });
   },
 
   sendEvent: (category, action, label = '', platform = '') => {


### PR DESCRIPTION
- Add sendError() to TectonicGA.
- Add window.onerror handler.
- Reduce nesting in send() & log error if ga is not a function.