### PR TITLE
tests/ci: Do not block PR trigger job until triggered jobs are finished

### DIFF
--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -48,15 +48,10 @@ job("triggers/tectonic-installer-pr-trigger") {
   }
 
   steps {
-    triggerBuilder {
-      configs {
-        blockableBuildTriggerConfig {
-          projects("tectonic-installer/PR-\${ghprbPullId}")
-          block {
-            buildStepFailureThreshold("FAILURE")
-            unstableThreshold("UNSTABLE")
-            failureThreshold("FAILURE")
-          }
+    downstreamParameterized {
+      trigger('tectonic-installer/PR-\${ghprbPullId}') {
+        parameters {
+          currentBuild()
         }
       }
     }

--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -49,11 +49,7 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   steps {
     downstreamParameterized {
-      trigger('tectonic-installer/PR-\${ghprbPullId}') {
-        parameters {
-          currentBuild()
-        }
-      }
+      trigger('tectonic-installer/PR-\${ghprbPullId}')
     }
   }
 


### PR DESCRIPTION
This change removes the synchronously from the PR trigger job