### PR TITLE
modules/aws: fix AWS iops default

### DIFF
--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "etcd_node" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
+    iops        = "${var.root_volume_iops}"
   }
 
   volume_tags = "${merge(map(

--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -78,7 +78,7 @@ resource "aws_launch_configuration" "master_conf" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
+    iops        = "${var.root_volume_iops}"
   }
 }
 

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -43,7 +43,7 @@ resource "aws_launch_configuration" "worker_conf" {
   root_block_device {
     volume_type = "${var.root_volume_type}"
     volume_size = "${var.root_volume_size}"
-    iops        = "${var.root_volume_type == "io1" ? var.root_volume_iops : 100}"
+    iops        = "${var.root_volume_iops}"
   }
 }
 


### PR DESCRIPTION
This commit fixes INST-96, which notes that users cannot customize the
IOPS of any AWS nodes unless the nodes are of type `io1`.

cc @alexsomesan