### PR TITLE
frontend: Add restore modal errors for unsupported or disabled platforms

### DIFF
--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -12,7 +12,7 @@ import {
   BARE_METAL_TF,
   DOCS,
   PLATFORM_NAMES,
-  SELECTED_PLATFORMS,
+  isEnabled,
   isSupported,
   optGroups,
 } from '../platforms';
@@ -56,7 +56,7 @@ const platformForm = new Form(PLATFORM_FORM, [
 const platformOptions = [];
 _.each(optGroups, optgroup => {
   const [name, ...group] = optgroup;
-  const platforms = _.filter(group, p => SELECTED_PLATFORMS.includes(p));
+  const platforms = _.filter(group, p => isEnabled(p));
   if (platforms.length) {
     platformOptions.push(<optgroup label={name} key={name}>{
       platforms.map(p => <option value={p} key={p}>{PLATFORM_NAMES[p]}</option>)

--- a/installer/frontend/platforms.js
+++ b/installer/frontend/platforms.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export const AWS = 'aws';
 export const AWS_TF = 'aws-tf';
 export const AZURE = 'azure';
@@ -6,6 +8,8 @@ export const BARE_METAL_TF = 'bare-metal-tf';
 export const OPENSTACK = 'openstack';
 
 export const isSupported = platform => [AWS_TF, BARE_METAL_TF].includes(platform);
+
+export const isEnabled = platform => _.get(window.config, 'platforms', []).includes(platform);
 
 export const PLATFORM_NAMES = {
   [AWS]: 'Amazon Web Services',
@@ -20,8 +24,6 @@ export const optGroups = [
   ['Graphical Installer (default)', AWS_TF, BARE_METAL_TF],
   ['Advanced Installer', AWS, BARE_METAL, AZURE, OPENSTACK],
 ];
-
-export const SELECTED_PLATFORMS = window.config ? window.config.platforms : [];
 
 export const DOCS = {
   [AWS]: 'https://coreos.com/tectonic/docs/latest/install/aws/aws-terraform.html',


### PR DESCRIPTION
![screenshot-2](https://user-images.githubusercontent.com/460802/29811291-ee3008a8-8cdd-11e7-9200-b92832181a4f.png)

Platforms can also be disabled using the `-platforms` command line option.
![screenshot-1](https://user-images.githubusercontent.com/460802/29811285-e718a7a0-8cdd-11e7-930d-cc23ca7041d9.png)
