### PR TITLE
platforms/metal: unify kubelet, install as enabled

### DIFF
--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -31,15 +31,6 @@ systemd:
           contents: {{.ign_docker_dropin_json}}
     - name: locksmithd.service
       mask: true
-    - name: kubelet.path
-      enable: true
-      contents: |
-        [Unit]
-        Description=Watch for kubeconfig
-        [Path]
-        PathExists=/etc/kubernetes/kubeconfig
-        [Install]
-        WantedBy=multi-user.target
     - name: wait-for-dns.service
       enable: true
       contents: |
@@ -54,6 +45,7 @@ systemd:
         [Install]
         RequiredBy=kubelet.service
     - name: kubelet.service
+      enable: true
       contents: {{.ign_kubelet_service_json}}
     - name: bootkube.service
       contents: |

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -8,15 +8,6 @@ systemd:
           contents: {{.ign_docker_dropin_json}}
     - name: locksmithd.service
       mask: true
-    - name: kubelet.path
-      enable: true
-      contents: |
-        [Unit]
-        Description=Watch for kubeconfig
-        [Path]
-        PathExists=/etc/kubernetes/kubeconfig
-        [Install]
-        WantedBy=multi-user.target
     - name: wait-for-dns.service
       enable: true
       contents: |
@@ -34,6 +25,7 @@ systemd:
       enable: true
       contents: {{.ign_kubelet_env_service_json}}
     - name: kubelet.service
+      enable: true
       contents: {{.ign_kubelet_service_json}}
 
 storage:


### PR DESCRIPTION
This updates kubelet setup on bare-metal to unify with all other
platforms. It gets rid of path activation and enables kubelet.service
directly from ignition.