### PR TITLE
modules/tectonic/resources: remove creation timestamp from console deployment

### DIFF
--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -19,7 +19,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         k8s-app: tectonic-console
         component: ui


### PR DESCRIPTION
cc @Quentin-M @yifan-gu 