### PR TITLE
test/ci: fix issue in dsl

### DIFF
--- a/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
+++ b/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
@@ -50,8 +50,8 @@ job("builders/tectonic-builder-docker-image") {
       echo "Just build the image"
     else
       echo "Pushing the Image to quay"
-      docker login quay.io -u ${QUAY_USERNAME} -p ${QUAY_PASSWD}
-      docker push ${TECTONIC_BUILDER_IMAGE}
+      docker login quay.io -u \${QUAY_USERNAME} -p \${QUAY_PASSWD}
+      docker push \${TECTONIC_BUILDER_IMAGE}
     fi
   """.stripIndent()
     shell(cmd)


### PR DESCRIPTION
Jenkins complain: ERROR: (tectonic_builder_docker_image.groovy, line 36) No such property: QUAY_USERNAME for class: javaposse.jobdsl.dsl.helpers.step.StepContext