### PR TITLE
frontend: Fix back button / stop storing current pathname in Redux

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -35,12 +35,6 @@ export const loadFactsActionTypes = {
   ERROR: 'LOAD_FACTS_ERROR',
 };
 
-export const navActionTypes = {
-  LOCATION_CHANGE: 'NAV_ACTION_LOCATION_CHANGE',
-};
-
-export const navChange = pathname => ({type: navActionTypes.LOCATION_CHANGE, payload: {pathname}});
-
 export const restoreActionTypes = {
   RESTORE_STATE: 'RESTORE_RESTORE_STATE',
 };

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -13,7 +13,6 @@ import {
   dirtyActionTypes,
   eventErrorsActionTypes,
   loadFactsActionTypes,
-  navActionTypes,
   restoreActionTypes,
   serverActionTypes,
   sequenceActionTypes,
@@ -216,21 +215,6 @@ const reducersTogether = combineReducers({
         error: action.payload,
         awsRegions: null,
       };
-    default:
-      return state;
-    }
-  },
-
-  // The current location as reported by react-router
-  // Should not be saved or restored.
-  path: (state, action) => {
-    if (state === undefined) {
-      return window.location.pathname;
-    }
-
-    switch (action.type) {
-    case navActionTypes.LOCATION_CHANGE:
-      return action.payload.pathname;
     default:
       return state;
     }


### PR DESCRIPTION
This makes React Router's history is the source of truth for all location information.