### PR TITLE
Improve UI for Tectonic Install failed case

### DIFF
--- a/installer/api/api.go
+++ b/installer/api/api.go
@@ -90,6 +90,7 @@ func New(config *Config) (http.Handler, error) {
 
 	// handlers_tectonic.go
 	mux.Handle("/tectonic/status", logRequests(httpHandler("POST", ctx, tectonicStatusHandler)))
+	mux.Handle("/tectonic/kubeconfig", logRequests(httpHandler("GET", ctx, tectonicKubeconfigHandler)))
 
 	// handlers_containerlinux.go
 	mux.Handle("/containerlinux/images/matchbox", logRequests(httpHandler("GET", ctx, listMatchboxImagesHandler)))

--- a/installer/api/handlers_tectonic.go
+++ b/installer/api/handlers_tectonic.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -315,4 +316,25 @@ func tectonicStatusHandler(w http.ResponseWriter, req *http.Request, ctx *Contex
 	}
 
 	return writeJSONResponse(w, req, http.StatusOK, response)
+}
+
+// Download kubeconfig file, or return a 404 if it doesn't exist yet.
+func tectonicKubeconfigHandler(w http.ResponseWriter, req *http.Request, ctx *Context) error {
+	// Restore the execution environment from the session.
+	_, ex, _, err := restoreExecutionFromSession(req, ctx.Sessions, nil)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := os.Open(filepath.Join(ex.WorkingDirectory(), kubeconfigLocation))
+	if err != nil {
+		http.Error(w, "Could not retrieve kubeconfig", http.StatusNotFound)
+		return nil
+	}
+	defer cfg.Close()
+
+	w.Header().Set("Content-Disposition", "attachment; filename=kubeconfig")
+	w.Header().Set("Content-Type", "text/plain")
+	io.Copy(w, cfg)
+	return nil
 }

