### PR TITLE
Add install guide to Sandbox overview

### DIFF
--- a/Documentation/tutorials/sandbox/index.md
+++ b/Documentation/tutorials/sandbox/index.md
@@ -4,6 +4,7 @@ Thank you for your interest in CoreOS Tectonic. We hope you’re excited to lear
 
 To help you get up and running with Tectonic Sandbox, we have designed these step-by-step tutorials. In them, we will walk you through:
 
+* [Installing Tectonic Sandbox][install-guide]
 * [Deploying an application on Tectonic Sandbox][first-app]
 * [Checking application logs][check-logs]
 * [Scaling an application][scale-app]
@@ -12,8 +13,9 @@ To help you get up and running with Tectonic Sandbox, we have designed these ste
 
 If you haven't already done so yet, [download and install][download-install] Tectonic Sandbox.
 
-<a href="first-app.html" class="btn btn-primary btn-lg">Let's Get Started</a>
+<a href="install.md" class="btn btn-primary btn-lg">Let's Get Started</a>
 
+[install-guide]: install.md
 [first-app]: first-app.md
 [check-logs]: check-logs.md
 [scale-app]: scale-app.md

--- a/Documentation/tutorials/sandbox/install.md
+++ b/Documentation/tutorials/sandbox/install.md
@@ -151,6 +151,7 @@ On Windows, run:
 $env:KUBECONFIG = "$PWD\provisioning\etc\kubernetes\kubeconfig"
 ```
 
+[**NEXT:** Deploying an application on Tectonic][first-app]
 
 [vagrant]: https://www.vagrantup.com/downloads.html
 [virtualbox]: https://www.virtualbox.org/wiki/Downloads


### PR DESCRIPTION
## Changes in this PR:
- [X] Add `install.md` to list of docs on Sandbox overview
- [X] Change the "Let's Get Started" button to redirect to the install guide
- [X] Link to `first-app.md` at the bottom of `install.md`