### PR TITLE
frontend: Add Start Over button back to install screen

### DIFF
--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -198,7 +198,7 @@ const Wizard = withNav(withRouter(connect(stateToProps)(
                     showPrev={!!t.previousFrom(currentPage)}
                     showNext={!!t.nextFrom(currentPage)}
                     disableNext={!canNavigateForward(state)}
-                    resetBtn={t.canReset} />
+                    resetBtn={currentPage.canReset} />
                 }
               </div>
             </div>

--- a/installer/frontend/trail.js
+++ b/installer/frontend/trail.js
@@ -53,6 +53,7 @@ const dryRunPage = {
   path: '/define/advanced',
   component: DryRun,
   title: 'Download Assets',
+  canReset: true,
 };
 
 const etcdPage = {
@@ -80,6 +81,7 @@ const TFPowerOnPage = {
   path: '/boot/tf/poweron',
   component: TF_PowerOn,
   title: 'Start Installation',
+  canReset: true,
 };
 
 const usersPage = {
@@ -232,8 +234,7 @@ sections.forEach((v, k) => {
 //    - moving from one page to some previous pages
 //    - presenting a (possibly disabled) list of all pages
 export class Trail {
-  constructor(trailSections, whitelist, opts = {}) {
-    this.canReset = opts.canReset;
+  constructor(trailSections, whitelist) {
     this.sections = trailSections;
     const sectionPages = this.sections.reduce((ls, l) => ls.concat(l), []);
     sectionPages.forEach(p => {
@@ -342,7 +343,7 @@ export const trail = ({cluster, clusterConfig, commitState}) => {
   const submitted = ready || (phase === commitPhases.SUCCEEDED);
   if (submitted) {
     if (clusterConfig[DRY_RUN]) {
-      return new Trail([sections.bootDryRun], null, {canReset: true});
+      return new Trail([sections.bootDryRun]);
     }
     return platformToSection[platform].boot;
   }


### PR DESCRIPTION
Also moves canReset to be an attribute of the trail pages.

<img width="816" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/29873535-950bb104-8dce-11e7-87db-29fc09ea8e62.png">