### PR TITLE
tf/common: write an installer-dedicated `kubelet.env`

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -97,9 +97,20 @@ data "template_file" "kubelet_env" {
   }
 }
 
+# TODO(lucab): remove this in favor of torcx boostrapper (OST-23)
 data "ignition_file" "kubelet_env" {
   filesystem = "root"
   path       = "/etc/kubernetes/kubelet.env"
+  mode       = 0644
+
+  content {
+    content = "${data.template_file.kubelet_env.rendered}"
+  }
+}
+
+data "ignition_file" "installer_kubelet_env" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/installer/kubelet.env"
   mode       = 0644
 
   content {

--- a/modules/ignition/outputs.import
+++ b/modules/ignition/outputs.import
@@ -15,3 +15,7 @@ variable "ign_kubelet_service_id" {
 variable "ign_locksmithd_service_id" {
   type = "string"
 }
+
+variable "ign_installer_kubelet_env_id" {
+  type = "string"
+}

--- a/modules/ignition/outputs.tf
+++ b/modules/ignition/outputs.tf
@@ -42,8 +42,13 @@ output "locksmithd_service_id" {
   value = "${data.ignition_systemd_unit.locksmithd.id}"
 }
 
+# TODO(lucab): remove this in favor of torcx boostrapper (OST-23)
 output "kubelet_env_id" {
   value = "${data.ignition_file.kubelet_env.id}"
+}
+
+output "installer_kubelet_env_id" {
+  value = "${data.ignition_file.installer_kubelet_env.id}"
 }
 
 output "kubelet_env_rendered" {

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -126,6 +126,7 @@ module "masters" {
   tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 
   ign_docker_dropin_id          = "${module.ignition_masters.docker_dropin_id}"
+  ign_installer_kubelet_env_id  = "${module.ignition_masters.installer_kubelet_env_id}"
   ign_kubelet_service_id        = "${module.ignition_masters.kubelet_service_id}"
   ign_locksmithd_service_id     = "${module.ignition_masters.locksmithd_service_id}"
   ign_max_user_watches_id       = "${module.ignition_masters.max_user_watches_id}"
@@ -166,6 +167,7 @@ module "workers" {
   worker_iam_role              = "${var.tectonic_aws_worker_iam_role_name}"
 
   ign_docker_dropin_id          = "${module.ignition_workers.docker_dropin_id}"
+  ign_installer_kubelet_env_id  = "${module.ignition_workers.installer_kubelet_env_id}"
   ign_kubelet_service_id        = "${module.ignition_workers.kubelet_service_id}"
   ign_locksmithd_service_id     = "${module.ignition_masters.locksmithd_service_id}"
   ign_max_user_watches_id       = "${module.ignition_workers.max_user_watches_id}"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -127,14 +127,15 @@ module "masters" {
   tectonic_service_disabled = "${var.tectonic_vanilla_k8s}"
   vm_size                   = "${var.tectonic_azure_master_vm_size}"
 
-  ign_azure_udev_rules_id   = "${module.ignition_masters.azure_udev_rules_id}"
-  ign_docker_dropin_id      = "${module.ignition_masters.docker_dropin_id}"
-  ign_docker_dropin_id      = "${module.ignition_masters.docker_dropin_id}"
-  ign_kubelet_env_id        = "${module.ignition_masters.kubelet_env_id}"
-  ign_kubelet_service_id    = "${module.ignition_masters.kubelet_service_id}"
-  ign_locksmithd_service_id = "${module.ignition_masters.locksmithd_service_id}"
-  ign_max_user_watches_id   = "${module.ignition_masters.max_user_watches_id}"
-  ign_tx_off_service_id     = "${module.ignition_masters.tx_off_service_id}"
+  ign_azure_udev_rules_id      = "${module.ignition_masters.azure_udev_rules_id}"
+  ign_docker_dropin_id         = "${module.ignition_masters.docker_dropin_id}"
+  ign_docker_dropin_id         = "${module.ignition_masters.docker_dropin_id}"
+  ign_installer_kubelet_env_id = "${module.ignition_workers.installer_kubelet_env_id}"
+  ign_kubelet_env_id           = "${module.ignition_masters.kubelet_env_id}"
+  ign_kubelet_service_id       = "${module.ignition_masters.kubelet_service_id}"
+  ign_locksmithd_service_id    = "${module.ignition_masters.locksmithd_service_id}"
+  ign_max_user_watches_id      = "${module.ignition_masters.max_user_watches_id}"
+  ign_tx_off_service_id        = "${module.ignition_masters.tx_off_service_id}"
 }
 
 module "ignition_workers" {
@@ -169,13 +170,14 @@ module "workers" {
   vm_size                      = "${var.tectonic_azure_worker_vm_size}"
   worker_count                 = "${var.tectonic_worker_count}"
 
-  ign_azure_udev_rules_id   = "${module.ignition_workers.azure_udev_rules_id}"
-  ign_docker_dropin_id      = "${module.ignition_workers.docker_dropin_id}"
-  ign_kubelet_env_id        = "${module.ignition_workers.kubelet_env_id}"
-  ign_kubelet_service_id    = "${module.ignition_workers.kubelet_service_id}"
-  ign_locksmithd_service_id = "${module.ignition_masters.locksmithd_service_id}"
-  ign_max_user_watches_id   = "${module.ignition_workers.max_user_watches_id}"
-  ign_tx_off_service_id     = "${module.ignition_workers.tx_off_service_id}"
+  ign_azure_udev_rules_id      = "${module.ignition_workers.azure_udev_rules_id}"
+  ign_docker_dropin_id         = "${module.ignition_workers.docker_dropin_id}"
+  ign_installer_kubelet_env_id = "${module.ignition_workers.installer_kubelet_env_id}"
+  ign_kubelet_env_id           = "${module.ignition_workers.kubelet_env_id}"
+  ign_kubelet_service_id       = "${module.ignition_workers.kubelet_service_id}"
+  ign_locksmithd_service_id    = "${module.ignition_masters.locksmithd_service_id}"
+  ign_max_user_watches_id      = "${module.ignition_workers.max_user_watches_id}"
+  ign_tx_off_service_id        = "${module.ignition_workers.tx_off_service_id}"
 }
 
 module "dns" {

--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -107,6 +107,11 @@ storage:
       mode: 0644
       contents:
         inline: {{.ign_max_user_watches_json}}
+    - path: /etc/kubernetes/installer/kubelet.env
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: {{.ign_kubelet_env_json}}
 passwd:
   users:
     - name: core

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -38,12 +38,11 @@ systemd:
 
 storage:
   files:
-    - path: /etc/kubernetes/.empty
+    - path: /etc/kubernetes/installer/kubelet.env
       filesystem: root
       mode: 0644
       contents:
-        inline: |
-          empty
+        inline: {{.ign_kubelet_env_json}}
     - path: /etc/hostname
       filesystem: root
       mode: 0644

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -102,6 +102,7 @@ resource "matchbox_group" "worker" {
     kube_version_image = "${var.tectonic_container_images["kube_version"]}"
 
     ign_docker_dropin_json       = "${jsonencode(module.ignition_workers.docker_dropin_rendered)}"
+    ign_kubelet_env_json         = "${jsonencode(module.ignition_workers.kubelet_env_rendered)}"
     ign_kubelet_env_service_json = "${jsonencode(module.ignition_workers.kubelet_env_service_rendered)}"
     ign_kubelet_service_json     = "${jsonencode(module.ignition_workers.kubelet_service_rendered)}"
     ign_max_user_watches_json    = "${jsonencode(module.ignition_workers.max_user_watches_rendered)}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -145,11 +145,12 @@ EOF
   tectonic_service          = "${module.tectonic.systemd_service}"
   tectonic_service_disabled = "${var.tectonic_vanilla_k8s}"
 
-  ign_docker_dropin_id      = "${module.ignition_masters.docker_dropin_id}"
-  ign_kubelet_env_id        = "${module.ignition_masters.kubelet_env_id}"
-  ign_kubelet_service_id    = "${module.ignition_masters.kubelet_service_id}"
-  ign_locksmithd_service_id = "${module.ignition_masters.locksmithd_service_id}"
-  ign_max_user_watches_id   = "${module.ignition_masters.max_user_watches_id}"
+  ign_docker_dropin_id         = "${module.ignition_masters.docker_dropin_id}"
+  ign_installer_kubelet_env_id = "${module.ignition_masters.installer_kubelet_env_id}"
+  ign_kubelet_env_id           = "${module.ignition_masters.kubelet_env_id}"
+  ign_kubelet_service_id       = "${module.ignition_masters.kubelet_service_id}"
+  ign_locksmithd_service_id    = "${module.ignition_masters.locksmithd_service_id}"
+  ign_max_user_watches_id      = "${module.ignition_masters.max_user_watches_id}"
 }
 
 module "ignition_workers" {
@@ -180,11 +181,12 @@ EOF
   tectonic_service          = ""
   tectonic_service_disabled = "${var.tectonic_vanilla_k8s}"
 
-  ign_docker_dropin_id      = "${module.ignition_workers.docker_dropin_id}"
-  ign_kubelet_env_id        = "${module.ignition_masters.kubelet_env_id}"
-  ign_kubelet_service_id    = "${module.ignition_workers.kubelet_service_id}"
-  ign_locksmithd_service_id = "${module.ignition_workers.locksmithd_service_id}"
-  ign_max_user_watches_id   = "${module.ignition_workers.max_user_watches_id}"
+  ign_docker_dropin_id         = "${module.ignition_workers.docker_dropin_id}"
+  ign_installer_kubelet_env_id = "${module.ignition_workers.installer_kubelet_env_id}"
+  ign_kubelet_env_id           = "${module.ignition_masters.kubelet_env_id}"
+  ign_kubelet_service_id       = "${module.ignition_workers.kubelet_service_id}"
+  ign_locksmithd_service_id    = "${module.ignition_workers.locksmithd_service_id}"
+  ign_max_user_watches_id      = "${module.ignition_workers.max_user_watches_id}"
 }
 
 module "secrets" {

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -71,12 +71,13 @@ module "masters" {
   private_key             = "${var.tectonic_vmware_ssh_private_key_path}"
   image_re                = "${var.tectonic_image_re}"
 
-  ign_docker_dropin_id       = "${module.ignition_masters.docker_dropin_id}"
-  ign_kubelet_env_id         = "${module.ignition_masters.kubelet_env_id}"
-  ign_kubelet_env_service_id = "${module.ignition_masters.kubelet_env_service_id}"
-  ign_kubelet_service_id     = "${module.ignition_masters.kubelet_service_id}"
-  ign_locksmithd_service_id  = "${module.ignition_masters.locksmithd_service_id}"
-  ign_max_user_watches_id    = "${module.ignition_masters.max_user_watches_id}"
+  ign_docker_dropin_id         = "${module.ignition_masters.docker_dropin_id}"
+  ign_installer_kubelet_env_id = "${module.ignition_masters.installer_kubelet_env_id}"
+  ign_kubelet_env_id           = "${module.ignition_masters.kubelet_env_id}"
+  ign_kubelet_env_service_id   = "${module.ignition_masters.kubelet_env_service_id}"
+  ign_kubelet_service_id       = "${module.ignition_masters.kubelet_service_id}"
+  ign_locksmithd_service_id    = "${module.ignition_masters.locksmithd_service_id}"
+  ign_max_user_watches_id      = "${module.ignition_masters.max_user_watches_id}"
 }
 
 module "ignition_workers" {
@@ -117,10 +118,11 @@ module "workers" {
   private_key             = "${var.tectonic_vmware_ssh_private_key_path}"
   image_re                = "${var.tectonic_image_re}"
 
-  ign_docker_dropin_id       = "${module.ignition_workers.docker_dropin_id}"
-  ign_kubelet_env_id         = "${module.ignition_workers.kubelet_env_id}"
-  ign_kubelet_env_service_id = "${module.ignition_workers.kubelet_env_service_id}"
-  ign_kubelet_service_id     = "${module.ignition_workers.kubelet_service_id}"
-  ign_locksmithd_service_id  = "${module.ignition_workers.locksmithd_service_id}"
-  ign_max_user_watches_id    = "${module.ignition_workers.max_user_watches_id}"
+  ign_docker_dropin_id         = "${module.ignition_workers.docker_dropin_id}"
+  ign_installer_kubelet_env_id = "${module.ignition_workers.installer_kubelet_env_id}"
+  ign_kubelet_env_id           = "${module.ignition_workers.kubelet_env_id}"
+  ign_kubelet_env_service_id   = "${module.ignition_workers.kubelet_env_service_id}"
+  ign_kubelet_service_id       = "${module.ignition_workers.kubelet_service_id}"
+  ign_locksmithd_service_id    = "${module.ignition_workers.locksmithd_service_id}"
+  ign_max_user_watches_id      = "${module.ignition_workers.max_user_watches_id}"
 }


### PR DESCRIPTION
This updates all platforms to write the initial `kubelet.env` under
an installer-dedicated directory `/etc/kubernetes/installer/`, in
order to differentiate between the file dropped by terraform/ignition
and the one written by a bootstrap agent.

It is a prerequisite for OST-23.