--- a/installer/api/handlers_tectonic.go
+++ b/installer/api/handlers_tectonic.go
@@ -26,9 +26,11 @@ import (
 
 // Status represents the individual state of a single Kubernetes service
 type Status struct {
-	Success bool   `json:"success"`
-	Failed  bool   `json:"failed"`
-	Message string `json:"message"`
+	Success   bool   `json:"success"`
+	Failed    bool   `json:"failed"`
+	Namespace string `json:"namespace"`
+	Pod       string `json:"pod"`
+	Message   string `json:"message"`
 }
 
 // Services represents whether several Tectonic components have yet booted (or failed)
@@ -101,6 +103,8 @@ func statusFromPods(pods []v1.Pod) Status {
 		if p.Status.Phase == v1.PodFailed {
 			status.Failed = true
 			status.Success = false
+			status.Namespace = p.ObjectMeta.Namespace
+			status.Pod = p.ObjectMeta.Name
 			return status
 		}
 

--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -148,9 +148,6 @@ input[type="text"].wiz-node-field {
 }
 
 .wiz-launch-progress {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   font-size: 16px;
 }
 

--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -76,15 +76,19 @@ strong {
 }
 
 code {
-  background: rgba(0, 0, 0, 0.03);
+  background: #f5f5f5;
+  border: 1px solid rgba(0, 0, 0, 0.075);
   border-radius: 3px;
-  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.075);
-  color: rgba(0, 0, 0, 0.75);
+  color: #333;
   display: inline-block;
   font-family: "Source Code Pro", Menlo, monospace;
-  font-size: 85%;
+  font-size: 11px;
   font-weight: 400;
-  padding: 0px 4px;
+  line-height: 20px;
+  margin-bottom: 15px;
+  padding: 4px 8px;
+  white-space: pre-wrap;
+  width: 100%;
 }
 
 h4 {
@@ -456,7 +460,6 @@ input.wiz-super-short-input {
 
 .alert-error {
   background-color: #FDF4F5;
-  border: 1px solid #DC415E;
   color: #DC415E;
 }
 

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -251,8 +251,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
                   <p>To debug, save logs and download "kubeconfig" for troubleshooting:</p>
                   <code>
                     $ export KUBECONFIG=/path/to/kubeconfig{'\n'}
-                    $ kubectl --namespace=tectonic-system logs TECTONIC-IDENTITY-POD{'\n'}
-                    $ kubectl --namespace=tectonic-system logs TECTONIC-CONSOLE-POD
+                    {_(tectonic).filter('failed').map(({namespace, pod}) => `$ kubectl --namespace=${namespace} logs ${pod}\n`).value()}
                   </code>
                   <a href="/tectonic/kubeconfig" download>
                     <Btn isError={true} title="Download kubeconfig" />

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -309,7 +309,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
                   </a>
                   <span className="spacer"></span>
                   <a onClick={saveLog}>
-                    <i className="fa fa-download"></i>&nbsp;&nbsp;Save log
+                    <i className="fa fa-download"></i>&nbsp;&nbsp;Save logs
                   </a>
                 </div>
               }
@@ -337,7 +337,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
                 <Alert severity="error" noIcon>
                   <b>{_.startCase(action)} Failed</b>. Your installation is blocked. To continue:
                   <ol style={{fontSize: 13, paddingLeft: 30, paddingTop: 10, paddingBottom: 10}}>
-                    <li><a onClick={saveLog}>Save Terraform log</a> and <a href="/terraform/assets" download>download assets</a> for debugging purposes.</li>
+                    <li><a onClick={saveLog}>Save Terraform logs</a> and <a href="/terraform/assets" download>download assets</a> for debugging purposes.</li>
                     <li>Destroy your cluster to clear anything that may have been created. Or,</li>
                     <li>Reapply Terraform.</li>
                   </ol>
@@ -355,13 +355,13 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
               }
               {isApplySuccess &&
                 <div className="wiz-launch-progress__help">
-                  You can save Terraform logs, or destroy your cluster if you change your mind:&nbsp;
+                  You can save Terraform logs, or destroy your cluster if you changed your mind:&nbsp;
                   <DropdownInline
                     header="Terraform Actions"
                     items={[
                       ['Destroy Cluster', this.destroy],
                       ['Retry Terraform Apply', this.retry],
-                      ['Save Terraform Log', saveLog],
+                      ['Save Terraform Logs', saveLog],
                     ]}
                   />
                 </div>

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -293,81 +293,79 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
         }
         <hr />
         <div className="row">
-          <div className="col-xs-12">
-            <ul className="wiz-launch-progress">
-              <Step done={statusMsg === 'success'} error={tfError}>
-                {tfError
-                  ? <span><span className="wiz-running-fg">{tfTitle}:</span> [Failure] Terraform {action} failed</span>
-                  : tfTitle}
-                {output && !isApplySuccess &&
-                  <div className="pull-right" style={{fontSize: '13px'}}>
-                    <a onClick={() => this.setState({showLogs: !showLogs})}>
-                      {showLogs
-                        ? <span><i className="fa fa-angle-up"></i>&nbsp;&nbsp;Hide logs</span>
-                        : <span><i className="fa fa-angle-down"></i>&nbsp;&nbsp;Show logs</span>}
-                    </a>
-                    <span className="spacer"></span>
-                    <a onClick={saveLog}>
-                      <i className="fa fa-download"></i>&nbsp;&nbsp;Save log
-                    </a>
+          <div className="col-xs-12 wiz-launch-progress">
+            <Step done={statusMsg === 'success'} error={tfError}>
+              {tfError
+                ? <span><span className="wiz-running-fg">{tfTitle}:</span> [Failure] Terraform {action} failed</span>
+                : tfTitle}
+              {output && !isApplySuccess &&
+                <div className="pull-right" style={{fontSize: '13px'}}>
+                  <a onClick={() => this.setState({showLogs: !showLogs})}>
+                    {showLogs
+                      ? <span><i className="fa fa-angle-up"></i>&nbsp;&nbsp;Hide logs</span>
+                      : <span><i className="fa fa-angle-down"></i>&nbsp;&nbsp;Show logs</span>}
+                  </a>
+                  <span className="spacer"></span>
+                  <a onClick={saveLog}>
+                    <i className="fa fa-download"></i>&nbsp;&nbsp;Save log
+                  </a>
+                </div>
+              }
+            </Step>
+            <div style={{marginLeft: 22}}>
+              {isAWS && isApply && statusMsg !== 'success' && <ProgressBar progress={state.terraformProgress} isActive={isTFRunning} />}
+              {showLogs && output && !isApplySuccess &&
+                <div className="log-pane">
+                  <div className="log-pane__header">
+                    <div className="log-pane__header__message">Terraform logs</div>
                   </div>
-                }
-              </Step>
-              <div style={{marginLeft: 22}}>
-                {isAWS && isApply && statusMsg !== 'success' && <ProgressBar progress={state.terraformProgress} isActive={isTFRunning} />}
-                {showLogs && output && !isApplySuccess &&
-                  <div className="log-pane">
-                    <div className="log-pane__header">
-                      <div className="log-pane__header__message">Terraform logs</div>
-                    </div>
-                    <div className="log-pane__body">
-                      <div className="log-area">
-                        <div className="log-scroll-pane" ref={node => this.outputNode = node}>
-                          <div className="log-contents">{output}</div>
-                        </div>
+                  <div className="log-pane__body">
+                    <div className="log-area">
+                      <div className="log-scroll-pane" ref={node => this.outputNode = node}>
+                        <div className="log-contents">{output}</div>
                       </div>
                     </div>
                   </div>
-                }
-                {state.xhrError && <Alert severity="error">{state.xhrError}</Alert>}
-                {commitPhase === commitPhases.FAILED && <Alert severity="error">{commitState.response}</Alert>}
-                {tfError && <Alert severity="error">{tfError.toString()}</Alert>}
-                {tfError && !isTFRunning &&
-                  <Alert severity="error" noIcon>
-                    <b>{_.startCase(action)} Failed</b>. Your installation is blocked. To continue:
-                    <ol style={{fontSize: 13, paddingLeft: 30, paddingTop: 10, paddingBottom: 10}}>
-                      <li><a onClick={saveLog}>Save Terraform log</a> and <a href="/terraform/assets" download>download assets</a> for debugging purposes.</li>
-                      <li>Destroy your cluster to clear anything that may have been created. Or,</li>
-                      <li>Reapply Terraform.</li>
-                    </ol>
-                    <Btn isError={true} onClick={this.destroy} title="Destroy Cluster and Start Over" />
-                    <Btn isError={true} onClick={this.retry} title="Retry Terraform Apply" />
-                  </Alert>
-                }
-                {isDestroySuccess &&
-                  <Alert noIcon>
-                    <b style={{fontWeight: '600'}}>Destroy Succeeded</b>
-                    <p>To continue, make a fresh start with Tectonic Installer, or simply close the browser tab to quit.</p>
-                    <Btn isError={false} onClick={this.startOver} title="Start Over" />
-                    <Btn isError={false} onClick={this.retry} title="Retry Terraform Apply" />
-                  </Alert>
-                }
-                {isApplySuccess &&
-                  <div className="wiz-launch-progress__help">
-                    You can save Terraform logs, or destroy your cluster if you change your mind:&nbsp;
-                    <DropdownInline
-                      header="Terraform Actions"
-                      items={[
-                        ['Destroy Cluster', this.destroy],
-                        ['Retry Terraform Apply', this.retry],
-                        ['Save Terraform Log', saveLog],
-                      ]}
-                    />
-                  </div>
-                }
-              </div>
-              {consoleSubsteps}
-            </ul>
+                </div>
+              }
+              {state.xhrError && <Alert severity="error">{state.xhrError}</Alert>}
+              {commitPhase === commitPhases.FAILED && <Alert severity="error">{commitState.response}</Alert>}
+              {tfError && <Alert severity="error">{tfError.toString()}</Alert>}
+              {tfError && !isTFRunning &&
+                <Alert severity="error" noIcon>
+                  <b>{_.startCase(action)} Failed</b>. Your installation is blocked. To continue:
+                  <ol style={{fontSize: 13, paddingLeft: 30, paddingTop: 10, paddingBottom: 10}}>
+                    <li><a onClick={saveLog}>Save Terraform log</a> and <a href="/terraform/assets" download>download assets</a> for debugging purposes.</li>
+                    <li>Destroy your cluster to clear anything that may have been created. Or,</li>
+                    <li>Reapply Terraform.</li>
+                  </ol>
+                  <Btn isError={true} onClick={this.destroy} title="Destroy Cluster and Start Over" />
+                  <Btn isError={true} onClick={this.retry} title="Retry Terraform Apply" />
+                </Alert>
+              }
+              {isDestroySuccess &&
+                <Alert noIcon>
+                  <b style={{fontWeight: '600'}}>Destroy Succeeded</b>
+                  <p>To continue, make a fresh start with Tectonic Installer, or simply close the browser tab to quit.</p>
+                  <Btn isError={false} onClick={this.startOver} title="Start Over" />
+                  <Btn isError={false} onClick={this.retry} title="Retry Terraform Apply" />
+                </Alert>
+              }
+              {isApplySuccess &&
+                <div className="wiz-launch-progress__help">
+                  You can save Terraform logs, or destroy your cluster if you change your mind:&nbsp;
+                  <DropdownInline
+                    header="Terraform Actions"
+                    items={[
+                      ['Destroy Cluster', this.destroy],
+                      ['Retry Terraform Apply', this.retry],
+                      ['Save Terraform Log', saveLog],
+                    ]}
+                  />
+                </div>
+              }
+            </div>
+            {consoleSubsteps}
           </div>
         </div>
         <br />

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -254,6 +254,9 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
                     $ kubectl --namespace=tectonic-system logs TECTONIC-IDENTITY-POD{'\n'}
                     $ kubectl --namespace=tectonic-system logs TECTONIC-CONSOLE-POD
                   </code>
+                  <a href="/tectonic/kubeconfig" download>
+                    <Btn isError={true} title="Download kubeconfig" />
+                  </a>
                   <p>To start over, destroy cluster to clear anything that may have been created.</p>
                   <Btn isError={true} onClick={this.destroy} title="Destroy Cluster and Start Over" />
                 </Alert>

--- a/tests/rspec/lib/aws_iam.rb
+++ b/tests/rspec/lib/aws_iam.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The AWSIAM contains helper functions to interact with AWS IAM
 module AWSIAM
   def self.assume_role

--- a/tests/rspec/lib/aws_region.rb
+++ b/tests/rspec/lib/aws_region.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def export_random_region_if_not_defined
   regions = %w[us-east-1 us-east-2 us-west-1 us-west-2]
 

--- a/tests/rspec/lib/aws_vpc.rb
+++ b/tests/rspec/lib/aws_vpc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 # AWSVPC represents an AWS virtual private cloud

--- a/tests/rspec/lib/grafiti.rb
+++ b/tests/rspec/lib/grafiti.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Grafiti contains helper functions to use the http://github.com/coreos/grafiti
 # tool
 class Grafiti

--- a/tests/rspec/lib/name_generator.rb
+++ b/tests/rspec/lib/name_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'jenkins'
 
 # NameGenerator contains helper functions to generate test resource names

--- a/tests/rspec/lib/operators.rb
+++ b/tests/rspec/lib/operators.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Operators contains helper functions to test creation of the CoreOS operators
 module Operators
   OPERATOR_NAMES = [

--- a/tests/rspec/spec/aws_vpc_internal_spec.rb
+++ b/tests/rspec/spec/aws_vpc_internal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shared_examples/k8s'
 require 'aws_vpc'
 require 'aws_region'

--- a/tests/rspec/spec/meta-tests/aws_vpc_spec.rb
+++ b/tests/rspec/spec/meta-tests/aws_vpc_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'aws_vpc'
 require 'aws_iam'
 

--- a/tests/rspec/spec/meta-tests/tfvars_file_spec.rb
+++ b/tests/rspec/spec/meta-tests/tfvars_file_spec.rb
@@ -2,7 +2,7 @@
 
 require 'tfvars_file'
 
-TFVARS_FILE_PATH = '../smoke/aws/vars/aws.tfvars.json'.freeze
+TFVARS_FILE_PATH = '../smoke/aws/vars/aws.tfvars.json'
 
 describe TFVarsFile do
   subject { described_class.new(TFVARS_FILE_PATH) }


### PR DESCRIPTION
Add Tectonic Console Failed alert box, which includes
- Output failure message if we have one
- kubeconfig download button
- kubectl commands for debugging with the actual pod names and namespaces

Fixes #356, but doesn't add the "Save log" download links from the mocks because it would be too much work at this time.

<img width="812" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/29774136-61e08d34-8c3b-11e7-9918-0e8c9df3ebc9.png">
<img width="651" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/29924947-b2678a72-8e99-11e7-93f5-6680a03e1b39.png">
