### PR TITLE
tests: Add option to trigger PR with and without smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,11 @@ pipeline {
       defaultValue: default_builder_image,
       description: 'tectonic-builder docker image to use for builds'
     )
+    booleanParam(
+      name: 'run_smoke_tests',
+      defaultValue: true,
+      description: ''
+    )
   }
 
   stages {
@@ -110,7 +115,12 @@ pipeline {
       }
     }
 
-    stage("Tests") {
+    stage("Smoke Tests") {
+      when {
+        expression {
+          return params.run_smoke_tests
+        }
+      }
       environment {
         TECTONIC_INSTALLER_ROLE = 'tectonic-installer'
         GRAFITI_DELETER_ROLE = 'grafiti-deleter'

--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger_no_smoke.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger_no_smoke.groovy
@@ -2,7 +2,7 @@
 
 folder("triggers")
 
-job("triggers/tectonic-installer-pr-trigger") {
+job("triggers/tectonic-installer-pr-trigger-no-smoke") {
   description('Tectonic Installer PR Trigger. Changes here will be reverted automatically.')
 
   concurrentBuild()
@@ -40,8 +40,8 @@ job("triggers/tectonic-installer-pr-trigger") {
       msgFailure("")
       commitStatusContext("Jenkins-Tectonic-Installer")
       buildDescTemplate("#\$pullId: \$abbrTitle")
-      blackListLabels("")
-      whiteListLabels("run-smoke-tests")
+      blackListLabels("run-smoke-tests")
+      whiteListLabels("")
       includedRegions("")
       excludedRegions("")
     }
@@ -49,7 +49,11 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   steps {
     downstreamParameterized {
-      trigger('tectonic-installer/PR-\${ghprbPullId}')
+      trigger('tectonic-installer/PR-\${ghprbPullId}') {
+        parameters {
+          booleanParam('run_smoke_tests', false)
+        }
+      }
     }
   }
 
@@ -57,7 +61,7 @@ job("triggers/tectonic-installer-pr-trigger") {
     wsCleanup()
     slackNotifier {
       authTokenCredentialId('tectonic-slack-token')
-      customMessage("Tectonic Installer PR Trigger")
+      customMessage("Tectonic Installer PR Trigger No Smoke Tests")
       includeCustomMessage(true)
       notifyBackToNormal(true)
       notifyFailure(true)


### PR DESCRIPTION
By adding an additional trigger job, we can differentiate the amount of
tests that should run per PR:

- `do-not-test` - run no tests at all
- no labels - run all tests except smoke tests
- `do-smoke-test` - run all tests

This is to temporally unblock Tectonic installer developers e.g. @ggreer which don't need to run the entire smoke test suite on their PRs all the time. In the long run I would like to implement more fine granular triggers (e.g. by cloud provider, ...).