### PR TITLE
Documentation/*.md: Swap out self-driving for automated operations

### DIFF
--- a/Documentation/generic-platform.md
+++ b/Documentation/generic-platform.md
@@ -2,7 +2,7 @@
 
 This document describes the generic compute, network, and storage needs of a Kubernetes self-hosted cluster. In particular the master, infra, and worker nodes.
 
-**Key User Question:** What is the minimum amount of compute/network architecture that is required to enable self-driving that a user cannot change?
+**Key User Question:** What is the minimum amount of compute/network architecture that is required to enable automated operations that a user cannot change?
 
 ## DNS Setup
 

--- a/Documentation/tutorials/index.md
+++ b/Documentation/tutorials/index.md
@@ -1,6 +1,6 @@
 # Welcome to the Tectonic tutorials!
 
-Thank you for your interest in CoreOS Tectonic. We hope you’re excited to learn how Tectonic works and how this self-driving Kubernetes solution can improve your organization’s application infrastructure.
+Thank you for your interest in CoreOS Tectonic. We hope you’re excited to learn how Tectonic works and how enterprise-ready Kubernetes can improve your organization’s application infrastructure.
 
 To help you get up and running with Tectonic, we have designed these step-by-step tutorials. In them, we will walk you through:
 


### PR DESCRIPTION
Replaces all appearances of "self-driving" in Tectonic docs.