### PR TITLE
Update version string to 1.7.1-tectonic.2

### DIFF
--- a/Documentation/hack/centos-workers.md
+++ b/Documentation/hack/centos-workers.md
@@ -6,7 +6,7 @@ This is unofficial. The author does not update, maintain, or support this setup.
 
 ## CoreOS Tectonic
 
-Provision a Tectonic `1.7.1-tectonic.1` bare-metal cluster (Container Linux, 1 controller, 2 workers) in the usual way with [matchbox](https://github.com/coreos/matchbox) and the Tectonic [Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html).
+Provision a Tectonic `1.7.1-tectonic.2` bare-metal cluster (Container Linux, 1 controller, 2 workers) in the usual way with [matchbox](https://github.com/coreos/matchbox) and the Tectonic [Installer](https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html).
 
 Locally, you may PXE boot QEMU/KVM nodes via Tectonic and matchbox on the `metal0` bridge.
 

--- a/Documentation/install/aws/aws-terraform.md
+++ b/Documentation/install/aws/aws-terraform.md
@@ -17,8 +17,8 @@ Generally, the AWS platform templates adhere to the standards defined by the pro
 Open a new terminal, and run the following commands to download and extract Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.1-tectonic.1.tar.gz # extract the tarball
+$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz # download
+$ tar xzvf tectonic-1.7.1-tectonic.2.tar.gz # extract the tarball
 $ cd tectonic
 ```
 

--- a/Documentation/install/aws/index.md
+++ b/Documentation/install/aws/index.md
@@ -16,8 +16,8 @@ Make sure a current version of either the Google Chrome or Mozilla Firefox web b
 Download the [Tectonic installer][latest-tectonic-release].
 
 ```bash
-wget https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz
-tar xzvf tectonic-1.7.1-tectonic.1.tar.gz
+wget https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz
+tar xzvf tectonic-1.7.1-tectonic.2.tar.gz
 cd tectonic
 ```
 
@@ -78,7 +78,7 @@ For those new to Tectonic and Kubernetes, the [Tectonic Tutorials][tutorials] pr
 [install-aws-requirements-creds]: requirements.md#privileges
 [install-aws-requirements-evpc]: requirements.md#using-an-existing-vpc
 [tutorials]: ../../tutorials/index.md
-[latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz
+[latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz
 [install-aws-troubleshooting]: ../../troubleshooting/faq.md
 [tf-state]: https://www.terraform.io/docs/state/
 [install-windows]: ../installer-windows.md

--- a/Documentation/install/azure/azure-terraform.md
+++ b/Documentation/install/azure/azure-terraform.md
@@ -65,8 +65,8 @@ Also ensure the SSH known_hosts file doesn't have old records for the API DNS na
 Open a new terminal and run the following commands to download and extract Tectonic Installer:
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.1-tectonic.1.tar.gz # extract the tarball
+$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz # download
+$ tar xzvf tectonic-1.7.1-tectonic.2.tar.gz # extract the tarball
 $ cd tectonic
 ```
 

--- a/Documentation/install/bare-metal/index.md
+++ b/Documentation/install/bare-metal/index.md
@@ -162,8 +162,8 @@ Make sure a current version of either the Google Chrome or Mozilla Firefox web b
 Download [Tectonic Installer][latest-tectonic-release].
 
 ```sh
-wget https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz
-tar xzvf tectonic-1.7.1-tectonic.1.tar.gz
+wget https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz
+tar xzvf tectonic-1.7.1-tectonic.2.tar.gz
 cd tectonic/tectonic-installer
 ```
 
@@ -217,7 +217,7 @@ After the installer is complete, you'll have a Tectonic cluster and be able to a
 [copr-repo]: https://copr.fedorainfracloud.org/coprs/g/CoreOS/matchbox/
 [coreos-release]: https://coreos.com/releases/
 [daemonset]: http://kubernetes.io/docs/admin/daemons/
-[latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz
+[latest-tectonic-release]: https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz
 [matchbox-config]: https://coreos.com/matchbox/docs/latest/config.html
 [matchbox-dnsmasq]: https://github.com/coreos/matchbox/tree/master/contrib/dnsmasq
 [matchbox]: https://coreos.com/matchbox

--- a/Documentation/install/bare-metal/metal-terraform.md
+++ b/Documentation/install/bare-metal/metal-terraform.md
@@ -22,8 +22,8 @@ For a complete list of requirements, see [Bare Metal Installation requirements][
 Open a new terminal, and run the following commands to download and extract Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz
-$ tar xzvf tectonic-1.7.1-tectonic.1.tar.gz
+$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz
+$ tar xzvf tectonic-1.7.1-tectonic.2.tar.gz
 $ cd tectonic
 ```
 

--- a/Documentation/install/openstack/openstack-terraform.md
+++ b/Documentation/install/openstack/openstack-terraform.md
@@ -24,8 +24,8 @@ Replace `<flavor>` with either option in the following commands. Now we're ready
 Open a new terminal, and run the following commands to download and extract Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.1-tectonic.1.tar.gz # extract the tarball
+$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz # download
+$ tar xzvf tectonic-1.7.1-tectonic.2.tar.gz # extract the tarball
 $ cd tectonic
 ```
 

--- a/Documentation/install/vmware/vmware-terraform.md
+++ b/Documentation/install/vmware/vmware-terraform.md
@@ -68,8 +68,8 @@ The following steps must be executed on a machine that has network connectivity 
 Open a new terminal, and run the following commands to download and extract Tectonic Installer.
 
 ```bash
-$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz # download
-$ tar xzvf tectonic-1.7.1-tectonic.1.tar.gz # extract the tarball
+$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz # download
+$ tar xzvf tectonic-1.7.1-tectonic.2.tar.gz # extract the tarball
 $ cd tectonic
 ```
 

--- a/Documentation/tutorials/installing-tectonic.md
+++ b/Documentation/tutorials/installing-tectonic.md
@@ -43,7 +43,7 @@ Make sure a current version of either the Google Chrome or Mozilla Firefox brows
 
 1. Download and run the Tectonic installer by opening a new terminal, and running the following command:
 ```
-$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.1.tar.gz
+$ curl -O https://releases.tectonic.com/tectonic-1.7.1-tectonic.2.tar.gz
 ```
 
 2. Double click the tarball to extract it, then navigate to the tectonic/tectonic-installer folder.
@@ -54,7 +54,7 @@ A browser window will open the Tectonic Installer to walk you through the setup 
 
 If you prefer to work within the terminal, extract and launch the Installer using:
 ```bash
-tar xzvf tectonic-1.7.1-tectonic.1.tar.gz # to extract the tarball
+tar xzvf tectonic-1.7.1-tectonic.2.tar.gz # to extract the tarball
 $ cd tectonic/tectonic-installer # to change to the previously untarred directory
 $ ./$PLATFORM/installer # to run the Tectonic Installer
 ```

--- a/Documentation/tutorials/tectonic-sandbox/index.md
+++ b/Documentation/tutorials/tectonic-sandbox/index.md
@@ -12,6 +12,7 @@ To help you get up and running with Tectonic Sandbox, we have designed these ste
 
 If you haven't already done so yet, [download and install][download-install] Tectonic Sandbox.
 
+<a href="first-app.html" class="btn btn-primary btn-lg">Let's Get Started</a>
 
 [first-app]: first-app.md
 [check-logs]: check-logs.md


### PR DESCRIPTION
Version strings have yet to be updated upstream to 1.7.1-tectonic.2
 
The "Let's Get Started" has also been added to`Documentation/tutorials/tectonic-sandbox/index.md`.