### PR TITLE
frontend: Add warning for small pod IP address ranges

### DIFF
--- a/installer/frontend/components/cidr.jsx
+++ b/installer/frontend/components/cidr.jsx
@@ -6,16 +6,20 @@ import { Deselect, Input, WithClusterConfig } from './ui';
 import { validate } from '../validate';
 import { DESELECTED_FIELDS } from '../cluster-config.js';
 
+export const cidrSize = cidr => {
+  if (validate.CIDR(cidr)) {
+    return null;
+  }
+  const [, bits] = cidr.split('/');
+
+  // JavaScript's bit shifting only works on signed 32bit ints so <<31 would be negative :(
+  return Math.pow(2, 32 - parseInt(bits, 10));
+};
+
 const CIDRTooltip = connect(
   ({clusterConfig}, {field}) => ({clusterConfig: clusterConfig, value: _.get(clusterConfig, field)})
 )(({value}) => {
-  if (validate.CIDR(value)) {
-    return null;
-  }
-  const [, bits] = value.split('/');
-  // javascript's bit shifting only works on signed 32bit ints so <<31
-  // would be negative :(
-  const addresses = Math.pow(2, 32 - parseInt(bits, 10));
+  const addresses = cidrSize(value);
   return <div className="tooltip">{addresses} IP address{addresses > 1 && 'es'}</div>;
 });
 

--- a/installer/frontend/components/k8s-cidrs.jsx
+++ b/installer/frontend/components/k8s-cidrs.jsx
@@ -1,15 +1,59 @@
+import _ from 'lodash';
+import pluralize from 'pluralize';
 import React from 'react';
+import { connect } from 'react-redux';
 
-import { CIDR } from './cidr';
+import { AWS_TF } from '../platforms';
+import { Alert } from './alert';
+import { CIDR, cidrSize } from './cidr';
 import {
+  AWS_CONTROLLERS,
+  AWS_WORKERS,
+  NUMBER_OF_INSTANCES,
+  PLATFORM_TYPE,
   POD_CIDR,
   SERVICE_CIDR,
 } from '../cluster-config';
+
+const PodRangeWarning = connect(
+  ({clusterConfig}) => ({clusterConfig})
+)(({clusterConfig}) => {
+  const size = cidrSize(_.get(clusterConfig, POD_CIDR));
+
+  // Currently, we only expect to have the node count for AWS because of the wizard screen order
+  if (!size || clusterConfig[PLATFORM_TYPE] !== AWS_TF) {
+    return null;
+  }
+
+  // Flannel assigns a minimum network size of /24 (256 IP addresses)
+  const maxNodes = Math.floor(size / 256);
+
+  const controllers = _.get(clusterConfig, `${AWS_CONTROLLERS}-${NUMBER_OF_INSTANCES}`, 0);
+  const workers = _.get(clusterConfig, `${AWS_WORKERS}-${NUMBER_OF_INSTANCES}`, 0);
+  const nodes = controllers + workers;
+  const utilization = nodes / maxNodes;
+
+  if (utilization < 0.75) {
+    return null;
+  }
+
+  if (utilization > 1) {
+    return <Alert severity="error">
+      <b>Pod Range Too Small</b><br />
+      {maxNodes === 0 ? 'No nodes' : `Only ${maxNodes} of your ${nodes} ${pluralize('node', nodes)}`} can fit within the pod range, since each node requires a minimum of 256 IP addresses.
+    </Alert>;
+  }
+  return <Alert>
+    <b>Pod Range Mostly Assigned</b><br />
+    Only {maxNodes} {pluralize('node', maxNodes)} can fit within the pod range, since each node requires a minimum of 256 IP addresses. You have selected {nodes} {pluralize('node', nodes)}.
+  </Alert>;
+});
 
 export const KubernetesCIDRs = ({validator}) => <div className="row form-group">
   <div className="col-xs-12">
     <h4>Kubernetes</h4>
     <CIDR name="Pod Range" field={POD_CIDR} placeholder="10.2.0.0/16" validator={validator} />
     <CIDR name="Service Range" field={SERVICE_CIDR} placeholder="10.3.0.0/16" validator={validator} />
+    <PodRangeWarning />
   </div>
 </div>;


### PR DESCRIPTION
Shows an error box if the number of configured nodes is greater than the pod range will allow. (But does not disable the Next Step button.)

Shows an info box if over 75% of the range will be used by the configured nodes.

This PR only checks for AWS. A future PR will add the warning for bare metal.

See #791

![screenshot-1](https://user-images.githubusercontent.com/460802/29482468-94fc9bd4-84cc-11e7-8314-4d8ca9792505.png)
![screenshot-2](https://user-images.githubusercontent.com/460802/29482469-974a0372-84cc-11e7-9512-d3b23e2fc0bc.png)