### PR TITLE
Installer: make backend compatible with Terraform 0.10.x

### DIFF
--- a/installer/api/handlers_terraform.go
+++ b/installer/api/handlers_terraform.go
@@ -47,7 +47,7 @@ func terraformApplyHandler(w http.ResponseWriter, req *http.Request, ctx *Contex
 		// Restore the execution environment from the session.
 		_, ex, _, err = restoreExecutionFromSession(req, ctx.Sessions, &input.Credentials)
 	} else {
-		// Create a new TerraForm Executor with the TF variables.
+		// Create a new Terraform Executor with the TF variables.
 		ex, err = newExecutorFromApplyHandlerInput(&input)
 	}
 	if err != nil {
@@ -57,24 +57,24 @@ func terraformApplyHandler(w http.ResponseWriter, req *http.Request, ctx *Contex
 
 	// Copy the TF Templates to the Executor's working directory.
 	if err := terraform.RestoreSources(ex.WorkingDirectory()); err != nil {
-		return newInternalServerError("could not write TerraForm templates: %s", err)
+		return newInternalServerError("could not write Terraform templates: %s", err)
 	}
 
 	// Choose to run 'get' or 'init' based on Terraform version.
-	verRx := regexp.MustCompile("^Terraform v0\\.[0-9]\\.[0-9]+")
+	sub10Rx := regexp.MustCompile("^Terraform v0\\.[0-9]\\.[0-9]+")
 	out, err := exec.Command("terraform", "version").Output()
 	if err != nil {
 		return newInternalServerError("Failed to determine Terraform version: %s", err)
 	}
-	var prepCommand = "init"
-	if verRx.Match(out) {
+	prepCommand := "init"
+	if sub10Rx.Match(out) {
 		prepCommand = "get"
 	}
 
-	// Execute TerraForm get or init and wait for it to finish.
+	// Execute Terraform get or init and wait for it to finish.
 	_, prepDone, err := ex.Execute(prepCommand, "-no-color", tfMainDir)
 	if err != nil {
-		return newInternalServerError("Failed to run TerraForm (%s): %s", prepCommand, err)
+		return newInternalServerError("Failed to run Terraform (%s): %s", prepCommand, err)
 	}
 	<-prepDone
 
@@ -93,7 +93,7 @@ func terraformApplyHandler(w http.ResponseWriter, req *http.Request, ctx *Contex
 		action = "apply"
 	}
 	if err != nil {
-		return newInternalServerError("Failed to run TerraForm (%s): %s", action, err)
+		return newInternalServerError("Failed to run Terraform (%s): %s", action, err)
 	}
 	session.Values["terraform_id"] = id
 	session.Values["action"] = action
@@ -142,10 +142,10 @@ func terraformDestroyHandler(w http.ResponseWriter, req *http.Request, ctx *Cont
 	}
 	tfMainDir := fmt.Sprintf("%s/platforms/%s", ex.WorkingDirectory(), input.Platform)
 
-	// Execute TerraForm apply in the background.
+	// Execute Terraform apply in the background.
 	id, _, err := ex.Execute("destroy", "-force", "-no-color", tfMainDir)
 	if err != nil {
-		return newInternalServerError("Failed to run TerraForm (apply): %s", err)
+		return newInternalServerError("Failed to run Terraform (apply): %s", err)
 	}
 
 	// Store both the path to the Executor and the ID of the execution so that
@@ -178,7 +178,7 @@ func newExecutorFromApplyHandlerInput(input *TerraformApplyHandlerInput) (*terra
 	// Create a new Executor.
 	ex, err := terraform.NewExecutor(exPath)
 	if err != nil {
-		return nil, newInternalServerError("Could not create TerraForm executor: %s", err)
+		return nil, newInternalServerError("Could not create Terraform executor: %s", err)
 	}
 
 	// Write the License and Pull Secret to disk, and wire these files in the
@@ -223,10 +223,10 @@ func newExecutorFromApplyHandlerInput(input *TerraformApplyHandlerInput) (*terra
 	if variables, err := json.MarshalIndent(input.Variables, "", "  "); err == nil {
 		ex.AddVariables(variables)
 	} else {
-		return nil, newBadRequestError("Could not marshal TerraForm variables: %s", err)
+		return nil, newBadRequestError("Could not marshal Terraform variables: %s", err)
 	}
 	if err := ex.AddCredentials(&input.Credentials); err != nil {
-		return nil, newBadRequestError("Could not validate TerraForm credentials: %v", err)
+		return nil, newBadRequestError("Could not validate Terraform credentials: %v", err)
 	}
 
 	return ex, nil
@@ -249,10 +249,10 @@ func restoreExecutionFromSession(req *http.Request, sessionProvider sessions.Sto
 	}
 	ex, err := terraform.NewExecutor(executionPath.(string))
 	if err != nil {
-		return nil, nil, -1, newInternalServerError("Could not create TerraForm executor")
+		return nil, nil, -1, newInternalServerError("Could not create Terraform executor")
 	}
 	if err := ex.AddCredentials(credentials); err != nil {
-		return nil, nil, -1, newBadRequestError("Could not validate TerraForm credentials")
+		return nil, nil, -1, newBadRequestError("Could not validate Terraform credentials")
 	}
 	return session, ex, executionID.(int), nil
 }


### PR DESCRIPTION
This change makes the the backend compatible with Terraform beyond 0.9.x

It adds logic to determine the version of Terraform being used and decides based on version if it needs to run `terraform get` in case of 0.9.x or `terraform init` for 0.10.x and beyond.

Note that the new `init` command also includes the previous functionality of `get` so there is no need to run both.

/cc: @sym3tri 