### PR TITLE
Revert "Use kubernetes version for anti-affinity."

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -106,7 +106,7 @@ resource "template_dir" "bootkube" {
     etcd_client_cert = "${base64encode(data.template_file.etcd_client_crt.rendered)}"
     etcd_client_key  = "${base64encode(data.template_file.etcd_client_key.rendered)}"
 
-    kubernetes_version = "${var.versions["kubernetes"]}"
+    tectonic_version = "${var.versions["tectonic"]}"
 
     master_count              = "${var.master_count}"
     node_monitor_grace_period = "${var.node_monitor_grace_period}"

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-controller-manager
-        pod-anti-affinity: kube-controller-manager-${kubernetes_version}
+        pod-anti-affinity: kube-controller-manager-${tectonic_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -26,7 +26,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                pod-anti-affinity: kube-controller-manager-${kubernetes_version}
+                pod-anti-affinity: kube-controller-manager-${tectonic_version}
             namespaces:
               - kube-system
             topologyKey: kubernetes.io/hostname
@@ -67,11 +67,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      selector:
-        matchLabels:
-          k8s-app: kube-controller-manager
-          pod-anti-affinity: kube-controller-manager-${kubernetes_version}
-          tier: control-plane
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         tier: control-plane
         k8s-app: kube-scheduler
-        pod-anti-affinity: kube-scheduler-${kubernetes_version}
+        pod-anti-affinity: kube-scheduler-${tectonic_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -26,7 +26,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                pod-anti-affinity: kube-scheduler-${kubernetes_version}
+                pod-anti-affinity: kube-scheduler-${tectonic_version}
             namespaces:
               - kube-system
             topologyKey: kubernetes.io/hostname
@@ -48,11 +48,6 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
-      selector:
-        matchLabels:
-          k8s-app: kube-scheduler
-          pod-anti-affinity: kube-scheduler-${kubernetes_version}
-          tier: control-plane
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"


### PR DESCRIPTION
Pull request #1667 introduced a regression in the kube-scheduler and
kube-controller-manager deployments that prevented them from being
created by bootkube start because the pod specs were invalid. The specs
contained a selector field, which should have been in the disruption
instead.

This reverts commit 6a37f2e365094165254679d3cac100ab7e20f143.

@yifan-gu @diegs 