### PR TITLE
Update nginx ingress controller to 0.9-beta.12

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -41,7 +41,7 @@ variable "tectonic_container_images" {
     heapster                     = "gcr.io/google_containers/heapster:v1.4.1"
     hyperkube                    = "quay.io/coreos/hyperkube:v1.7.3_coreos.0"
     identity                     = "quay.io/coreos/dex:v2.6.1"
-    ingress_controller           = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11"
+    ingress_controller           = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.12"
     kenc                         = "quay.io/coreos/kenc:0.0.2"
     kubedns                      = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4"
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4"


### PR DESCRIPTION
**Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.12`

*Breaking changes:*

- SSL passthrough is disabled by default. To enable the feature use `--enable-ssl-passthrough`

*New Features:*

- Support for arm64
- New flags to customize listen ports
- Per minute rate limiting
- Rate limit whitelist
- Configuration of nginx worker timeout (to avoid zombie nginx workers processes)
- Redirects from non-www to www
- Custom default backend (per Ingress)
- Graceful shutdown for NGINX

Complete changelog [here](https://github.com/kubernetes/ingress/blob/master/controllers/nginx/Changelog.md)
