### PR TITLE
tests: Add hint to README for license and pull secret path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Further details can be found in our [Jenkinsfile](./Jenkinsfile) which serves as
 the single source of truth.
 
 To run a smoke test locally you need to set the following environment variables:
+
 ```
 CLUSTER
 AWS_ACCESS_KEY_ID
@@ -136,7 +137,15 @@ TF_VAR_base_domain
 TF_VAR_tectonic_admin_email
 TF_VAR_tectonic_admin_password_hash
 ```
-and run `make tests/smoke TEST=spec/aws_spec.rb`
+
+Make sure both the *Tectonic pull secret* as well as the *Tectonic license* is
+saved somewhere in the repository folder. Only the repository folder will be
+mounted into the Docker container where the tests will be executed in. The test
+framework will not be able to read any files outside the repository folder
+during test execution.
+
+Once the environment variables are set, run `make tests/smoke
+TEST=spec/aws_spec.rb`.
 
 
 [platform-lifecycle]: Documentation/platform-lifecycle.md


### PR DESCRIPTION
To improve usability of runnning the smoke tests locally, we run them
inside a docker container. The Tectonic installer repository will be
mounted into the container before executing the tests. In order for the
installer to read the *pull-secret* and *license* file, they have to be
in the repository folder, otherwise they can not be read by the
installer during runtime.

This commit adds a hint to the README to point this fact out.