### PR TITLE
bootkube: add explicit start ordering

### DIFF
--- a/modules/bootkube/resources/bootkube.service
+++ b/modules/bootkube/resources/bootkube.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Bootstrap a Kubernetes cluster
 ConditionPathExists=!/opt/tectonic/init_bootkube.done
+Wants=kubelet.service
+After=kubelet.service
 
 [Service]
 Type=oneshot

--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -60,6 +60,8 @@ systemd:
         [Unit]
         Description=Bootstrap a Kubernetes cluster
         ConditionPathExists=!/opt/tectonic/init_bootkube.done
+        Wants=kubelet.service
+        After=kubelet.service
         [Service]
         Type=oneshot
         RemainAfterExit=true


### PR DESCRIPTION
This introduces an explicit weak start-ordering between kubelet and bootkube,
with the following rationale:
 * After: bootkube needs kubelet to work
 * Wants: kubelet may be crash-looping for some time at first before kubelet.env
   appears, so we introduce a weak dependency here (i.e. no `Requires`).