### PR TITLE
tests: Trigger forensic scripts in rspec tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ def quay_creds = [
 ]
 
 def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.36'
-def tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v2.0'
+def tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v3.0'
 
 pipeline {
   agent none

--- a/images/tectonic-smoke-test-env/Dockerfile
+++ b/images/tectonic-smoke-test-env/Dockerfile
@@ -6,7 +6,7 @@ COPY ./tests/rspec/Gemfile* /tmp/app/
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y -q \
-    curl make unzip && \
+    curl make unzip jq awscli ssh && \
     apt-get clean
 
 RUN cd /tmp/app && bundler install && rm -r /tmp/app
@@ -18,3 +18,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 
 # Install Terraform
 RUN curl -L https://github.com/coreos/terraform/releases/download/${TERRAFORM_VERSION}/linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
+
+# Add user jenkins (uid: 1000), this is needed among others for `ssh` to not
+# complain about missing user.
+RUN useradd -u 1000 -ms /bin/bash jenkins 

--- a/tests/rspec/lib/aws.rb
+++ b/tests/rspec/lib/aws.rb
@@ -4,12 +4,15 @@ require 'env_var'
 module AWS
   def self.check_prerequisites
     raise 'AWS credentials not defined' unless credentials_defined?
-    raise 'TF_VAR_tectonic_aws_ssh_key is not defined' unless
-      EnvVar.set?(%w[TF_VAR_tectonic_aws_ssh_key])
+    raise 'TF_VAR_tectonic_aws_ssh_key is not defined' unless ssh_key_defined?
   end
 
   def self.credentials_defined?
     credential_names = %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
     EnvVar.set?(credential_names)
+  end
+
+  def self.ssh_key_defined?
+    EnvVar.set?(%w[TF_VAR_tectonic_aws_ssh_key])
   end
 end

--- a/tests/rspec/lib/forensic.rb
+++ b/tests/rspec/lib/forensic.rb
@@ -1,0 +1,18 @@
+require 'ssh'
+
+# Forensic contains helper functions to run the cluster forensic scripts
+module Forensic
+  def self.run(cluster)
+    return if cluster.platform != 'aws'
+    check_prerequisites
+
+    env_variables = cluster.env_variables
+    env_variables['AWS_REGION'] = cluster.tfvars_file.region
+
+    succeeded = system(
+      env_variables,
+      './../smoke/aws/cluster-foreach.sh ./../smoke/forensics.sh'
+    )
+    raise 'Forensic script failed' unless succeeded
+  end
+end

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -1,6 +1,7 @@
 require 'smoke_test'
 require 'cluster'
 require 'aws'
+require 'forensic'
 
 RSpec.shared_examples 'withCluster' do |tf_vars_path|
   before(:all) do
@@ -9,8 +10,12 @@ RSpec.shared_examples 'withCluster' do |tf_vars_path|
     prefix = File.basename(tf_vars_path).split('.').first
     raise 'could not extract prefix from tfvars file name' if prefix == ''
 
-    @cluster = Cluster.new(prefix, tf_vars_path)
+    @cluster = Cluster.new(prefix, tf_vars_path, 'aws')
     @cluster.start
+  end
+
+  after(:each) do |example|
+    Forensic.run(@cluster) if example.exception
   end
 
   after(:all) do

--- a/tests/rspec/lib/ssh.rb
+++ b/tests/rspec/lib/ssh.rb
@@ -1,0 +1,9 @@
+def check_prerequisites
+  return if ssh_agent_has_key?
+  raise 'No ssh key registered in ssh-agent. Run `ssh-add' \
+        '<path-to-private-key>`to add a key.'
+end
+
+def ssh_agent_has_key?
+  system('ssh-add -l')
+end

--- a/tests/rspec/lib/tfvars_file.rb
+++ b/tests/rspec/lib/tfvars_file.rb
@@ -22,6 +22,11 @@ class TFVarsFile
     master_count + worker_count
   end
 
+  # TODO: Randomize region on AWS
+  def region
+    data['tectonic_aws_region']
+  end
+
   private
 
   def master_count

--- a/tests/smoke/aws/vars/aws.tfvars.json
+++ b/tests/smoke/aws/vars/aws.tfvars.json
@@ -25,5 +25,7 @@
 
     "tectonic_aws_external_vpc_id": "",
 
-    "tectonic_stats_url": "https://stats-collector-staging.tectonic.com"
+    "tectonic_stats_url": "https://stats-collector-staging.tectonic.com",
+
+    "tectonic_aws_region": "eu-west-1"
 }


### PR DESCRIPTION
For now, this simply triggers the forensic.sh script via our rspec
shared example. With this change comes a new version of the
tectonic-smoke-test-env. Namely v3.0.