### PR TITLE
modules/update-payload: Make sure TCO always updates itself first.

### DIFF
--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -6,6 +6,87 @@
       "kind": "Deployment",
       "metadata": {
         "labels": {
+          "k8s-app": "tectonic-channel-operator",
+          "managed-by-channel-operator": "true"
+        },
+        "name": "tectonic-channel-operator",
+        "namespace": "tectonic-system"
+      },
+      "spec": {
+        "replicas": 1,
+        "selector": {
+          "matchLabels": {
+            "k8s-app": "tectonic-channel-operator"
+          }
+        },
+        "template": {
+          "metadata": {
+            "labels": {
+              "k8s-app": "tectonic-channel-operator",
+              "tectonic-app-version-name": "tectonic-cluster"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "CLUSTER_ID",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "key": "clusterID",
+                        "name": "tectonic-config"
+                      }
+                    }
+                  }
+                ],
+                "image": "quay.io/coreos/tectonic-channel-operator:0.4.0",
+                "name": "tectonic-channel-operator",
+                "resources": {
+                  "limits": {
+                    "cpu": "20m",
+                    "memory": "50Mi"
+                  },
+                  "requests": {
+                    "cpu": "20m",
+                    "memory": "50Mi"
+                  }
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/etc/ssl/certs",
+                    "name": "certs"
+                  }
+                ]
+              }
+            ],
+            "imagePullSecrets": [
+              {
+                "name": "coreos-pull-secret"
+              }
+            ],
+            "restartPolicy": "Always",
+            "securityContext": {
+              "runAsNonRoot": true,
+              "runAsUser": 65534
+            },
+            "volumes": [
+              {
+                "hostPath": {
+                  "path": "/usr/share/ca-certificates"
+                },
+                "name": "certs"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "extensions/v1beta1",
+      "kind": "Deployment",
+      "metadata": {
+        "labels": {
           "k8s-app": "container-linux-update-operator",
           "managed-by-channel-operator": "true"
         },
@@ -99,87 +180,6 @@
               "runAsNonRoot": true,
               "runAsUser": 65534
             }
-          }
-        }
-      }
-    },
-    {
-      "apiVersion": "extensions/v1beta1",
-      "kind": "Deployment",
-      "metadata": {
-        "labels": {
-          "k8s-app": "tectonic-channel-operator",
-          "managed-by-channel-operator": "true"
-        },
-        "name": "tectonic-channel-operator",
-        "namespace": "tectonic-system"
-      },
-      "spec": {
-        "replicas": 1,
-        "selector": {
-          "matchLabels": {
-            "k8s-app": "tectonic-channel-operator"
-          }
-        },
-        "template": {
-          "metadata": {
-            "labels": {
-              "k8s-app": "tectonic-channel-operator",
-              "tectonic-app-version-name": "tectonic-cluster"
-            }
-          },
-          "spec": {
-            "containers": [
-              {
-                "env": [
-                  {
-                    "name": "CLUSTER_ID",
-                    "valueFrom": {
-                      "configMapKeyRef": {
-                        "key": "clusterID",
-                        "name": "tectonic-config"
-                      }
-                    }
-                  }
-                ],
-                "image": "quay.io/coreos/tectonic-channel-operator:0.4.0",
-                "name": "tectonic-channel-operator",
-                "resources": {
-                  "limits": {
-                    "cpu": "20m",
-                    "memory": "50Mi"
-                  },
-                  "requests": {
-                    "cpu": "20m",
-                    "memory": "50Mi"
-                  }
-                },
-                "volumeMounts": [
-                  {
-                    "mountPath": "/etc/ssl/certs",
-                    "name": "certs"
-                  }
-                ]
-              }
-            ],
-            "imagePullSecrets": [
-              {
-                "name": "coreos-pull-secret"
-              }
-            ],
-            "restartPolicy": "Always",
-            "securityContext": {
-              "runAsNonRoot": true,
-              "runAsUser": 65534
-            },
-            "volumes": [
-              {
-                "hostPath": {
-                  "path": "/usr/share/ca-certificates"
-                },
-                "name": "certs"
-              }
-            ]
           }
         }
       }


### PR DESCRIPTION
Before 1.7.1, TCO updates itself by applying the TCO deployment manifest in the payload.
In order to make sure it updates itself first without changing other cluster state, we need to make TCO appears first in the list.