### PR TITLE
tectonic console and identity schedule on unique nodes.

### DIFF
--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -22,9 +22,19 @@ spec:
       creationTimestamp: null
       labels:
         k8s-app: tectonic-console
+        pod-anti-affinity: tectonic-console-${tectonic_version}
         component: ui
       name: tectonic-console
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                pod-anti-affinity: tectonic-console-${tectonic_version}
+            namespaces:
+              - tectonic-system
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /opt/bridge/bin/bridge

--- a/modules/tectonic/resources/manifests/identity/deployment.yaml
+++ b/modules/tectonic/resources/manifests/identity/deployment.yaml
@@ -21,8 +21,18 @@ spec:
       name: tectonic-identity
       labels:
         k8s-app: tectonic-identity
+        pod-anti-affinity: tectonic-identity-${tectonic_version}
         component: identity
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                pod-anti-affinity: tectonic-identity-${tectonic_version}
+            namespaces:
+              - tectonic-system
+            topologyKey: kubernetes.io/hostname
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
- Using anti-affinity, ensure tectonic-console and tectonic-identity
pods land on unique nodes ensuring HA.

- Resolves https://github.com/coreos/tectonic-installer/issues/1615