### PR TITLE
kube-flannel-cfg: enable hairpin mode

### DIFF
--- a/modules/net/canal/resources/manifests/kube-flannel.yaml
+++ b/modules/net/canal/resources/manifests/kube-flannel.yaml
@@ -12,7 +12,8 @@ data:
       "name": "cbr0",
       "type": "flannel",
       "delegate": {
-        "isDefaultGateway": true
+        "isDefaultGateway": true,
+        "hairpinMode": true
       }
     }
   net-conf.json: |

--- a/modules/net/flannel_vxlan/resources/manifests/kube-flannel.yaml
+++ b/modules/net/flannel_vxlan/resources/manifests/kube-flannel.yaml
@@ -12,7 +12,8 @@ data:
       "name": "cbr0",
       "type": "flannel",
       "delegate": {
-        "isDefaultGateway": true
+        "isDefaultGateway": true,
+        "hairpinMode": true
       }
     }
   net-conf.json: |


### PR DESCRIPTION
Edit flannel configmap to enable hairpin mode

Hairpin mode is needed to allow pods to communicate with themselves via Service IP. This change is required as the kubelet --hairpin-mode flag is not supported when CNI is being used. 