### PR TITLE
azure: Remove hardcoded Container Linux version

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -70,14 +70,13 @@ variable "tectonic_versions" {
   type        = "map"
 
   default = {
-    alertmanager    = "v0.7.1"
-    container_linux = "1353.8.0"
-    etcd            = "3.1.8"
-    kubernetes      = "1.7.1+tectonic.1"
-    monitoring      = "1.4.1"
-    prometheus      = "v1.7.1"
-    tectonic        = "1.7.1-tectonic.1"
-    tectonic-etcd   = "0.0.1"
+    alertmanager  = "v0.7.1"
+    etcd          = "3.1.8"
+    kubernetes    = "1.7.1+tectonic.1"
+    monitoring    = "1.4.1"
+    prometheus    = "v1.7.1"
+    tectonic      = "1.7.1-tectonic.1"
+    tectonic-etcd = "0.0.1"
   }
 }
 

--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -24,7 +24,7 @@ resource "azurerm_virtual_machine" "etcd_node" {
     publisher = "CoreOS"
     offer     = "CoreOS"
     sku       = "${var.cl_channel}"
-    version   = "${var.versions["container_linux"]}"
+    version   = "latest"
   }
 
   storage_os_disk {

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -23,7 +23,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
     publisher = "CoreOS"
     offer     = "CoreOS"
     sku       = "${var.cl_channel}"
-    version   = "${var.versions["container_linux"]}"
+    version   = "latest"
   }
 
   storage_os_disk {

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -28,7 +28,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
     publisher = "CoreOS"
     offer     = "CoreOS"
     sku       = "${var.cl_channel}"
-    version   = "${var.versions["container_linux"]}"
+    version   = "latest"
   }
   storage_os_disk {
     name              = "worker-${count.index}-os-${var.storage_id}"


### PR DESCRIPTION
Currently, the Container Linux version is referenced in the `storage_image_reference` map for the creation of Azure resources as `version   = "${var.versions["container_linux"]}"`.

The `versions` var points to the `tectonic_versions` map, defined in `config.tf`.

The default map for `tectonic_versions` map hardcodes `container_linux`, which is causing Azure implementations to be instantiated w/ an old version of Container Linux.

This PR uses `version   = "latest"` instead, which will work across all Azure SKUs / `cl_channel`s.

@crawford: this fixes what we were discussing on the channel

cc: @alexsomesan @s-urbaniak @squat