### PR TITLE
modules/tectonic/resources: pin components to masters

### DIFF
--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -25,6 +25,16 @@ spec:
         component: ui
       name: tectonic-console
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  matchLabels:
+                    k8s-app: tectonic-console
+              topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /opt/bridge/bin/bridge
@@ -163,3 +173,9 @@ spec:
       - name: tectonic-identity-grpc-client-secret
         secret:
           secretName: tectonic-identity-grpc-client-secret
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/modules/tectonic/resources/manifests/identity/deployment.yaml
+++ b/modules/tectonic/resources/manifests/identity/deployment.yaml
@@ -23,16 +23,16 @@ spec:
         k8s-app: tectonic-identity
         component: identity
     spec:
-      volumes:
-      - name: config
-        configMap:
-          name: tectonic-identity
-          items:
-          - key: config.yaml
-            path: config.yaml
-      - name: tectonic-identity-grpc-server-secret
-        secret:
-          secretName: tectonic-identity-grpc-server-secret
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  matchLabels:
+                    k8s-app: tectonic-identity
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: tectonic-identity
         imagePullPolicy: IfNotPresent
@@ -66,6 +66,22 @@ spec:
       # private registry.
       imagePullSecrets:
       - name: coreos-pull-secret
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      volumes:
+      - name: config
+        configMap:
+          name: tectonic-identity
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: tectonic-identity-grpc-server-secret
+        secret:
+          secretName: tectonic-identity-grpc-server-secret

--- a/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/default-backend/deployment.yaml
@@ -10,7 +10,16 @@ spec:
       labels:
         k8s-app: default-http-backend
     spec:
-      terminationGracePeriodSeconds: 60
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  matchLabels:
+                    k8s-app: default-http-backend
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: default-http-backend
         # Any image is permissable as long as:
@@ -35,3 +44,10 @@ spec:
             memory: 20Mi
       imagePullSecrets:
       - name: coreos-pull-secret
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      terminationGracePeriodSeconds: 60
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"

--- a/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
+++ b/modules/tectonic/resources/manifests/ingress/nodeport/deployment.yaml
@@ -16,6 +16,16 @@ spec:
         component: ingress-controller
         type: nginx
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  matchLabels:
+                    k8s-app: tectonic-lb
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: nginx-ingress-lb
           image: ${ingress_controller_image}
@@ -55,5 +65,11 @@ spec:
               port: 10254
               scheme: HTTP
       dnsPolicy: ClusterFirst
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
       restartPolicy: Always
       terminationGracePeriodSeconds: 60
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"


### PR DESCRIPTION
This commit pins the identity, ingress, and console components to master
nodes and configures them with `preferred` anti-affinity to promote HA
configurations.

Tomorrow, when @derekparker is in, we can create the update-spec and add these new manifests to allow clusters to update to this configuration.