### PR TITLE
tests/ci: add multibranch tectonic-installer jenkins job

### DIFF
--- a/tests/jenkins-jobs/README.md
+++ b/tests/jenkins-jobs/README.md
@@ -33,6 +33,14 @@ Parameters:
 
 * No input parameters are required.
 
+## Tectonic Installer MultiBranch Job
+
+This file (`tectonic_installer_multibranch_job.groovy`) creates a Jenkins job called `tectonic-installer` this is the job which the tests will run.
+
+Parameters:
+
+* No input parameters are required.
+
 ## Tectonic Installer Upstream Terraform Trigger
 
 This file creates a Jenkins job called `upstream-terraform-trigger` under `triggers` folder to run the tests against the `Tectonic Installer` in the `master` branch using the `upstream Terraform`

--- a/tests/jenkins-jobs/tectonic_installer_multibranch_job.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_multibranch_job.groovy
@@ -1,0 +1,40 @@
+#!/bin/env groovy​
+
+multibranchPipelineJob("tectonic-installer") {
+  description("Install a Kubernetes cluster the CoreOS Tectonic Way: HA, self-hosted, RBAC, etcd Operator, and more\nThis job is manage by tectonic-installer.\nChanges here will be reverted automatically.")
+  branchSources {
+    branchSource {
+      source {
+        github {
+          scanCredentialsId("37477e0c-2ab6-46fe-a83b-64b1add4777d")
+          checkoutCredentialsId("37477e0c-2ab6-46fe-a83b-64b1add4777d")
+          apiUri("")
+          repoOwner("coreos")
+          repository("tectonic-installer")
+          buildForkPRHead(false)
+          buildForkPRMerge(true)
+          buildOriginBranch(true)
+          buildOriginBranchWithPR(false)
+          buildOriginPRHead(false)
+          buildOriginPRMerge(true)
+        }
+      }
+      strategy {
+        defaultBranchPropertyStrategy {
+          props {
+            noTriggerBranchProperty()
+          }
+        }
+      }
+    }
+  }
+  orphanedItemStrategy {
+    discardOldItems {
+      daysToKeep(5)
+      numToKeep(100)
+    }
+  }
+  triggers {
+    periodic(1440)
+  }
+}


### PR DESCRIPTION
Before merging this PR we need to delete the existing `tectonic-installer` Jenkins job.
This will replace the existing one.

cc @mxinden 