### PR TITLE
scripts: fix `make dist`

### DIFF
--- a/installer/scripts/release/common.env.sh
+++ b/installer/scripts/release/common.env.sh
@@ -6,6 +6,9 @@ REPOSITORY_ROOT="$ROOT/.."
 WORKSPACE_DIR="$ROOT/.workspace"
 TMP_DIR="$WORKSPACE_DIR/tmpdir"
 
+VERSION=$("$REPOSITORY_ROOT/git-version")
+export VERSION
+
 export TECTONIC_RELEASE_BUCKET=releases.tectonic.com
 export TECTONIC_BINARY_BUCKET=tectonic-release
 export TECTONIC_RELEASE="tectonic-$VERSION"


### PR DESCRIPTION
VERSION is no longer being set in Makefile, so `make dist` created `tectonic-.tar.gz`
Regression introduced in #1131.