### PR TITLE
Replace aws test implemented in bash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,6 +140,7 @@ pipeline {
                         cd tests/rspec
                         bundler exec rspec spec/aws_spec.rb
                       """
+                      deleteDir()
                     }
                   }
                 }
@@ -162,53 +163,8 @@ pipeline {
                         cd tests/rspec
                         bundler exec rspec spec/aws_vpc_internal_spec.rb
                       """
+                      deleteDir()
                     }
-                  }
-                }
-              }
-            }
-          },
-          "SmokeTest Terraform: AWS": {
-            node('worker && ec2') {
-              withCredentials(creds) {
-                withDockerContainer(args: '-v /etc/passwd:/etc/passwd:ro', image: params.builder_image) {
-                  ansiColor('xterm') {
-                    checkout scm
-                    unstash 'installer'
-                    unstash 'smoke'
-                    script {
-                      try {
-                        timeout(45) {
-                          sh """#!/bin/bash -ex
-                          . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$TECTONIC_INSTALLER_ROLE"
-                          ${WORKSPACE}/tests/smoke/aws/smoke.sh plan vars/aws-tls.tfvars
-                          ${WORKSPACE}/tests/smoke/aws/smoke.sh create vars/aws-tls.tfvars | tee ${WORKSPACE}/terraform.log
-                          ${WORKSPACE}/tests/smoke/aws/smoke.sh test vars/aws-tls.tfvars
-                          ${WORKSPACE}/tests/smoke/aws/smoke.sh destroy vars/aws-tls.tfvars
-                          """
-                        }
-                      } catch (err) {
-                        timeout (5) {
-                          sshagent(['aws-smoke-test-ssh-key']) {
-                            sh """#!/bin/bash
-                            # Running without -ex because we don't care if this fails
-                            . ${WORKSPACE}/tests/smoke/aws/smoke.sh common vars/aws-tls.tfvars
-                            ${WORKSPACE}/tests/smoke/aws/cluster-foreach.sh ${WORKSPACE}/tests/smoke/forensics.sh
-                            """
-                          }
-                        }
-                        timeout(5) {
-                          sh """#!/bin/bash -x
-                          . ${WORKSPACE}/tests/smoke/aws/smoke.sh assume-role "$GRAFITI_DELETER_ROLE"
-                          ${WORKSPACE}/tests/smoke/aws/smoke.sh grafiti-clean vars/aws-tls.tfvars
-                          """
-                        }
-
-                        // Stage should fail
-                        throw err
-                      }
-                    }
-                    deleteDir()
                   }
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,14 +131,16 @@ pipeline {
             node('worker && ec2') {
               withCredentials(creds) {
                 withDockerContainer(tectonic_smoke_test_env_image) {
-                  ansiColor('xterm') {
-                    checkout scm
-                    unstash 'installer'
-                    unstash 'smoke'
-                    sh """#!/bin/bash -ex
-                      cd tests/rspec
-                      bundler exec rspec spec/aws_spec.rb
-                    """
+                  sshagent(['aws-smoke-test-ssh-key']) {
+                    ansiColor('xterm') {
+                      checkout scm
+                      unstash 'installer'
+                      unstash 'smoke'
+                      sh """#!/bin/bash -ex
+                        cd tests/rspec
+                        bundler exec rspec spec/aws_spec.rb
+                      """
+                    }
                   }
                 }
               }
@@ -151,14 +153,16 @@ pipeline {
                     image: tectonic_smoke_test_env_image,
                     args: '--device=/dev/net/tun --cap-add=NET_ADMIN -u root'
                 ) {
-                  ansiColor('xterm') {
-                    checkout scm
-                    unstash 'installer'
-                    unstash 'smoke'
-                    sh """#!/bin/bash -ex
-                      cd tests/rspec
-                      bundler exec rspec spec/aws_vpc_internal_spec.rb
-                    """
+                  sshagent(['aws-smoke-test-ssh-key']) {
+                    ansiColor('xterm') {
+                      checkout scm
+                      unstash 'installer'
+                      unstash 'smoke'
+                      sh """#!/bin/bash -ex
+                        cd tests/rspec
+                        bundler exec rspec spec/aws_vpc_internal_spec.rb
+                      """
+                    }
                   }
                 }
               }

--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -48,4 +48,9 @@ class AwsCluster < Cluster
     Grafiti.new(@build_path, ENV['TF_VAR_tectonic_aws_region']).clean
     super
   end
+
+  def recover_from_failed_destroy
+    Grafiti.new(@build_path, ENV['TF_VAR_tectonic_aws_region']).clean
+    super
+  end
 end

--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -2,12 +2,17 @@
 
 require 'cluster'
 require 'aws_region'
+require 'json'
+require 'jenkins'
+require 'grafiti'
+require 'env_var'
+require 'aws_iam'
 
 # AWSCluster represents a k8s cluster on AWS cloud provider
-
 class AwsCluster < Cluster
   def initialize(tfvars_file)
     export_random_region_if_not_defined
+    AWSIAM.assume_role if Jenkins.environment?
 
     super(tfvars_file)
   end
@@ -37,5 +42,10 @@ class AwsCluster < Cluster
 
   def ssh_key_defined?
     EnvVar.set?(%w[TF_VAR_tectonic_aws_ssh_key])
+  end
+
+  def recover_from_failed_destroy
+    Grafiti.new(@build_path, ENV['TF_VAR_tectonic_aws_region']).clean
+    super
   end
 end

--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -48,9 +48,4 @@ class AwsCluster < Cluster
     Grafiti.new(@build_path, ENV['TF_VAR_tectonic_aws_region']).clean
     super
   end
-
-  def recover_from_failed_destroy
-    Grafiti.new(@build_path, ENV['TF_VAR_tectonic_aws_region']).clean
-    super
-  end
 end

--- a/tests/rspec/lib/aws_iam.rb
+++ b/tests/rspec/lib/aws_iam.rb
@@ -1,7 +1,13 @@
 # The AWSIAM contains helper functions to interact with AWS IAM
 module AWSIAM
   def self.assume_role
+    return if ENV.key?('AWS_SESSION_TOKEN')
+
     role_name = ENV['TECTONIC_INSTALLER_ROLE']
+
+    if role_name.to_s.empty?
+      raise 'TECTONIC_INSTALLER_ROLE environment variable not set'
+    end
 
     role_arn = JSON.parse(
       `aws iam get-role --role-name="#{role_name}"`
@@ -9,14 +15,18 @@ module AWSIAM
 
     credentials = request_credentials(role_arn)
 
-    ENV['AWS_ACCESS_KEY_ID'] = credentials['AccessKeyId']
-    ENV['AWS_SECRET_ACCESS_KEY'] = credentials['SecretAccessKey']
-    ENV['AWS_SESSION_TOKEN'] = credentials['SessionToken']
+    export_env_variables(credentials)
   end
 
   def self.request_credentials(role_arn)
     cmd = "aws sts assume-role --role-arn='#{role_arn}'"\
           ' --role-session-name=tectonic-installer'
     JSON.parse(`#{cmd}`)['Credentials']
+  end
+
+  def self.export_env_variables(credentials)
+    ENV['AWS_ACCESS_KEY_ID'] = credentials['AccessKeyId']
+    ENV['AWS_SECRET_ACCESS_KEY'] = credentials['SecretAccessKey']
+    ENV['AWS_SESSION_TOKEN'] = credentials['SessionToken']
   end
 end

--- a/tests/rspec/lib/aws_iam.rb
+++ b/tests/rspec/lib/aws_iam.rb
@@ -1,0 +1,22 @@
+# The AWSIAM contains helper functions to interact with AWS IAM
+module AWSIAM
+  def self.assume_role
+    role_name = ENV['TECTONIC_INSTALLER_ROLE']
+
+    role_arn = JSON.parse(
+      `aws iam get-role --role-name="#{role_name}"`
+    )['Role']['Arn']
+
+    credentials = request_credentials(role_arn)
+
+    ENV['AWS_ACCESS_KEY_ID'] = credentials['AccessKeyId']
+    ENV['AWS_SECRET_ACCESS_KEY'] = credentials['SecretAccessKey']
+    ENV['AWS_SESSION_TOKEN'] = credentials['SessionToken']
+  end
+
+  def self.request_credentials(role_arn)
+    cmd = "aws sts assume-role --role-arn='#{role_arn}'"\
+          ' --role-session-name=tectonic-installer'
+    JSON.parse(`#{cmd}`)['Credentials']
+  end
+end

--- a/tests/rspec/lib/aws_vpc.rb
+++ b/tests/rspec/lib/aws_vpc.rb
@@ -88,7 +88,7 @@ class AWSVPC
       end
     end
 
-    raise 'could not destroy vpc with Terraform' unless succeeded
+    raise 'could not destroy vpc with Terraform'
   end
 
   def wait_for_vpn_access_server

--- a/tests/rspec/lib/aws_vpc.rb
+++ b/tests/rspec/lib/aws_vpc.rb
@@ -4,13 +4,13 @@ require 'json'
 class AWSVPC
   attr_reader :vpn_url
   attr_reader :ovpn_password
-  attr_reader :vpn_conf
   attr_reader :name
   attr_reader :vpc_dns
   attr_reader :vpc_id
   attr_reader :private_zone_id
   attr_reader :master_subnet_ids
   attr_reader :worker_subnet_ids
+  attr_reader :vpn_connection
 
   def initialize(name)
     @name = name

--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -11,7 +11,7 @@ class Cluster
   MAX_NAME_LENGTH = 28
   RANDOM_HASH_LENGTH = 5
 
-  attr_reader :tfvars_file, :kubeconfig, :manifest_path
+  attr_reader :tfvars_file, :kubeconfig, :manifest_path, :build_path
 
   def initialize(tfvars_file)
     @tfvars_file = tfvars_file
@@ -20,9 +20,9 @@ class Cluster
     # S3 buckets can only handle lower case names
     @name = (ENV['CLUSTER'] || generate_name(tfvars_file.prefix)).downcase
 
-    @manifest_path = `echo $(realpath ../../build)/#{@name}/generated`
-                     .delete("\n")
-    @kubeconfig = manifest_path + '/auth/kubeconfig'
+    @build_path = File.join(File.realpath('../../'), "build/#{@name}")
+    @manifest_path = File.join(@build_path, 'generated')
+    @kubeconfig = File.join(manifest_path, 'auth/kubeconfig')
   end
 
   def start
@@ -88,8 +88,11 @@ class Cluster
       return if system(env_variables, 'make -C ../.. destroy')
     end
 
+    recover_from_failed_destroy
     raise 'Destroying cluster failed'
   end
+
+  def recover_from_failed_destroy() end
 
   def clean
     succeeded = system(env_variables, 'make -C ../.. destroy')

--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -95,7 +95,7 @@ class Cluster
   def recover_from_failed_destroy() end
 
   def clean
-    succeeded = system(env_variables, 'make -C ../.. destroy')
+    succeeded = system(env_variables, 'make -C ../.. clean')
     raise 'could not clean build directory' unless succeeded
   end
 

--- a/tests/rspec/lib/grafiti.rb
+++ b/tests/rspec/lib/grafiti.rb
@@ -1,0 +1,51 @@
+# Grafiti contains helper functions to use the http://github.com/coreos/grafiti
+# tool
+class Grafiti
+  attr_reader :build_path
+  attr_reader :tmp_dir
+  attr_reader :config_file_path
+  attr_reader :tag_file_path
+  attr_reader :terraform_log_path
+  attr_reader :aws_region
+
+  def initialize(build_path, region)
+    @aws_region = region
+    @build_path = build_path
+    @tmp_dir = `mktemp -d -p #{@build_path}`.chomp
+    @config_file_path = File.join(@tmp_dir, 'config.toml')
+    @tag_file_path = File.join(@tmp_dir, 'tag.json')
+    @terraform_log_path = File.join(build_path, 'terraform.tfstate')
+    write_config_file
+    write_tag_file
+  end
+
+  def clean
+    cmd = 'grafiti'\
+          " --config #{@config_file_path}"\
+          ' --ignore-errors'\
+          ' delete'\
+          ' --all-deps'\
+          " --delete-file #{@tag_file_path}"
+
+    succeded = system({ 'AWS_REGION' => @aws_region }, cmd)
+    raise 'failed to run grafiti delete' unless succeded
+  end
+
+  def cluster_id
+    cmd = 'grep -m 1 -oP'\
+          ' \'^ *\"tags\.tectonicClusterID\": \"\K[0-9a-z-]*(?=\",$)\''\
+          " #{terraform_log_path}"
+    `#{cmd}`.chomp
+  end
+
+  def write_config_file
+    IO.write(@config_file_path, 'maxNumRequestRetries = 11')
+  end
+
+  def write_tag_file
+    content = '{"TagFilters":['\
+              "  {\"Key\":\"tectonicClusterID\",\"Values\":[\"#{cluster_id}\""\
+              ']}]}'
+    IO.write(@tag_file_path, content)
+  end
+end

--- a/tests/rspec/spec/aws_vpc_internal_spec.rb
+++ b/tests/rspec/spec/aws_vpc_internal_spec.rb
@@ -1,10 +1,13 @@
 require 'shared_examples/k8s'
 require 'aws_vpc'
 require 'aws_region'
+require 'jenkins'
+require 'aws_iam'
 
 RSpec.describe 'aws-vpc' do
   before(:all) do
     export_random_region_if_not_defined
+    AWSIAM.assume_role if Jenkins.environment?
     @vpc = AWSVPC.new('test-vpc')
     @vpc.create
   end

--- a/tests/rspec/spec/meta-tests/aws_vpc_spec.rb
+++ b/tests/rspec/spec/meta-tests/aws_vpc_spec.rb
@@ -1,8 +1,10 @@
 require 'aws_vpc'
+require 'aws_iam'
 
 describe AWSVPC do
   before(:all) do
-    @vpc = described_class.new('eu-west-1', 'test-vpc')
+    AWSIAM.assume_role if Jenkins.environment?
+    @vpc = described_class.new('test-vpc')
   end
 
   it '#initialize generated a password' do

--- a/tests/rspec/spec/meta-tests/tfvars_file_spec.rb
+++ b/tests/rspec/spec/meta-tests/tfvars_file_spec.rb
@@ -2,7 +2,7 @@
 
 require 'tfvars_file'
 
-TFVARS_FILE_PATH = '../smoke/aws/vars/aws.tfvars.json'
+TFVARS_FILE_PATH = '../smoke/aws/vars/aws.tfvars.json'.freeze
 
 describe TFVarsFile do
   subject { described_class.new(TFVARS_FILE_PATH) }


### PR DESCRIPTION
This PR removes our main AWS test that was implemented in bash. In order to replace it this PR introduces in addition in RSpec:
- Grafiti to run after failed destroy
- Assume AWS tectonic-installer role