### PR TITLE
modules/*,platforms/*: use custom flannel cni bin

### DIFF
--- a/modules/aws/ignition/ignition.tf
+++ b/modules/aws/ignition/ignition.tf
@@ -41,7 +41,6 @@ data "template_file" "kubelet" {
     cluster_dns_ip         = "${var.kube_dns_service_ip}"
     node_label             = "${var.kubelet_node_label}"
     node_taints_param      = "${var.kubelet_node_taints != "" ? "--register-with-taints=${var.kubelet_node_taints}" : ""}"
-    cni_bin_dir_flag       = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"
     kubeconfig_s3_location = "${var.kubeconfig_s3_location}"
   }
 }

--- a/modules/aws/ignition/resources/services/kubelet.service
+++ b/modules/aws/ignition/resources/services/kubelet.service
@@ -29,7 +29,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --node-labels=${node_label} \
   ${node_taints_param} \
-  ${cni_bin_dir_flag} \
+  --cni-bin-dir=/var/lib/cni/bin \
   --minimum-container-ttl-duration=6m0s \
   --cluster-dns=${cluster_dns_ip} \
   --cluster-domain=cluster.local \

--- a/modules/aws/ignition/variables.tf
+++ b/modules/aws/ignition/variables.tf
@@ -28,10 +28,6 @@ variable "kubelet_node_taints" {
   description = "Taints that Kubelet will apply on the node"
 }
 
-variable "kubelet_cni_bin_dir" {
-  type = "string"
-}
-
 variable "bootkube_service" {
   type        = "string"
   description = "The content of the bootkube systemd service unit"

--- a/modules/azure/master-as/ignition-master.tf
+++ b/modules/azure/master-as/ignition-master.tf
@@ -52,7 +52,6 @@ data "template_file" "kubelet-master" {
   vars {
     node_label        = "${var.kubelet_node_label}"
     node_taints_param = "${var.kubelet_node_taints != "" ? "--register-with-taints=${var.kubelet_node_taints}" : ""}"
-    cni_bin_dir_flag  = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"
     cloud_provider    = "${var.cloud_provider}"
     cluster_dns       = "${var.tectonic_kube_dns_service_ip}"
   }

--- a/modules/azure/master-as/resources/master-kubelet.service
+++ b/modules/azure/master-as/resources/master-kubelet.service
@@ -28,7 +28,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --node-labels=${node_label} \
   ${node_taints_param} \
-  ${cni_bin_dir_flag} \
+  --cni-bin-dir=/var/lib/cni/bin \
   --minimum-container-ttl-duration=6m0s \
   --cluster_dns=${cluster_dns} \
   --cluster_domain=cluster.local \

--- a/modules/azure/master-as/variables.tf
+++ b/modules/azure/master-as/variables.tf
@@ -83,10 +83,6 @@ variable "kubelet_node_taints" {
   type = "string"
 }
 
-variable "kubelet_cni_bin_dir" {
-  type = "string"
-}
-
 variable "bootkube_service" {
   type        = "string"
   description = "The content of the bootkube systemd service unit"

--- a/modules/azure/worker-as/ignition-worker.tf
+++ b/modules/azure/worker-as/ignition-worker.tf
@@ -40,10 +40,9 @@ data "template_file" "kubelet-worker" {
   template = "${file("${path.module}/resources/worker-kubelet.service")}"
 
   vars {
-    node_label       = "${var.kubelet_node_label}"
-    cloud_provider   = "${var.cloud_provider}"
-    cluster_dns      = "${var.tectonic_kube_dns_service_ip}"
-    cni_bin_dir_flag = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"
+    node_label     = "${var.kubelet_node_label}"
+    cloud_provider = "${var.cloud_provider}"
+    cluster_dns    = "${var.tectonic_kube_dns_service_ip}"
   }
 }
 

--- a/modules/azure/worker-as/resources/worker-kubelet.service
+++ b/modules/azure/worker-as/resources/worker-kubelet.service
@@ -27,7 +27,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --allow-privileged \
   --node-labels=${node_label} \
-  ${cni_bin_dir_flag} \
+  --cni-bin-dir=/var/lib/cni/bin \
   --minimum-container-ttl-duration=6m0s \
   --cluster_dns=${cluster_dns} \
   --cluster_domain=cluster.local \

--- a/modules/azure/worker-as/variables.tf
+++ b/modules/azure/worker-as/variables.tf
@@ -88,10 +88,6 @@ variable "cl_channel" {
   type = "string"
 }
 
-variable "kubelet_cni_bin_dir" {
-  type = "string"
-}
-
 variable "extra_tags" {
   type = "map"
 }

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -74,7 +74,6 @@ data "template_file" "kubelet" {
     cluster_dns       = "${var.tectonic_kube_dns_service_ip}"
     node_labels       = "${var.node_labels}"
     node_taints_param = "${var.node_taints != "" ? "--register-with-taints=${var.node_taints}" : ""}"
-    cni_bin_dir_flag  = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"
   }
 }
 

--- a/modules/openstack/nodes/resources/kubelet.service
+++ b/modules/openstack/nodes/resources/kubelet.service
@@ -28,7 +28,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --node-labels=${node_labels} \
   ${node_taints_param} \
-  ${cni_bin_dir_flag} \
+  --cni-bin-dir=/var/lib/cni/bin \
   --minimum-container-ttl-duration=6m0s \
   --cluster_dns=${cluster_dns} \
   --cluster_domain=cluster.local \

--- a/modules/openstack/nodes/variables.tf
+++ b/modules/openstack/nodes/variables.tf
@@ -46,10 +46,6 @@ variable "node_taints" {
   type = "string"
 }
 
-variable "kubelet_cni_bin_dir" {
-  type = "string"
-}
-
 variable "hostname_infix" {
   type = "string"
 }

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -54,7 +54,6 @@ data "template_file" "kubelet" {
     cluster_dns_ip    = "${var.kube_dns_service_ip}"
     node_label        = "${var.kubelet_node_label}"
     node_taints_param = "${var.kubelet_node_taints != "" ? "--register-with-taints=${var.kubelet_node_taints}" : ""}"
-    cni_bin_dir_flag  = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"
   }
 }
 

--- a/modules/vmware/node/resources/services/kubelet.service
+++ b/modules/vmware/node/resources/services/kubelet.service
@@ -28,7 +28,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --allow-privileged \
   --node-labels=${node_label} \
   ${node_taints_param} \
-  ${cni_bin_dir_flag} \
+  --cni-bin-dir=/var/lib/cni/bin \
   --minimum-container-ttl-duration=6m0s \
   --cluster-dns=${cluster_dns_ip} \
   --cluster-domain=cluster.local \

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -27,10 +27,6 @@ variable "kubelet_node_taints" {
   description = "Taints that Kubelet will apply on the node"
 }
 
-variable "kubelet_cni_bin_dir" {
-  type = "string"
-}
-
 variable "bootkube_service" {
   type        = "string"
   description = "The content of the bootkube systemd service unit"

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -86,7 +86,6 @@ module "ignition_masters" {
 
   kubelet_node_label        = "node-role.kubernetes.io/master"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
-  kubelet_cni_bin_dir       = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kube_dns_service_ip       = "${module.bootkube.kube_dns_service_ip}"
   kubeconfig_s3_location    = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
   assets_s3_location        = "${aws_s3_bucket_object.tectonic_assets.bucket}/${aws_s3_bucket_object.tectonic_assets.key}"
@@ -135,7 +134,6 @@ module "ignition_workers" {
 
   kubelet_node_label     = "node-role.kubernetes.io/node"
   kubelet_node_taints    = ""
-  kubelet_cni_bin_dir    = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kube_dns_service_ip    = "${module.bootkube.kube_dns_service_ip}"
   kubeconfig_s3_location = "${aws_s3_bucket_object.kubeconfig.bucket}/${aws_s3_bucket_object.kubeconfig.key}"
   assets_s3_location     = ""

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -117,7 +117,6 @@ module "masters" {
   cloud_provider_config        = "${jsonencode(data.null_data_source.cloud_provider.inputs)}"
   kubelet_node_label           = "node-role.kubernetes.io/master"
   kubelet_node_taints          = "node-role.kubernetes.io/master=:NoSchedule"
-  kubelet_cni_bin_dir          = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   bootkube_service             = "${module.bootkube.systemd_service}"
   tectonic_service             = "${module.tectonic.systemd_service}"
   tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
@@ -149,7 +148,6 @@ module "workers" {
   cloud_provider               = "azure"
   cloud_provider_config        = "${jsonencode(data.null_data_source.cloud_provider.inputs)}"
   kubelet_node_label           = "node-role.kubernetes.io/node"
-  kubelet_cni_bin_dir          = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   versions                     = "${var.tectonic_versions}"
   cl_channel                   = "${var.tectonic_cl_channel}"
 

--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -83,7 +83,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=node-role.kubernetes.io/master \
-          {{.cni_bin_dir_flag}} \
+          --cni-bin-dir=/var/lib/cni/bin \
           --register-with-taints=node-role.kubernetes.io/master=:NoSchedule \
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -73,7 +73,7 @@ systemd:
           --allow-privileged \
           --hostname-override={{.domain_name}} \
           --node-labels=node-role.kubernetes.io/node \
-          {{.cni_bin_dir_flag}} \
+          --cni-bin-dir=/var/lib/cni/bin
           --cluster_dns={{.k8s_dns_service_ip}} \
           --cluster_domain=cluster.local
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/run/kubelet-pod.uuid

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -32,7 +32,6 @@ resource "matchbox_group" "controller" {
   metadata {
     domain_name        = "${element(var.tectonic_metal_controller_domains, count.index)}"
     k8s_dns_service_ip = "${module.bootkube.kube_dns_service_ip}"
-    cni_bin_dir_flag   = "${var.tectonic_calico_network_policy ? "--cni-bin-dir=/var/lib/cni/bin" : "" }"
     ssh_authorized_key = "${var.tectonic_ssh_authorized_key}"
     exclude_tectonic   = "${var.tectonic_vanilla_k8s}"
 
@@ -70,7 +69,6 @@ resource "matchbox_group" "worker" {
   metadata {
     domain_name        = "${element(var.tectonic_metal_worker_domains, count.index)}"
     k8s_dns_service_ip = "${module.bootkube.kube_dns_service_ip}"
-    cni_bin_dir_flag   = "${var.tectonic_calico_network_policy ? "--cni-bin-dir=/var/lib/cni/bin" : "" }"
     ssh_authorized_key = "${var.tectonic_ssh_authorized_key}"
 
     # extra data

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -137,7 +137,6 @@ EOF
   hostname_infix               = "master"
   node_labels                  = "node-role.kubernetes.io/master"
   node_taints                  = "node-role.kubernetes.io/master=:NoSchedule"
-  kubelet_cni_bin_dir          = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   tectonic_experimental        = "${var.tectonic_experimental}"
   tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 }
@@ -162,7 +161,6 @@ EOF
   hostname_infix               = "worker"
   node_labels                  = "node-role.kubernetes.io/node"
   node_taints                  = ""
-  kubelet_cni_bin_dir          = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   tectonic_service_disabled    = "${var.tectonic_vanilla_k8s}"
 }
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -44,7 +44,6 @@ module "masters" {
 
   kubelet_node_label        = "node-role.kubernetes.io/master"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
-  kubelet_cni_bin_dir       = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kube_dns_service_ip       = "${module.bootkube.kube_dns_service_ip}"
   container_images          = "${var.tectonic_container_images}"
   bootkube_service          = "${module.bootkube.systemd_service}"
@@ -79,7 +78,6 @@ module "workers" {
 
   kubelet_node_label  = "node-role.kubernetes.io/node"
   kubelet_node_taints = ""
-  kubelet_cni_bin_dir = "${var.tectonic_calico_network_policy ? "/var/lib/cni/bin" : "" }"
   kube_dns_service_ip = "${module.bootkube.kube_dns_service_ip}"
   container_images    = "${var.tectonic_container_images}"
   bootkube_service    = ""


### PR DESCRIPTION
This commit fixes issue #1731, which describes a regression introduced
when we added support for Calico network policies. At this point,
whenever Calico is not enabled, we do not use the cni plugin
binaries installed by Flannel and default to using the binaries in
hyperkube. This means that we cannot update our cni plugins
just by updating the Flannel deployment and introduces more skew
between deployments of Tectonic.

cc @abhinavdahiya @s-urbaniak 