### PR TITLE
modules/bootkube: remove critical pod annotation

### DIFF
--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -20,7 +20,6 @@ spec:
         tectonic-operators.coreos.com/managed-by: kube-version-operator
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       containers:
       - name: kube-apiserver
@@ -81,8 +80,6 @@ spec:
           readOnly: false
       hostNetwork: true
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -24,8 +24,6 @@ spec:
         k8s-app: kube-controller-manager
         pod-anti-affinity: kube-controller-manager-${kubernetes_version}
         tectonic-operators.coreos.com/managed-by: kube-version-operator
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       affinity:
         podAntiAffinity:
@@ -74,8 +72,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"

--- a/modules/bootkube/resources/manifests/kube-proxy.yaml
+++ b/modules/bootkube/resources/manifests/kube-proxy.yaml
@@ -18,8 +18,6 @@ spec:
         tier: node
         k8s-app: kube-proxy
         tectonic-operators.coreos.com/managed-by: kube-version-operator
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       containers:
       - name: kube-proxy
@@ -47,8 +45,6 @@ spec:
           readOnly: true
       hostNetwork: true
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -24,8 +24,6 @@ spec:
         k8s-app: kube-scheduler
         pod-anti-affinity: kube-scheduler-${kubernetes_version}
         tectonic-operators.coreos.com/managed-by: kube-version-operator
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       affinity:
         podAntiAffinity:
@@ -55,8 +53,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       tolerations:
-      - key: "CriticalAddonsOnly"
-        operator: "Exists"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"


### PR DESCRIPTION
Remove the critical pod annotation and toleration from the
controller-manager and scheduler, since this can result in dangerous
behavior as discussed in
https://github.com/kubernetes-incubator/bootkube/issues/519.

fixes: #734 

cc @aaronlevy 