### PR TITLE
modules/tectonic: remove updater enabled statistic

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -86,10 +86,9 @@ resource "template_dir" "tectonic" {
     cluster_id   = "${format("%s-%s-%s-%s-%s", substr(random_id.cluster_id.hex, 0, 8), substr(random_id.cluster_id.hex, 8, 4), substr(random_id.cluster_id.hex, 12, 4), substr(random_id.cluster_id.hex, 16, 4), substr(random_id.cluster_id.hex, 20, 12))}"
     cluster_name = "${var.cluster_name}"
 
-    platform                 = "${var.platform}"
-    certificates_strategy    = "${var.ca_generated == "true" ? "installerGeneratedCA" : "userProvidedCA"}"
-    identity_api_service     = "${var.identity_api_service}"
-    tectonic_updater_enabled = "${var.experimental ? "true" : "false"}"
+    platform              = "${var.platform}"
+    certificates_strategy = "${var.ca_generated == "true" ? "installerGeneratedCA" : "userProvidedCA"}"
+    identity_api_service  = "${var.identity_api_service}"
 
     image_re = "${var.image_re}"
   }

--- a/modules/tectonic/resources/manifests/config.yaml
+++ b/modules/tectonic/resources/manifests/config.yaml
@@ -8,7 +8,6 @@ data:
   clusterName: "${cluster_name}"
   installerPlatform: "${platform}"
   certificatesStrategy: "${certificates_strategy}"
-  tectonicUpdaterEnabled: "${tectonic_updater_enabled}"
   consoleBaseAddress: "https://${console_base_address}"
   kubeAPIServerURL: "${kube_apiserver_url}"
   tectonicVersion: "${tectonic_version}"

--- a/modules/tectonic/resources/manifests/stats-emitter.yaml
+++ b/modules/tectonic/resources/manifests/stats-emitter.yaml
@@ -26,7 +26,6 @@ spec:
         - --license=/etc/tectonic/licenses/license
         - --output=/etc/tectonic/stats/extensions
         - --extension=installerPlatform:$(INSTALLER_PLATFORM)
-        - --extension=tectonicUpdaterEnabled:$(TECTONIC_UPDATER_ENABLED)
         - --extension=certificatesStrategy:$(CERTIFICATES_STRATEGY)
         - --extension=initialTectonicVersion:$(INITIAL_TECTONIC_VERSION)
         env:
@@ -40,11 +39,6 @@ spec:
             configMapKeyRef:
               name: tectonic-config
               key: certificatesStrategy
-        - name: TECTONIC_UPDATER_ENABLED
-          valueFrom:
-            configMapKeyRef:
-              name: tectonic-config
-              key: tectonicUpdaterEnabled
         - name: INITIAL_TECTONIC_VERSION
           valueFrom:
             configMapKeyRef:
@@ -84,7 +78,6 @@ spec:
           - --license=/etc/tectonic/licenses/license
           - --output=/etc/tectonic/stats/extensions
           - --extension=installerPlatform:$(INSTALLER_PLATFORM)
-          - --extension=tectonicUpdaterEnabled:$(TECTONIC_UPDATER_ENABLED)
           - --extension=certificatesStrategy:$(CERTIFICATES_STRATEGY)
           - --extension=initialTectonicVersion:$(INITIAL_TECTONIC_VERSION)
         env:
@@ -98,11 +91,6 @@ spec:
             configMapKeyRef:
               name: tectonic-config
               key: certificatesStrategy
-        - name: TECTONIC_UPDATER_ENABLED
-          valueFrom:
-            configMapKeyRef:
-              name: tectonic-config
-              key: tectonicUpdaterEnabled
         - name: INITIAL_TECTONIC_VERSION
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
This commit removes the `tectonicUpdaterEnabled` statistic from the
stats-extender and from the Tectonic Installer since this option is
always enabled. No changes are needed to the BigQuery schema thanks to
the design of the `extensions` schema. Furthermore, since the updater was
decoupled from the experimental features, the reported value for this metric
has been incorrect.

cc @alexsomesan @sym3tri 