### PR TITLE
config.tf: bump TEO to 0.0.2 for CRD migration

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -58,7 +58,7 @@ variable "tectonic_container_images" {
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.5.2"
-    tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.1"
+    tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
     tectonic_monitoring_auth     = "quay.io/coreos/tectonic-monitoring-auth:v0.0.1"
     tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.5.1"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.1.3"

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -222,7 +222,7 @@
                 "command": [
                   "/usr/local/bin/tectonic-etcd-operator"
                 ],
-                "image": "quay.io/coreos/tectonic-etcd-operator:v0.0.1",
+                "image": "quay.io/coreos/tectonic-etcd-operator:v0.0.2",
                 "name": "tectonic-etcd-operator",
                 "resources": {
                   "limits": {


### PR DESCRIPTION
This TEO release does not update the etcd-operator or the self-hosted cluster. It just recognizes the change of AppVersions now being CRDs by using the updated operator-client. 

@Quentin-M @yifan-gu @xiang90 @hongchaodeng 