### PR TITLE
modules/openstack/secgroups: Enable Port 80 for workers inside cluster

### DIFF
--- a/modules/openstack/secgroups/output.tf
+++ b/modules/openstack/secgroups/output.tf
@@ -25,6 +25,8 @@ output "secgroup_node_ids" {
   value = [
     "${openstack_networking_secgroup_v2.base.id}",
     "${openstack_networking_secgroup_v2.k8s.id}",
+    "${openstack_networking_secgroup_v2.k8s_nodes.id}",
+
   ]
 }
 

--- a/modules/openstack/secgroups/rules/k8s_nodes/secgroup.tf
+++ b/modules/openstack/secgroups/rules/k8s_nodes/secgroup.tf
@@ -1,0 +1,9 @@
+resource "openstack_networking_secgroup_rule_v2" "http" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 80
+  port_range_max    = 80
+  protocol          = "tcp"
+  remote_ip_prefix  = "${var.cluster_cidr}"
+  security_group_id = "${var.secgroup_id}"
+}

--- a/modules/openstack/secgroups/rules/k8s_nodes/variables.tf
+++ b/modules/openstack/secgroups/rules/k8s_nodes/variables.tf
@@ -1,0 +1,7 @@
+variable "secgroup_id" {
+  type = "string"
+}
+
+variable "cluster_cidr" {
+  type = "string"
+}

--- a/modules/openstack/secgroups/secgroup.tf
+++ b/modules/openstack/secgroups/secgroup.tf
@@ -20,6 +20,18 @@ module "k8s" {
   cluster_cidr = "${var.cluster_cidr}"
 }
 
+resource "openstack_networking_secgroup_v2" "k8s_nodes" {
+  name                 = "${var.cluster_name}_k8s_nodes"
+  description          = "Ports needed by Kubernetes nodes"
+  delete_default_rules = true
+}
+
+module "k8s_nodes" {
+  source       = "rules/k8s_nodes"
+  secgroup_id  = "${openstack_networking_secgroup_v2.k8s_nodes.id}"
+  cluster_cidr = "${var.cluster_cidr}"
+}
+
 resource "openstack_networking_secgroup_v2" "etcd" {
   name                 = "${var.cluster_name}_etcd"
   description          = "Ports needed by etcd"


### PR DESCRIPTION
Users should be able to use port 80 with their installs. 

We were running a load balancer on port 80 forwarding to 30080 on each worker but the kube-proxy would load balance traffic to port 80 on the other workers. Hence, to support HTTP on port 80 this port needs to be open inside the cluster.