### PR TITLE
azure: bump hyperkube to 1.7.2

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -40,7 +40,7 @@ variable "tectonic_container_images" {
     flannel                         = "quay.io/coreos/flannel:v0.8.0-amd64"
     flannel_cni                     = "quay.io/coreos/flannel-cni:0.1.0"
     heapster                        = "gcr.io/google_containers/heapster:v1.4.0"
-    hyperkube                       = "quay.io/coreos/hyperkube:v1.7.1_coreos.0"
+    hyperkube                       = "quay.io/coreos/hyperkube:v1.7.2_coreos.0"
     identity                        = "quay.io/coreos/dex:v2.5.0"
     ingress_controller              = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11"
     kenc                            = "quay.io/coreos/kenc:0.0.2"


### PR DESCRIPTION
This is needed to test PVC + managed disks, since the workers are on managed disks.

This fixes #1589.