### PR TITLE
module/bootkube: Fix anti-affinity labels / selectors for controller manager and scheduler.

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -103,7 +103,7 @@ resource "template_dir" "bootkube" {
     etcd_client_cert = "${base64encode(data.template_file.etcd_client_crt.rendered)}"
     etcd_client_key  = "${base64encode(data.template_file.etcd_client_key.rendered)}"
 
-    tectonic_version = "${var.versions["tectonic"]}"
+    kubernetes_version = "${replace(var.versions["kubernetes"], "+", "-")}"
 
     master_count              = "${var.master_count}"
     node_monitor_grace_period = "${var.node_monitor_grace_period}"

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -12,12 +12,16 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: kube-controller-manager
   template:
     metadata:
       labels:
         tier: control-plane
         k8s-app: kube-controller-manager
-        pod-anti-affinity: kube-controller-manager-${tectonic_version}
+        pod-anti-affinity: kube-controller-manager-${kubernetes_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -26,7 +30,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                pod-anti-affinity: kube-controller-manager-${tectonic_version}
+                pod-anti-affinity: kube-controller-manager-${kubernetes_version}
             namespaces:
               - kube-system
             topologyKey: kubernetes.io/hostname

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -12,12 +12,16 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      tier: control-plane
+      k8s-app: kube-scheduler
   template:
     metadata:
       labels:
         tier: control-plane
         k8s-app: kube-scheduler
-        pod-anti-affinity: kube-scheduler-${tectonic_version}
+        pod-anti-affinity: kube-scheduler-${kubernetes_version}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
@@ -26,7 +30,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                pod-anti-affinity: kube-scheduler-${tectonic_version}
+                pod-anti-affinity: kube-scheduler-${kubernetes_version}
             namespaces:
               - kube-system
             topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
The anti-affinity label should match the kubernetes version instead
of the tectonic version.

The selector of the controller manager and scheduler should not
contain the anti-affinity label.