### PR TITLE
README: remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Tectonic Installer
-![Build Status](https://jenkins-tectonic-installer.prod.coreos.systems/buildStatus/icon?job=tectonic-installer/master)
 
 Tectonic is built on pure-upstream Kubernetes but has an opinion on the best way to install and run a Kubernetes cluster. This project helps you install a Kubernetes cluster the "Tectonic Way". It provides good defaults, enables install automation, and is customizable to meet your infrastructure needs.
 


### PR DESCRIPTION
The Tectonic Installer jenkins isn't word readable so this badge is
pointless. Remove it until we have published results.