### PR TITLE
tests/ci: add slack notification to #tectonic-installer channel

### DIFF
--- a/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
+++ b/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
@@ -65,6 +65,7 @@ job("builders/tectonic-builder-docker-image") {
       includeCustomMessage(true)
       notifyBackToNormal(true)
       notifyFailure(true)
+      notifyRepeatedFailure(true)
       room('#tectonic-installer-ci')
       teamDomain('coreos')
     }

--- a/tests/jenkins-jobs/tectonic_installer_nightly_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_nightly_trigger.groovy
@@ -38,7 +38,18 @@ job("triggers/tectonic-installer-nightly-trigger") {
       includeCustomMessage(true)
       notifyBackToNormal(true)
       notifyFailure(true)
+      notifyRepeatedFailure(true)
       room('#tectonic-installer-ci')
+      teamDomain('coreos')
+    }
+    slackNotifier {
+      authTokenCredentialId('tectonic-slack-token')
+      customMessage("Tectonic Installer Nightly Build - Master Branch")
+      includeCustomMessage(true)
+      notifyBackToNormal(true)
+      notifyFailure(true)
+      notifyRepeatedFailure(true)
+      room('#tectonic-installer')
       teamDomain('coreos')
     }
   }

--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -61,6 +61,7 @@ job("triggers/tectonic-installer-pr-trigger") {
       includeCustomMessage(true)
       notifyBackToNormal(true)
       notifyFailure(true)
+      notifyRepeatedFailure(true)
       room('#tectonic-installer-ci')
       teamDomain('coreos')
     }

--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger_no_smoke.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger_no_smoke.groovy
@@ -65,6 +65,7 @@ job("triggers/tectonic-installer-pr-trigger-no-smoke") {
       includeCustomMessage(true)
       notifyBackToNormal(true)
       notifyFailure(true)
+      notifyRepeatedFailure(true)
       room('#tectonic-installer-ci')
       teamDomain('coreos')
     }

--- a/tests/jenkins-jobs/tectonic_installer_upstream_terraform_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_upstream_terraform_trigger.groovy
@@ -45,6 +45,7 @@ job("triggers/upstream-terraform-trigger") {
       includeCustomMessage(true)
       notifyBackToNormal(true)
       notifyFailure(true)
+      notifyRepeatedFailure(true)
       room('#tectonic-installer-ci')
       teamDomain('coreos')
     }


### PR DESCRIPTION
- Add extra notification when running the nightly build to
tectonic-installer channel
- add option to notify when have repeated failures