### PR TITLE
tests: Enfore consistent name for local clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,13 +153,14 @@ smoke-test-env-docker-image:
 	docker build -t quay.io/coreos/tectonic-smoke-test-env -f images/tectonic-smoke-test-env/Dockerfile .
 
 .PHONY: tests/smoke
-tests/smoke: installer-env smoke-test-env-docker-image
+tests/smoke: smoke-test-env-docker-image
 	docker run \
 	--rm \
 	-it \
 	-v ${CURDIR}:${CURDIR} \
 	-w ${CURDIR}/tests/rspec \
-	-e  AWS_ACCESS_KEY_ID \
+	-e CLUSTER \
+	-e AWS_ACCESS_KEY_ID \
 	-e AWS_SECRET_ACCESS_KEY \
 	-e TF_VAR_tectonic_aws_ssh_key \
 	-e TF_VAR_tectonic_license_path \

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ smoke-test-env-docker-image:
 	docker build -t quay.io/coreos/tectonic-smoke-test-env -f images/tectonic-smoke-test-env/Dockerfile .
 
 .PHONY: tests/smoke
-tests/smoke: smoke-test-env-docker-image
+tests/smoke: bin/smoke smoke-test-env-docker-image
 	docker run \
 	--rm \
 	-it \

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ structure-check:
 SMOKE_SOURCES := $(shell find $(TOP_DIR)/tests/smoke -name '*.go')
 .PHONY: bin/smoke
 bin/smoke: $(SMOKE_SOURCES)
-	@CGO_ENABLED=0 go test ./tests/smoke/ -c -o bin/smoke
+	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test ./tests/smoke/ -c -o bin/smoke
 
 .PHONY: vendor-smoke
 vendor-smoke: $(TOP_DIR)/tests/smoke/glide.yaml

--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -11,8 +11,10 @@ require 'aws_iam'
 # AWSCluster represents a k8s cluster on AWS cloud provider
 class AwsCluster < Cluster
   def initialize(tfvars_file)
-    export_random_region_if_not_defined
-    AWSIAM.assume_role if Jenkins.environment?
+    if Jenkins.environment?
+      export_random_region_if_not_defined
+      AWSIAM.assume_role
+    end
 
     super(tfvars_file)
   end

--- a/tests/rspec/lib/name_generator.rb
+++ b/tests/rspec/lib/name_generator.rb
@@ -1,0 +1,34 @@
+require 'jenkins'
+
+# NameGenerator contains helper functions to generate test resource names
+module NameGenerator
+  MAX_NAME_LENGTH = 28
+  RANDOM_HASH_LENGTH = 5
+
+  def self.generate(prefix)
+    name = if Jenkins.environment?
+             jenkins_env_name(prefix)
+           else
+             local_env_name
+           end
+    name.downcase
+  end
+
+  def self.jenkins_env_name(prefix)
+    build_id = ENV['BUILD_ID']
+    branch_name = ENV['BRANCH_NAME']
+    name = "#{prefix}-#{branch_name}-#{build_id}"
+    name = name[0..(MAX_NAME_LENGTH - RANDOM_HASH_LENGTH - 1)]
+    name += SecureRandom.hex[0...RANDOM_HASH_LENGTH]
+    name
+  end
+
+  def self.local_env_name
+    unless  ENV.key?('CLUSTER')
+      raise 'Please define the CLUSTER environment variable '\
+            'in a local test setup e.g. '\
+            '`export CLUSTER=my-cluster-name`'
+    end
+    ENV['CLUSTER']
+  end
+end


### PR DESCRIPTION
When someone runs the smoke tests locally this PR enforces that a cluster name is set. This ensures, that we can identify a left over cluster with a person instead of seeing random cluster names.