### PR TITLE
kvo: v1.7.1-kvo.4 & regenerate update payload.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -31,7 +31,7 @@ variable "tectonic_container_images" {
     console                         = "quay.io/coreos/tectonic-console:v1.8.5"
     identity                        = "quay.io/coreos/dex:v2.5.0"
     container_linux_update_operator = "quay.io/coreos/container-linux-update-operator:v0.2.2"
-    kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.7.1-kvo.3"
+    kube_version_operator           = "quay.io/coreos/kube-version-operator:v1.7.1-kvo.4"
     tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.4.0"
     node_agent                      = "quay.io/coreos/node-agent:61288ac4d06d304e6947c22cfec4caf1a10ddaa1"
     prometheus_operator             = "quay.io/coreos/prometheus-operator:v0.11.0"

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -84,7 +84,7 @@
                   "--cache-images=false",
                   "--version-mapping=/upgrade-spec.json"
                 ],
-                "image": "quay.io/coreos/kube-version-operator:v1.7.1-kvo.3",
+                "image": "quay.io/coreos/kube-version-operator:v1.7.1-kvo.4",
                 "name": "kube-version-operator"
               }
             ],


### PR DESCRIPTION
Cherry-picks https://github.com/coreos/tectonic-installer/pull/1584 on the 1.7.1 branch.