### PR TITLE
Revert `Change all AppVersion TPRs to CRDs.`

### DIFF
--- a/modules/tectonic/resources/manifests/updater/app-version-kind.yaml
+++ b/modules/tectonic/resources/manifests/updater/app-version-kind.yaml
@@ -1,10 +1,7 @@
-apiVersion: "apiextensions.k8s.io/v1beta1"
-kind: "CustomResourceDefinition"
+apiVersion: "extensions/v1beta1"
+kind: "ThirdPartyResource"
 metadata:
-  name: "appversions.tco.coreos.com"
-spec:
-  group: "tco.coreos.com"
-  version: "v1"
-  names:
-    plural: "appversions"
-    kind: "AppVersion"
+  name: "app-version.coreos.com"
+description: "An experimental specification for Tectonic components' versions"
+versions:
+  - name: "v1"

--- a/modules/tectonic/resources/manifests/updater/app_versions/app-version-kubernetes.yaml
+++ b/modules/tectonic/resources/manifests/updater/app_versions/app-version-kubernetes.yaml
@@ -1,4 +1,4 @@
-apiVersion: tco.coreos.com/v1
+apiVersion: coreos.com/v1
 kind: AppVersion
 metadata:
   name: kubernetes

--- a/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-cluster.yaml
+++ b/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: tco.coreos.com/v1
+apiVersion: coreos.com/v1
 kind: AppVersion
 metadata:
   name: tectonic-cluster

--- a/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-etcd.yaml
+++ b/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-etcd.yaml
@@ -1,4 +1,4 @@
-apiVersion: tco.coreos.com/v1
+apiVersion: coreos.com/v1
 kind: AppVersion
 metadata:
   name: tectonic-etcd

--- a/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-monitoring.yaml
+++ b/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-monitoring.yaml
@@ -1,4 +1,4 @@
-apiVersion: tco.coreos.com/v1
+apiVersion: coreos.com/v1
 kind: AppVersion
 metadata:
   name: tectonic-monitoring

--- a/modules/tectonic/resources/manifests/updater/migration-status-kind.yaml
+++ b/modules/tectonic/resources/manifests/updater/migration-status-kind.yaml
@@ -3,7 +3,7 @@ kind: "CustomResourceDefinition"
 metadata:
   name: "migrationstatuses.kvo.coreos.com"
 spec:
-  group: "kvo.coreos.com"
+  group: "tco.coreos.com"
   version: "v1"
   names:
     plural: "migrationstatuses"

--- a/modules/tectonic/resources/manifests/updater/migration-status-kind.yaml
+++ b/modules/tectonic/resources/manifests/updater/migration-status-kind.yaml
@@ -1,10 +1,7 @@
-apiVersion: "apiextensions.k8s.io/v1beta1"
-kind: "CustomResourceDefinition"
+apiVersion: "extensions/v1beta1"
+kind: "ThirdPartyResource"
 metadata:
-  name: "migrationstatuses.kvo.coreos.com"
-spec:
-  group: "tco.coreos.com"
-  version: "v1"
-  names:
-    plural: "migrationstatuses"
-    kind: "MigrationStatus"
+  name: "migration-status.coreos.com"
+description: "Resource to track migrations that have ran for a particular version."
+versions:
+- name: "v1"

--- a/modules/tectonic/resources/manifests/updater/tectonic-channel-operator-kind.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-channel-operator-kind.yaml
@@ -1,10 +1,7 @@
-apiVersion: "apiextensions.k8s.io/v1beta1"
-kind: "CustomResourceDefinition"
+apiVersion: "extensions/v1beta1"
+kind: "ThirdPartyResource"
 metadata:
-  name: "channeloperatorconfigs.tco.coreos.com"
-spec:
-  group: "tco.coreos.com"
-  version: "v1"
-  names:
-    plural: "channeloperatorconfigs"
-    kind: "ChannelOperatorConfig"
+  name: "channel-operator-config.coreos.com"
+description: "Tectonic Channel Operator Config"
+versions:
+  - name: "v1"


### PR DESCRIPTION
This PR reverts #1704 and the PR that tried to patch it #1714. There are several incorrect API types in manifests that cause clusters not to come up:
* https://github.com/coreos/tectonic-installer/blob/master/modules/tectonic/resources/manifests/updater/tectonic-channel-operator-config.yaml#L2
* https://github.com/coreos/tectonic-installer/blob/master/modules/tectonic/resources/tectonic.sh#L216
* https://github.com/coreos/tectonic-installer/blob/master/modules/tectonic/resources/tectonic.sh#L223

These should be addressed all at once rather than in pieces in follow up commits.

cc @rithujohn191 @yifan-gu 