### PR TITLE
Double dash flag consistency.

### DIFF
--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -99,7 +99,7 @@ ExecStart=/usr/lib/coreos/etcd-wrapper \
   --discovery-srv=${var.base_domain} \
   --advertise-client-urls=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2379 \
   ${var.tls_enabled
-      ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt -peer-client-cert-auth=true"
+      ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt --peer-client-cert-auth=true"
       : ""} \
   --initial-advertise-peer-urls=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2380 \
   --listen-client-urls=${var.tls_enabled ? "https" : "http"}://0.0.0.0:2379 \

--- a/modules/azure/etcd/ignition.tf
+++ b/modules/azure/etcd/ignition.tf
@@ -174,7 +174,7 @@ ExecStart=/usr/lib/coreos/etcd-wrapper \
           join(";", formatlist("%s.${var.base_domain}", slice(formatlist("${var.cluster_name}-%s", var.const_internal_node_names), 0, var.etcd_count)))), count.index)} \
   --advertise-client-urls=${var.tls_enabled ? "https" : "http"}://$${COREOS_AZURE_IPV4_DYNAMIC}:2379 \
   ${var.tls_enabled
-      ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt -peer-client-cert-auth=true"
+      ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt --peer-client-cert-auth=true"
       : ""} \
   --initial-advertise-peer-urls=${var.tls_enabled ? "https" : "http"}://$${COREOS_AZURE_IPV4_DYNAMIC}:2380 \
   --listen-client-urls=${var.tls_enabled ? "https" : "http"}://0.0.0.0:2379 \

--- a/modules/openstack/etcd/ignition.tf
+++ b/modules/openstack/etcd/ignition.tf
@@ -135,7 +135,7 @@ ExecStart=/usr/lib/coreos/etcd-wrapper \
   --discovery-srv=${var.base_domain} \
   --advertise-client-urls=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2379 \
   ${var.tls_enabled
-      ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt -peer-client-cert-auth=true"
+      ? "--cert-file=/etc/ssl/etcd/server.crt --key-file=/etc/ssl/etcd/server.key --peer-cert-file=/etc/ssl/etcd/peer.crt --peer-key-file=/etc/ssl/etcd/peer.key --peer-trusted-ca-file=/etc/ssl/etcd/ca.crt --peer-client-cert-auth=true"
       : ""} \
   --initial-advertise-peer-urls=${var.tls_enabled ? "https" : "http"}://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2380 \
   --listen-client-urls=${var.tls_enabled ? "https" : "http"}://0.0.0.0:2379 \


### PR DESCRIPTION
All etcd flags are preceded by double dash except for "-peer-client-cert-auth" which can be found with either single and double dash (modules/vmware/etcd/ignition.tf, modules/bootkube/resources/experimental/bootstrap-manifests/bootstrap-etcd.yaml)

Not sure if there's any reason behind this, so just adding consistency here by setting always double dash.