### PR TITLE
modules/bootkube: fix disruption

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -106,7 +106,7 @@ resource "template_dir" "bootkube" {
     etcd_client_cert = "${base64encode(data.template_file.etcd_client_crt.rendered)}"
     etcd_client_key  = "${base64encode(data.template_file.etcd_client_key.rendered)}"
 
-    kubernetes_version = "${var.versions["kubernetes"]}"
+    kubernetes_version = "${replace(var.versions["kubernetes"], "+", "-")}"
 
     master_count              = "${var.master_count}"
     node_monitor_grace_period = "${var.node_monitor_grace_period}"

--- a/modules/bootkube/resources/manifests/kube-controller-manager-disruption.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager-disruption.yaml
@@ -7,5 +7,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      tier: control-plane
       k8s-app: kube-controller-manager
+      pod-anti-affinity: kube-controller-manager-${kubernetes_version}
+      tier: control-plane

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -67,11 +67,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      selector:
-        matchLabels:
-          k8s-app: kube-controller-manager
-          pod-anti-affinity: kube-controller-manager-${kubernetes_version}
-          tier: control-plane
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/modules/bootkube/resources/manifests/kube-scheduler-disruption.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler-disruption.yaml
@@ -7,5 +7,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      tier: control-plane
       k8s-app: kube-scheduler
+      pod-anti-affinity: kube-scheduler-${kubernetes_version}
+      tier: control-plane

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -48,11 +48,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      selector:
-        matchLabels:
-          k8s-app: kube-scheduler
-          pod-anti-affinity: kube-scheduler-${kubernetes_version}
-          tier: control-plane
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"


### PR DESCRIPTION
Pull request #1667 introduced a regression in the kube-scheduler and
kube-controller-manager deployments that prevented them from being
created by bootkube start because the pod specs were invalid. The specs
contained a `selector` field, which should have been in the disruption
instead.

This is a very urgent issue. PTAL @diegs @yifan-gu @Quentin-M.