### PR TITLE
modules/net/calico: disable CNI plugin

### DIFF
--- a/modules/net/calico-network-policy/resources/manifests/kube-calico.yaml
+++ b/modules/net/calico-network-policy/resources/manifests/kube-calico.yaml
@@ -1,40 +1,3 @@
-# Calico Kubernetes Datastore Hosted Install
-# Calico policy-only with user-supplied networking
-# http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/
-#
-# This ConfigMap is used to configure a self-hosted Calico installation.
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-calico-cfg
-  namespace: kube-system
-data:
-  # The CNI network configuration to install on each node.
-  # http://docs.projectcalico.org/v2.2/reference/cni-plugin/configuration
-  # https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration
-  # depends on flannel to perform networking
-  cni_network_config: |-
-    {
-        "name": "k8s-pod-network",
-        "cniVersion": "${cni_version}",
-        "type": "calico",
-        "log_level": "${log_level}",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
-        },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "${kube_apiserver_url}",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
-        }
-    }
----
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -123,9 +86,7 @@ subjects:
   name: kube-calico
   namespace: kube-system
 ---
-# This manifest installs the calico/node container, as well
-# as the Calico CNI plugins and network config on
-# each master and worker node in a Kubernetes cluster.
+# This manifest installs the calico/node container.
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -209,43 +170,10 @@ spec:
             - mountPath: /var/run/calico
               name: var-run-calico
               readOnly: false
-        # This container installs the Calico CNI binaries
-        # and CNI network config file on each node.
-        - name: install-cni
-          image: ${calico_cni_image}
-          command: ["/install-cni.sh"]
-          env:
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: kube-calico-cfg
-                  key: cni_network_config
-            - name: CNI_NET_DIR
-              value: "/etc/kubernetes/cni/net.d"
-            # Set the hostname based on the k8s node name.
-            - name: KUBERNETES_NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            # Set list of cni binaries that flannel-cni installs and calico should skip.
-            - name: SKIP_CNI_BINARIES
-              value: "bridge,cnitool,dhcp,flannel,host-local,ipvlan,loopback,macvlan,noop,portmap,ptp,tuning"
-          volumeMounts:
-            - mountPath: /host/opt/cni/bin
-              name: host-cni-bin
-            - mountPath: /host/etc/cni/net.d
-              name: cni-net-dir
       volumes:
         - name: var-run-calico
           hostPath:
             path: /var/run/calico
-        - name: host-cni-bin
-          hostPath:
-            path: ${host_cni_bin}
-        - name: cni-net-dir
-          hostPath:
-            path: /etc/kubernetes/cni/net.d
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
When deployed in conjunction with flannel, currently the calico and
flannel plugin race with each other. Incidentally the kubelet picks up
calico first.

This fixes it by removing the calico CNI manifests from the network
policy deployment.

/cc @squeed @tmjd