### PR TITLE
*: bump etcd-operator to v0.5.0

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -36,7 +36,7 @@ variable "tectonic_container_images" {
     console                         = "quay.io/coreos/tectonic-console:v1.8.6"
     error_server                    = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                            = "quay.io/coreos/etcd:v3.1.8"
-    etcd_operator                   = "quay.io/coreos/etcd-operator:v0.4.2"
+    etcd_operator                   = "quay.io/coreos/etcd-operator:v0.5.0"
     flannel                         = "quay.io/coreos/flannel:v0.8.0-amd64"
     flannel_cni                     = "quay.io/coreos/flannel-cni:0.1.0"
     heapster                        = "gcr.io/google_containers/heapster:v1.4.0"


### PR DESCRIPTION
etcd-operator v0.5.0 is gonna use CRD since TPR is being deprecated in k8s 1.7 and will be completely deprecated in k8s 1.8 .