### PR TITLE
Fix spelling of 'Terraform' word

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ pipeline {
               }
             }
           },
-          "SmokeTest TerraForm: AWS": {
+          "SmokeTest Terraform: AWS": {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(args: '-v /etc/passwd:/etc/passwd:ro', image: params.builder_image) {
@@ -190,7 +190,7 @@ pipeline {
               }
             }
           },
-          "SmokeTest TerraForm: AWS (non-TLS)": {
+          "SmokeTest Terraform: AWS (non-TLS)": {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(params.builder_image) {
@@ -209,7 +209,7 @@ pipeline {
               }
             }
           },
-          "SmokeTest TerraForm: AWS (experimental)": {
+          "SmokeTest Terraform: AWS (experimental)": {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(params.builder_image) {
@@ -228,7 +228,7 @@ pipeline {
               }
             }
           },
-          "SmokeTest TerraForm: AWS (network policy)": {
+          "SmokeTest Terraform: AWS (network policy)": {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(params.builder_image) {
@@ -269,7 +269,7 @@ pipeline {
               }
             }
           },
-          "SmokeTest TerraForm: AWS (custom ca)": {
+          "SmokeTest Terraform: AWS (custom ca)": {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(params.builder_image) {
@@ -288,7 +288,7 @@ pipeline {
               }
             }
           },
-          "SmokeTest TerraForm: AWS (private vpc)": {
+          "SmokeTest Terraform: AWS (private vpc)": {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(image: params.builder_image, args: '--device=/dev/net/tun --cap-add=NET_ADMIN -u root') {

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -1,5 +1,5 @@
 # This output is meant to be used to inject a dependency on the generated
-# assets. As of TerraForm v0.9, it is difficult to make a module depend on
+# assets. As of Terraform v0.9, it is difficult to make a module depend on
 # another module (no depends_on, no triggers), or to make a data source
 # depend on a module (no depends_on, no triggers, generally no dummy variable).
 #

--- a/modules/tectonic/output.tf
+++ b/modules/tectonic/output.tf
@@ -1,5 +1,5 @@
 # This output is meant to be used to inject a dependency on the generated
-# assets. As of TerraForm v0.9, it is difficult to make a module depend on
+# assets. As of Terraform v0.9, it is difficult to make a module depend on
 # another module (no depends_on, no triggers), or to make a data source
 # depend on a module (no depends_on, no triggers, generally no dummy variable).
 #

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -141,6 +141,6 @@ data "archive_file" "assets" {
   #
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
-  # folder, we write it in the TerraForm managed hidden folder `.terraform`.
+  # folder, we write it in the Terraform managed hidden folder `.terraform`.
   output_path = "./.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id} ${module.flannel-vxlan.id} ${module.calico-network-policy.id}")}.zip"
 }

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -120,6 +120,6 @@ data "archive_file" "assets" {
   #
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
-  # folder, we write it in the TerraForm managed hidden folder `.terraform`.
+  # folder, we write it in the Terraform managed hidden folder `.terraform`.
   output_path = "./.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id} ${module.flannel_vxlan.id} ${module.calico_network_policy.id}")}.zip"
 }

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -122,6 +122,6 @@ data "archive_file" "assets" {
   #
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
-  # folder, we write it in the TerraForm managed hidden folder `.terraform`.  
+  # folder, we write it in the Terraform managed hidden folder `.terraform`.  
   output_path = "./.terraform/generated_${sha1("${module.tectonic.id} ${module.bootkube.id} ${module.flannel-vxlan.id} ${module.calico-network-policy.id}")}.zip"
 }


### PR DESCRIPTION
As noted by @squat, we were using a funny spelling for the word 'Terraform'.
This fixes it.