### PR TITLE
sign-payload.sh: Copy old signature to sig.old if it exists already.

### DIFF
--- a/modules/update-payload/sign-payload.sh
+++ b/modules/update-payload/sign-payload.sh
@@ -89,7 +89,15 @@ function sign_with_yubikey() {
   # concatenating them together.
 }
 
-if [[ ${SIGN_WITH_TEST_KEY} == "true" ]]; then
+function copy_existing_sig() {
+  if [ -f "${DIR}/payload.json.sig" ]; then
+      cp "${DIR}/payload.json.sig" "${DIR}/payload.json.sig.old"
+  fi
+}
+
+copy_existing_sig
+
+if [[ "${SIGN_WITH_TEST_KEY}" == "true" ]]; then
   sign_with_testkey
 else
   sign_with_yubikey


### PR DESCRIPTION
Otherwise if we cancel signing when yubikey asks for pin, the old
sig will be removed already.