### PR TITLE
make-update-payload.sh: Include AppVersion's metadata in desired versions.

### DIFF
--- a/modules/update-payload/make-update-payload.sh
+++ b/modules/update-payload/make-update-payload.sh
@@ -98,13 +98,13 @@ for f in ${ASSETS_DIR}/app_versions/*.yaml; do
   fi
   tmpfile=$(mktemp /tmp/desiredVersion.XXXXXX)
   # shellcheck disable=SC2086
-  name=$(yaml2json < ${f} | jq .metadata.name)
+  metadata=$(yaml2json < ${f} | jq .metadata)
   # shellcheck disable=SC2086
   desiredVersion=$(yaml2json < ${f} | jq .status.currentVersion)
   # shellcheck disable=SC2086
   cat <<EOF > ${tmpfile}
 {
-  "name": ${name},
+  "metadata": ${metadata},
   "version": ${desiredVersion}
 }
 EOF

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -311,11 +311,23 @@
       "version": "1.7.1+tectonic.1"
     },
     {
-      "name": "tectonic-etcd",
+      "metadata": {
+        "labels": {
+          "managed-by-channel-operator": "true"
+        },
+        "name": "tectonic-etcd",
+        "namespace": "tectonic-system"
+      },
       "version": "0.0.1"
     },
     {
-      "name": "tectonic-monitoring",
+      "metadata": {
+        "labels": {
+          "managed-by-channel-operator": "true"
+        },
+        "name": "tectonic-monitoring",
+        "namespace": "tectonic-system"
+      },
       "version": "1.4.1"
     }
   ]


### PR DESCRIPTION
This copies the appversion's metadata in the payload so we can
decide whether to create an appversion by looking at its annotation
in the payload.