### PR TITLE
Use kubernetes version for anti-affinity.

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -106,7 +106,7 @@ resource "template_dir" "bootkube" {
     etcd_client_cert = "${base64encode(data.template_file.etcd_client_crt.rendered)}"
     etcd_client_key  = "${base64encode(data.template_file.etcd_client_key.rendered)}"
 
-    tectonic_version = "${var.versions["tectonic"]}"
+    kubernetes_version = "${var.versions["kubernetes"]}"
 
     master_count              = "${var.master_count}"
     node_monitor_grace_period = "${var.node_monitor_grace_period}"

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-controller-manager
-        pod-anti-affinity: kube-controller-manager-${tectonic_version}
+        pod-anti-affinity: kube-controller-manager-${kubernetes_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -26,7 +26,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                pod-anti-affinity: kube-controller-manager-${tectonic_version}
+                pod-anti-affinity: kube-controller-manager-${kubernetes_version}
             namespaces:
               - kube-system
             topologyKey: kubernetes.io/hostname
@@ -67,6 +67,11 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      selector:
+        matchLabels:
+          k8s-app: kube-controller-manager
+          pod-anti-affinity: kube-controller-manager-${kubernetes_version}
+          tier: control-plane
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-scheduler
-        pod-anti-affinity: kube-scheduler-${tectonic_version}
+        pod-anti-affinity: kube-scheduler-${kubernetes_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -26,7 +26,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                pod-anti-affinity: kube-scheduler-${tectonic_version}
+                pod-anti-affinity: kube-scheduler-${kubernetes_version}
             namespaces:
               - kube-system
             topologyKey: kubernetes.io/hostname
@@ -48,6 +48,11 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      selector:
+        matchLabels:
+          k8s-app: kube-scheduler
+          pod-anti-affinity: kube-scheduler-${kubernetes_version}
+          tier: control-plane
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"


### PR DESCRIPTION
We don't always upgrade the control plane when bumping tectonic versions
(e.g. from 1.6.7-tectonic.1 to 1.6.7-tectonic.2). I think it only makes
sense to enforce the anti-affinity when we are actually bumping
kubernetes.

Right now we have a divergence where 1.6.7-tectonic.2 clusters that
were installed from that version will have '1.6.7-tectonic.2'
anti-affinity in their manifests, whereas anything prior will have
'1.6.7-tectonic.1'.