### PR TITLE
tests: Refactor cluster logic to use inheritance for different platforms

### DIFF
--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -1,18 +1,26 @@
-require 'env_var'
+require 'cluster'
 
-# AWS contains helper functions for the AWS cloud provider
-module AWS
-  def self.check_prerequisites
-    raise 'AWS credentials not defined' unless credentials_defined?
-    raise 'TF_VAR_tectonic_aws_ssh_key is not defined' unless ssh_key_defined?
+# AWSCluster represents a k8s cluster on AWS cloud provider
+class AWSCluster < Cluster
+  def env_variables
+    variables = super
+    variables['PLATFORM'] = 'aws'
+    variables
   end
 
-  def self.credentials_defined?
+  def check_prerequisites
+    raise 'AWS credentials not defined' unless credentials_defined?
+    raise 'TF_VAR_tectonic_aws_ssh_key is not defined' unless ssh_key_defined?
+
+    super
+  end
+
+  def credentials_defined?
     credential_names = %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
     EnvVar.set?(credential_names)
   end
 
-  def self.ssh_key_defined?
+  def ssh_key_defined?
     EnvVar.set?(%w[TF_VAR_tectonic_aws_ssh_key])
   end
 end

--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -9,9 +9,9 @@ class Cluster
   MAX_NAME_LENGTH = 28
   RANDOM_HASH_LENGTH = 5
 
-  attr_reader :tfvars_file, :kubeconfig, :manifest_path, :platform
+  attr_reader :tfvars_file, :kubeconfig, :manifest_path
 
-  def initialize(prefix, tfvars_file_path, platform)
+  def initialize(prefix, tfvars_file_path)
     # Enable local testers to specify a static cluster name
     # S3 buckets can only handle lower case names
     @name = (ENV['CLUSTER'] || generate_name(prefix)).downcase
@@ -21,8 +21,6 @@ class Cluster
     @manifest_path = `echo $(realpath ../../build)/#{@name}/generated`
                      .delete("\n")
     @kubeconfig = manifest_path + '/auth/kubeconfig'
-
-    @platform = platform
   end
 
   def start
@@ -47,8 +45,7 @@ class Cluster
   def env_variables
     {
       'CLUSTER' => @name,
-      'TF_VAR_tectonic_cluster_name' => @name,
-      'PLATFORM' => @platform
+      'TF_VAR_tectonic_cluster_name' => @name
     }
   end
 
@@ -96,7 +93,7 @@ class Cluster
       begin
         KubeCTL.run(@kubeconfig, 'cluster-info')
         return
-      rescue KubectlCmdError
+      rescue KubeCTL::KubeCTLCmdError
         sleep 10
       end
     end

--- a/tests/rspec/lib/forensic.rb
+++ b/tests/rspec/lib/forensic.rb
@@ -3,7 +3,7 @@ require 'ssh'
 # Forensic contains helper functions to run the cluster forensic scripts
 module Forensic
   def self.run(cluster)
-    return if cluster.platform != 'aws'
+    return if cluster.class.name != 'AWSCluster'
     check_prerequisites
 
     env_variables = cluster.env_variables

--- a/tests/rspec/lib/kubectl_helpers.rb
+++ b/tests/rspec/lib/kubectl_helpers.rb
@@ -6,7 +6,7 @@ require 'English'
 module KubeCTL
   def self.run(kubeconfig, args)
     out = `KUBECONFIG=#{kubeconfig} kubectl #{args}`
-    raise KubectlCmdError if $CHILD_STATUS.exitstatus != 0
+    raise KubeCTLCmdError if $CHILD_STATUS.exitstatus != 0
     out
   end
 
@@ -15,8 +15,8 @@ module KubeCTL
     JSON.parse(out)
   end
 
-  # KubectlCmdError is raised whenever the shell command 'kubectl' fails
-  class KubectlCmdError < StandardError
+  # KubeCTLCmdError is raised whenever the shell command 'kubectl' fails
+  class KubeCTLCmdError < StandardError
     def initialize(msg = 'failed to call kubectl')
       super
     end

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -1,16 +1,13 @@
 require 'smoke_test'
-require 'cluster'
-require 'aws'
+require 'aws_cluster'
 require 'forensic'
 
 RSpec.shared_examples 'withCluster' do |tf_vars_path|
   before(:all) do
-    AWS.check_prerequisites
-
     prefix = File.basename(tf_vars_path).split('.').first
     raise 'could not extract prefix from tfvars file name' if prefix == ''
 
-    @cluster = Cluster.new(prefix, tf_vars_path, 'aws')
+    @cluster = AWSCluster.new(prefix, tf_vars_path)
     @cluster.start
   end
 


### PR DESCRIPTION
I soon want to add Azure to our RSpec code base. This will make it as simple as adding  a child class to the `Cluster` parent class.