### PR TITLE
tests: Enable concurrent PR builds

### DIFF
--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -5,6 +5,8 @@ folder("triggers")
 job("triggers/tectonic-installer-pr-trigger") {
   description('Tectonic Installer PR Trigger. Changes here will be reverted automatically.')
 
+  concurrentBuild()
+
   logRotator(30, 100)
   label("master")
 


### PR DESCRIPTION
The Tectonic installer PR trigger job waits until the main pipeline
finishes. This enables mutliple trigger jobs to run concurrent,
otherwise we could never test more than one PR at once.

@cpanato What do you think? Is this a sane fix?