### PR TITLE
vmware: multi-az labels

### DIFF
--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -52,7 +52,7 @@ data "template_file" "kubelet" {
 
   vars {
     cluster_dns_ip    = "${var.kube_dns_service_ip}"
-    node_label        = "${var.kubelet_node_label}"
+    node_label        = "${format("%s,failure-domain.beta.kubernetes.io/region=%s,failure-domain.beta.kubernetes.io/zone=%s", var.kubelet_node_label, var.vmware_datacenter , var.vmware_cluster)}"
     node_taints_param = "${var.kubelet_node_taints != "" ? "--register-with-taints=${var.kubelet_node_taints}" : ""}"
     cni_bin_dir_flag  = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"
   }


### PR DESCRIPTION
manually adds `failure-domain.beta.kubernetes.io/region` and `failure-domain.beta.kubernetes.io/zone` labels to the nodes. 

This change does not have immediate impact with the current VMware Tectonic design. Based on Field Engineering engagement discussion, this change is useful for multi-AZ topology deployment of Tectonic on VMware.

/cc: @lander2k2 @metral 