### PR TITLE
frontend: Installation Complete page changes

### DIFF
--- a/installer/frontend/components/success.jsx
+++ b/installer/frontend/components/success.jsx
@@ -22,30 +22,11 @@ export const Success = connect(stateToProps)(
   ({tectonicConsole, platformType}) => <div>
     <div className="row">
       <div className="col-xs-12">
-        <p>All set! Now you can access the Tectonic Console. Once there, you’ll be able to configure kubectl, and deploy your first application to the cluster.</p>
-        <p>The Tectonic Console gives you an easy-to-navigate view of your cluster.</p>
-      </div>
-    </div>
-
-    <div className="row">
-      <div className="col-xs-12">
-        <a href={`https://${tectonicConsole}`} target="_blank">
-          <button className="btn btn-primary wiz-giant-button"
-            style={{marginTop: 20}}
-            onClick={() => handleAllDone(platformType)}>Go to my Tectonic Console&nbsp;&nbsp;<i className="fa fa-external-link"></i></button>
-        </a>
-      </div>
-    </div>
-
-    <hr className="spacer" />
-
-    <div className="row">
-      <div className="col-xs-12">
-        <h4>Cluster assets are important, save them now!</h4>
+        <h4>1. Cluster assets are important, save them now!</h4>
         <p>Download and keep your cluster assets in a safe place. These are needed to destroy, replicate or quickly reinstall.</p>
         <a href="/terraform/assets" download>
-          <button className="btn btn-default" style={{marginTop: 20}}>
-            <i className="fa fa-download"></i>&nbsp;&nbsp;Download assets
+          <button className="btn btn-default" style={{marginTop: 10}}>
+            <i className="fa fa-download"></i>&nbsp;&nbsp;Download Assets
           </button>
         </a>
       </div>
@@ -55,24 +36,16 @@ export const Success = connect(stateToProps)(
 
     <div className="row">
       <div className="col-xs-12">
-        <h4>Install kubectl</h4>
-        <p>
-        You can interact with nodes and deploy your Kubernetes-aware applications with kubectl. See the <a href="https://kubernetes.io/docs/tasks/kubectl/install/" target="_blank">upstream kubectl documentation</a> for more details.
-        </p>
-        <a href="https://coreos.com/tectonic/docs/latest/tutorials/first-app.html#configuring-credentials" target="_blank"><button className="btn btn-default" style={{marginTop: 20}}>Configure kubectl&nbsp;&nbsp;<i className="fa fa-external-link"></i></button></a>
+        <h4>2. Check out Tectonic Console</h4>
+        <p>The Tectonic Console gives you an easy-to-navigate view of your cluster.</p>
+        <a href={`https://${tectonicConsole}`} target="_blank">
+          <button className="btn btn-primary wiz-giant-button"
+            style={{marginTop: 20, marginBottom: 80}}
+            onClick={() => handleAllDone(platformType)}>Go to my Tectonic Console&nbsp;&nbsp;<i className="fa fa-external-link"></i></button>
+        </a>
       </div>
     </div>
-    <hr className="spacer" />
-
-    <div className="row">
-      <div className="col-xs-12">
-        <h4>Deploy Your First Application</h4>
-        <p>
-        Once you have kubectl set up, learn how to deploy your first app!
-        </p>
-        <a href="https://coreos.com/tectonic/docs/latest/tutorials/first-app.html#deploying-a-simple-application" target="_blank"><button className="btn btn-default" style={{marginTop: 20}}>Deploy Application&nbsp;&nbsp;<i className="fa fa-external-link"></i></button></a>
-      </div>
-    </div>
-  </div>);
+  </div>
+);
 
 Success.canNavigateForward = () => false;


### PR DESCRIPTION
Remove "Install kubectl" and "Deploy Your First Application" sections because they have been moved to the Tectonic Console start page.

Text and layout changes for the remaining sections.

Completes installer side of #363.

![screenshot-2](https://user-images.githubusercontent.com/460802/29150525-16b33ab6-7db6-11e7-9d9c-6d76915366e0.png)
