### PR TITLE
Azure: delete os disk on termination

### DIFF
--- a/modules/azure/etcd/etcd.tf
+++ b/modules/azure/etcd/etcd.tf
@@ -20,6 +20,8 @@ resource "azurerm_virtual_machine" "etcd_node" {
   vm_size               = "${var.vm_size}"
   availability_set_id   = "${azurerm_availability_set.etcd.id}"
 
+  delete_os_disk_on_termination = true
+
   storage_image_reference {
     publisher = "CoreOS"
     offer     = "CoreOS"

--- a/modules/azure/master-as/master.tf
+++ b/modules/azure/master-as/master.tf
@@ -19,6 +19,8 @@ resource "azurerm_virtual_machine" "tectonic_master" {
   vm_size               = "${var.vm_size}"
   availability_set_id   = "${azurerm_availability_set.tectonic_masters.id}"
 
+  delete_os_disk_on_termination = true
+
   storage_image_reference {
     publisher = "CoreOS"
     offer     = "CoreOS"

--- a/modules/azure/worker-as/workers.tf
+++ b/modules/azure/worker-as/workers.tf
@@ -19,10 +19,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
   vm_size               = "${var.vm_size}"
   availability_set_id   = "${azurerm_availability_set.tectonic_workers.id}"
 
-  # boot_diagnostics {
-  #   enabled     = true
-  #   storage_uri = "${azurerm_storage_account.tectonic_worker.primary_blob_endpoint}"
-  # }
+  delete_os_disk_on_termination = true
 
   storage_image_reference {
     publisher = "CoreOS"
@@ -30,6 +27,7 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
     sku       = "${var.cl_channel}"
     version   = "latest"
   }
+
   storage_os_disk {
     name              = "worker-${count.index}-os-${var.storage_id}"
     managed_disk_type = "${var.storage_type}"
@@ -37,12 +35,14 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
     caching           = "ReadWrite"
     os_type           = "linux"
   }
+
   os_profile {
     computer_name  = "${var.cluster_name}-worker-${count.index}"
     admin_username = "core"
     admin_password = ""
     custom_data    = "${base64encode("${data.ignition_config.worker.rendered}")}"
   }
+
   os_profile_linux_config {
     disable_password_authentication = true
 
@@ -51,10 +51,12 @@ resource "azurerm_virtual_machine" "tectonic_worker" {
       key_data = "${file(var.public_ssh_key)}"
     }
   }
+
   tags = "${merge(map(
     "Name", "${var.cluster_name}-worker-${count.index}",
     "tectonicClusterID", "${var.cluster_id}"),
     var.extra_tags)}"
+
   lifecycle {
     ignore_changes = ["storage_data_disk"]
   }


### PR DESCRIPTION
I seems the current installer can leak OS disks when deleting instances on Azure (observed in the CI environment).

This change attempts to address that problem.

/cc: @mxinden @cpanato 