### PR TITLE
platforms/openstack/neutron: Revert DNS change for workers

### DIFF
--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -193,7 +193,7 @@ module "dns" {
   master_count     = "${var.tectonic_master_count}"
   master_ips       = "${openstack_networking_port_v2.master.*.all_fixed_ips}"
   worker_count     = "${var.tectonic_worker_count}"
-  worker_ips       = "${openstack_networking_port_v2.worker.*.all_fixed_ips}"
+  worker_ips       = "${openstack_networking_floatingip_v2.worker.*.address}"
 
   tectonic_experimental = "${var.tectonic_experimental}"
   tectonic_vanilla_k8s  = "${var.tectonic_vanilla_k8s}"


### PR DESCRIPTION
90f4d06c changed the worker DNS records to the port on the
private subnet. Reverting this change so that workers can
be accessed externally by name.