### PR TITLE
azure: Remove hardcoded CL ver (`versions["container_linux"]`)

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -70,14 +70,13 @@ variable "tectonic_versions" {
   type        = "map"
 
   default = {
-    container_linux = "1353.8.0"
-    etcd            = "3.1.8"
-    prometheus      = "v1.7.1"
-    alertmanager    = "v0.7.1"
-    monitoring      = "1.4.1"
-    kubernetes      = "1.7.1+tectonic.1"
-    tectonic        = "1.7.1-tectonic.2"
-    tectonic-etcd   = "0.0.1"
+    etcd          = "3.1.8"
+    prometheus    = "v1.7.1"
+    alertmanager  = "v0.7.1"
+    monitoring    = "1.4.1"
+    kubernetes    = "1.7.1+tectonic.1"
+    tectonic      = "1.7.1-tectonic.2"
+    tectonic-etcd = "0.0.1"
   }
 }
 

--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -18,7 +18,7 @@ resource "azurerm_virtual_machine" "etcd_node" {
     publisher = "CoreOS"
     offer     = "CoreOS"
     sku       = "${var.cl_channel}"
-    version   = "${var.versions["container_linux"]}"
+    version   = "latest"
   }
 
   storage_os_disk {

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -40,7 +40,7 @@ resource "azurerm_virtual_machine" "tectonic_master" {
     publisher = "CoreOS"
     offer     = "CoreOS"
     sku       = "${var.cl_channel}"
-    version   = "${var.versions["container_linux"]}"
+    version   = "latest"
   }
 
   storage_os_disk {

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -45,7 +45,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
     publisher = "CoreOS"
     offer     = "CoreOS"
     sku       = "${var.cl_channel}"
-    version   = "${var.versions["container_linux"]}"
+    version   = "latest"
   }
   storage_os_disk {
     name          = "worker-osdisk"


### PR DESCRIPTION
Cherry-picks #1668 in the Tectonic 1.7.1 release.

/cc @justaugustus