### PR TITLE
Added export TF_VAR_tectonic_azure_client_secret to azure install guide

### DIFF
--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -127,6 +127,7 @@ $ export ARM_SUBSCRIPTION_ID=abc-123-456
 $ export ARM_CLIENT_ID=generated-app-id
 $ export ARM_CLIENT_SECRET=generated-pass
 $ export ARM_TENANT_ID=generated-tenant
+$ export TF_VAR_tectonic_azure_client_secret="${ARM_CLIENT_SECRET}"
 ```
 
 Now we're ready to specify our cluster configuration.


### PR DESCRIPTION
Added` export TF_VAR_tectonic_azure_client_secret="${ARM_CLIENT_SECRET}"` to azure install guide. Without this step the install pauses for the user to input the secret with:
```
var.tectonic_azure_client_secret
  The client secret to use.

  Enter a value:
```