### PR TITLE
tests: fix GUI test

### DIFF
--- a/installer/frontend/ui-tests/utils/awsInstallerInput.js
+++ b/installer/frontend/ui-tests/utils/awsInstallerInput.js
@@ -13,6 +13,7 @@ const buildExpectedJson = () => {
   delete json.tectonic_admin_password_hash;
   delete json.tectonic_aws_extra_tags;
   delete json.tectonic_aws_external_private_zone;
+  delete json.tectonic_aws_private_endpoints;
 
   return json;
 };

--- a/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
+++ b/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
@@ -1,7 +1,7 @@
 {
     "tectonic_aws_az_count": "2",
     "tectonic_aws_etcd_ec2_type": "m4.large",
-    "tectonic_aws_external_vpc_public": false,
+    "tectonic_aws_public_endpoints": false,
     "tectonic_aws_master_ec2_type": "m4.large",
     "tectonic_aws_ssh_key": "jenkins",
     "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",


### PR DESCRIPTION
The GUI tests are failing because the are using one of the output files
from a different frontend test rather than their own configuration. This
GUI test modifies the configuration file to suite its needs, which will
always be a game of catchup. This fixes the issue for the time being but
it will need more refactoring.

cc @kyoto 