### PR TITLE
Fix legacy release scripts

### DIFF
--- a/git-version
+++ b/git-version
@@ -8,8 +8,8 @@ VERSION=$(git rev-parse HEAD)
 # check if the current commit has a matching tag,
 # and prepend the matching tag to the version, if available.
 TAG=$(git describe --exact-match --abbrev=0 --tags ${VERSION} 2> /dev/null || true)
-if [ -z "$TAG" ]; then
-	VERSION=$TAG_$VERSION
+if [ ! -z "$TAG" ]; then
+	VERSION=${TAG}_${VERSION}
 fi
 
 # check for changed files (not untracked files)

--- a/installer/scripts/release/common.env.sh
+++ b/installer/scripts/release/common.env.sh
@@ -6,8 +6,7 @@ REPOSITORY_ROOT="$ROOT/.."
 WORKSPACE_DIR="$ROOT/.workspace"
 TMP_DIR="$WORKSPACE_DIR/tmpdir"
 
-VERSION=$("$REPOSITORY_ROOT/git-version")
-export VERSION
+export VERSION=${VERSION:-$("$REPOSITORY_ROOT/git-version")}
 
 export TECTONIC_RELEASE_BUCKET=releases.tectonic.com
 export TECTONIC_BINARY_BUCKET=tectonic-release

--- a/installer/scripts/release/make_github_release.sh
+++ b/installer/scripts/release/make_github_release.sh
@@ -13,10 +13,10 @@ source "$DIR/common.env.sh"
 GITHUB_API_URL="https://api.github.com/repos/coreos/tectonic-installer/releases"
 
 # shellcheck disable=SC2028
-echo "Creating new release on GitHub ${#GITHUB_CREDENTIALS} \n\n {\"tag_name\":\"$VERSION\",\"prerelease\":$PRE_RELEASE,\"body\":\"Release tarball is available at $TECTONIC_RELEASE_TARBALL_URL.\"}"
+echo "Creating new release on GitHub ${#GITHUB_CREDENTIALS} \n\n {\"tag_name\":\"$VERSION\", \"name\": \"$VERSION\", \"prerelease\":$PRE_RELEASE,\"body\":\"Release tarball is available at $TECTONIC_RELEASE_TARBALL_URL.\"}"
 curl \
     --fail \
     -u "$GITHUB_CREDENTIALS" \
     -H "Content-Type: application/json" \
-    -d "{\"tag_name\":\"$VERSION\",\"prerelease\":$PRE_RELEASE,\"body\":\"Release tarball is available at $TECTONIC_RELEASE_TARBALL_URL.\"}" \
+    -d "{\"tag_name\":\"$VERSION\",\"name\": \"$VERSION\",\"prerelease\":$PRE_RELEASE,\"body\":\"Release tarball is available at $TECTONIC_RELEASE_TARBALL_URL.\"}" \
     $GITHUB_API_URL


### PR DESCRIPTION
Cherry-picks https://github.com/coreos/tectonic-installer/pull/1809

- Fixes an issue where the tag was never used as part of the version, as initially intended (intro in #987) 
- Fixes an issue where the commit SHA was used for the release instead of the provided tag (intro in #1613) - therefore creating invalid tarball names and breaking the Github release creation (`422 Unprocessable Entity` because no tag with that name)
- Fixes a issue that existed for too long where the Github release was created without a name provided - letting Github pick a default name for the release, a.k.a. the git commit message, and thus forcing the release manager to rename the release manually after the fact

/cc @sudhaponnaganti 