### PR TITLE
monitoring: bump monitoring to 1.5.2, CRD compatiblity

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -54,13 +54,13 @@ variable "tectonic_container_images" {
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:3517908b1a1837e78cfd041a0e51e61c7835d85f"
     prometheus                   = "quay.io/prometheus/prometheus:v1.7.1"
     prometheus_config_reload     = "quay.io/coreos/prometheus-config-reloader:v0.0.2"
-    prometheus_operator          = "quay.io/coreos/prometheus-operator:v0.11.1"
+    prometheus_operator          = "quay.io/coreos/prometheus-operator:v0.12.0"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.5.2"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
     tectonic_monitoring_auth     = "quay.io/coreos/tectonic-monitoring-auth:v0.0.1"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.5.1"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.5.2"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.1.3"
   }
 }

--- a/modules/tectonic/resources/manifests/monitoring/alertmanager.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/alertmanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: main

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-alertmanager.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-alertmanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: alertmanager

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-apiserver.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-apiserver.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-apiserver

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kube-controller-manager.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kube-controller-manager.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-controller-manager

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kube-scheduler.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kube-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-scheduler

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kube-state-metrics.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kube-state-metrics.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kube-state-metrics

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kubelet.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-kubelet.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: kubelet

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-node-exporter.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-node-exporter.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: node-exporter

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-prometheus-operator.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-prometheus-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus-operator

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-prometheus.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s-service-monitor-prometheus.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-k8s.yaml
@@ -1,4 +1,4 @@
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: k8s

--- a/modules/tectonic/resources/manifests/monitoring/prometheus-operator-cluster-role.yaml
+++ b/modules/tectonic/resources/manifests/monitoring/prometheus-operator-cluster-role.yaml
@@ -8,7 +8,13 @@ rules:
   resources:
   - thirdpartyresources
   verbs:
-  - create
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -40,3 +46,7 @@ rules:
   resources:
   - nodes
   verbs: ["list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -56,19 +56,6 @@ wait_for_crd() {
   set -e
 }
 
-wait_for_tpr() {
-  set +e
-  i=0
-
-  echo "Waiting for TPR $2"
-  until $KUBECTL -n "$1" get thirdpartyresources "$2"; do
-    i=$((i+1))
-    echo "TPR $2 not available yet, retrying in 5 seconds ($i)"
-    sleep 5
-  done
-  set -e
-}
-
 wait_for_pods() {
   set +e
   echo "Waiting for pods in namespace $1"
@@ -175,9 +162,9 @@ kubectl create -f monitoring/prometheus-operator-service-account.yaml
 kubectl create -f monitoring/prometheus-operator-svc.yaml
 kubectl create -f monitoring/prometheus-operator.yaml
 
-wait_for_tpr tectonic-system prometheus.monitoring.coreos.com
-wait_for_tpr tectonic-system alertmanager.monitoring.coreos.com
-wait_for_tpr tectonic-system service-monitor.monitoring.coreos.com
+wait_for_crd tectonic-system prometheuses.monitoring.coreos.com
+wait_for_crd tectonic-system alertmanagers.monitoring.coreos.com
+wait_for_crd tectonic-system servicemonitors.monitoring.coreos.com
 
 kubectl create -f monitoring/alertmanager-config.yaml
 kubectl create -f monitoring/alertmanager-service.yaml

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -282,7 +282,7 @@
                   "-logtostderr=true",
                   "-v=4"
                 ],
-                "image": "quay.io/coreos/tectonic-prometheus-operator:v1.5.1",
+                "image": "quay.io/coreos/tectonic-prometheus-operator:v1.5.2",
                 "name": "tectonic-prometheus-operator",
                 "resources": {
                   "limits": {


### PR DESCRIPTION
This will need to be cherry-picked on to 1.7.3 branch as well.

\cc @brancz  