### PR TITLE
config.tf: Bump TCO to 0.4.3

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -58,7 +58,7 @@ variable "tectonic_container_images" {
     prometheus_operator             = "quay.io/coreos/prometheus-operator:v0.11.0"
     stats_emitter                   = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender                  = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
-    tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.4.1"
+    tectonic_channel_operator       = "quay.io/coreos/tectonic-channel-operator:0.4.3"
     tectonic_etcd_operator          = "quay.io/coreos/tectonic-etcd-operator:v0.0.1"
     tectonic_monitoring_auth        = "quay.io/coreos/tectonic-monitoring-auth:v0.0.1"
     tectonic_prometheus_operator    = "quay.io/coreos/tectonic-prometheus-operator:v1.4.1"
@@ -75,7 +75,7 @@ variable "tectonic_versions" {
     kubernetes    = "1.7.1+tectonic.1"
     monitoring    = "1.4.1"
     prometheus    = "v1.7.1"
-    tectonic      = "1.7.1-tectonic.1"
+    tectonic      = "1.7.3-tectonic.1"
     tectonic-etcd = "0.0.1"
   }
 }

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.1-tectonic.1",
+  "version": "1.7.3-tectonic.1",
   "deployments": [
     {
       "apiVersion": "extensions/v1beta1",
@@ -40,7 +40,7 @@
                     }
                   }
                 ],
-                "image": "quay.io/coreos/tectonic-channel-operator:0.4.1",
+                "image": "quay.io/coreos/tectonic-channel-operator:0.4.3",
                 "name": "tectonic-channel-operator",
                 "resources": {
                   "limits": {


### PR DESCRIPTION
Changes:
- Migrate ChannelOperatorConfig/AppVersion/TectonicVersion/MigrationStatus TPR to CRD.
- Support install new object if its upgrade behavior is "CreateOrUpdate".
