### PR TITLE
modules/tectonic: fix CRD API group

### DIFF
--- a/modules/tectonic/resources/manifests/updater/migration-status-kind.yaml
+++ b/modules/tectonic/resources/manifests/updater/migration-status-kind.yaml
@@ -3,7 +3,7 @@ kind: "CustomResourceDefinition"
 metadata:
   name: "migrationstatuses.kvo.coreos.com"
 spec:
-  group: "tco.coreos.com"
+  group: "kvo.coreos.com"
   version: "v1"
   names:
     plural: "migrationstatuses"


### PR DESCRIPTION
This commit fixes the API group of the Migration Status CRD. The correct
API group is `kvo.coreos.com`. The incorrect group was causing the
Tectonic systemd unit to fail to bring up all the components.

Fixes a regression introduced in: #1704 

cc @yifan-gu @rithujohn191 