### PR TITLE
Azure: correct API endpoint FQDN when using external DNS

### DIFF
--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -73,5 +73,5 @@ output "ingress_fqdn" {
 }
 
 output "api_fqdn" {
-  value = "${azurerm_public_ip.api_ip.fqdn}"
+  value = "${var.base_domain == "" ? azurerm_public_ip.api_ip.fqdn : "${var.cluster_name}-api.${var.base_domain}"}"
 }


### PR DESCRIPTION
It appears that in the case of using an externally managed DNS domain, the API endpoint configured in kubeconfig was still based on the default Azure (`<CLUSTER>.<LOCATION>.cloudapp.azure.com`).

This change fixes the problem by propagating the FQDN of the record created in external DNS for the API endpoint.

/cc: @sym3tri @Quentin-M @robszumski This should be included in the nearest release.
