### PR TITLE
tests: Do not block PR trigger job until triggered jobs are finished

### DIFF
--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -47,22 +47,15 @@ job("triggers/tectonic-installer-pr-trigger") {
     }
   }
 
-  steps {
-    triggerBuilder {
+  publishers {
+    hudson.plugins.parameterizedtrigger.buildTrigger {
       configs {
-        blockableBuildTriggerConfig {
+        buildTriggerConfig {
           projects("tectonic-installer/PR-\${ghprbPullId}")
-          block {
-            buildStepFailureThreshold("FAILURE")
-            unstableThreshold("UNSTABLE")
-            failureThreshold("FAILURE")
-          }
+          condition("SUCCESS")
         }
       }
     }
-  }
-
-  publishers {
     wsCleanup()
     slackNotifier {
       authTokenCredentialId('tectonic-slack-token')


### PR DESCRIPTION
In my opinion there is no need for this. In addition, whenever a PR
build fails, the failure will propagate to the trigger job otherwise,
which then sends a slack message.

@cpanato What do you think?