### PR TITLE
modules/update-payload/payload.json: fix after #1699

### DIFF
--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.1-tectonic.1",
+  "version": "1.7.3-tectonic.1",
   "deployments": [
     {
       "apiVersion": "extensions/v1beta1",
@@ -314,7 +314,7 @@
         "name": "kubernetes",
         "namespace": "tectonic-system"
       },
-      "version": "1.7.1+tectonic.1"
+      "version": "1.7.3+tectonic.1"
     },
     {
       "metadata": {


### PR DESCRIPTION
Sorry, the correct payload is on the `crd_migrations` working branch for the release, but not in master. The test infrastructure was broken and thus these did not run.