### PR TITLE
tests/frontend: Add more Nightwatch tests for AWS

### DIFF
--- a/installer/frontend/ui-tests/commands/expectNoValidationError.js
+++ b/installer/frontend/ui-tests/commands/expectNoValidationError.js
@@ -1,0 +1,4 @@
+exports.command = function() {
+  this.expect.element('.wiz-error-message:not(.hidden)').to.not.be.present;
+  return this;
+};

--- a/installer/frontend/ui-tests/commands/expectValidationErrorContains.js
+++ b/installer/frontend/ui-tests/commands/expectValidationErrorContains.js
@@ -1,0 +1,4 @@
+exports.command = function(text) {
+  this.expect.element('.wiz-error-message:not(.hidden)').text.contains(text);
+  return this;
+};

--- a/installer/frontend/ui-tests/pages/awsCredentialsPage.js
+++ b/installer/frontend/ui-tests/pages/awsCredentialsPage.js
@@ -7,14 +7,18 @@ const awsCredentialsPageCommands = {
     if (process.env.AWS_SESSION_TOKEN) {
       this
         .setField('@sessionTokenTrue')
-        .setField('@awsAccessKey', process.env.AWS_ACCESS_KEY_ID)
-        .setField('@secretAccesskey', process.env.AWS_SECRET_ACCESS_KEY)
         .setField('@sessionToken', process.env.AWS_SESSION_TOKEN);
-    } else {
-      this
-        .setField('@awsAccessKey', process.env.AWS_ACCESS_KEY_ID)
-        .setField('@secretAccesskey', process.env.AWS_SECRET_ACCESS_KEY);
     }
+
+    this
+      .setField('@awsAccessKey', 'abc')
+      .expectValidationErrorContains('AWS key IDs are at least 20 characters')
+      .setField('@awsAccessKey', process.env.AWS_ACCESS_KEY_ID)
+      .expectNoValidationError()
+      .setField('@secretAccesskey', 'abc')
+      .expectValidationErrorContains('AWS secrets are at least 40 characters')
+      .setField('@secretAccesskey', process.env.AWS_SECRET_ACCESS_KEY)
+      .expectNoValidationError();
 
     this.expect.element(regionOption).to.be.visible.before(60000);
     this.selectOption(regionOption);

--- a/installer/frontend/ui-tests/pages/clusterInfoPage.js
+++ b/installer/frontend/ui-tests/pages/clusterInfoPage.js
@@ -14,15 +14,31 @@ const clusterInfoPageCommands = {
     fs.writeFileSync(configPath, pull_secret);
     /* eslint-enable no-sync */
 
-    this
-      .setField('@name', json.tectonic_cluster_name)
-      .setValue('@coreOSLicenseUpload', coreOSLicensePath)
-      .setValue('@pullSecretUpload', configPath);
+    this.setField('@name', 'a%$#b');
+    if (platform === 'aws') {
+      this.expectValidationErrorContains('must be a valid AWS Stack Name');
+    }
+    if (platform === 'metal') {
+      this.expectValidationErrorContains('must be alphanumeric');
+    }
+
+    this.setField('@name', json.tectonic_cluster_name);
+    this.expectNoValidationError();
+
+    this.setValue('@coreOSLicenseUpload', coreOSLicensePath);
+    this.setValue('@pullSecretUpload', configPath);
+
     if (platform === 'aws') {
       this
-        .click('.list-add')
-        .setField('input[id="awsTags.1.key"]', 'test_tag')
-        .setField('input[id="awsTags.1.value"]', 'testing');
+        .setField('input[id="awsTags.0.key"]', '')
+        .setField('input[id="awsTags.0.value"]', 'testing')
+        .expectValidationErrorContains('Both fields are required')
+        .setField('input[id="awsTags.0.key"]', 'test_tag')
+        .setField('input[id="awsTags.0.value"]', '')
+        .expectValidationErrorContains('Both fields are required')
+        .setField('input[id="awsTags.0.key"]', 'test_tag')
+        .setField('input[id="awsTags.0.value"]', 'testing')
+        .expectNoValidationError();
     }
   },
 };

--- a/installer/frontend/ui-tests/pages/consoleLoginPage.js
+++ b/installer/frontend/ui-tests/pages/consoleLoginPage.js
@@ -1,15 +1,29 @@
 const consoleLoginPageCommands = {
   test(json) {
     this
+      .setField('@email', 'abc')
+      .expectValidationErrorContains('Invalid email address')
       .setField('@email', json.tectonic_admin_email)
-      .setField('@password', 'password')
-      .setField('@confirmPassword', 'password');
+      .expectNoValidationError();
+
+    this.setField('@password', 'password');
+    this.setField('@confirmPassword', 'abc');
+    this.expect.element('@alertError').text.to.contain('Passwords do not match');
+
+    this.setField('@password', 'abc');
+    this.setField('@confirmPassword', 'password');
+    this.expect.element('@alertError').text.to.contain('Passwords do not match');
+
+    this.setField('@password', 'password');
+    this.setField('@confirmPassword', 'password');
+    this.expect.element('@alertError').to.not.be.present;
   },
 };
 
 module.exports = {
   commands: [consoleLoginPageCommands],
   elements: {
+    alertError: '.alert-error',
     email: 'input#adminEmail',
     password: 'input#adminPassword',
     confirmPassword: 'input#adminPassword2',

--- a/installer/frontend/ui-tests/pages/networkingPage.js
+++ b/installer/frontend/ui-tests/pages/networkingPage.js
@@ -1,45 +1,60 @@
 const networkingPageCommands = {
+  testCidrInputs(json) {
+    this.setField('#serviceCIDR', json.tectonic_service_cidr);
+
+    this.setField('#podCIDR', '10.2.0.0/15');
+    this.expectValidationErrorContains('AWS subnets must be between /16 and /28');
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').to.not.be.present;
+
+    this.setField('#podCIDR', '10.2.0.0/16');
+    this.expectNoValidationError();
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').to.not.be.present;
+
+    this.setField('#podCIDR', '10.2.0.0/21');
+    this.expectNoValidationError();
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').text.to.equal('Pod Range Mostly Assigned');
+
+    this.setField('#podCIDR', '10.2.0.0/22');
+    this.expectNoValidationError();
+    this.expect.element('@alertErrorTitle').text.to.equal('Pod Range Too Small');
+    this.expect.element('@alertWarningTitle').to.not.be.present;
+
+    this.setField('#podCIDR', '10.2.0.0/29');
+    this.expectValidationErrorContains('AWS subnets must be between /16 and /28');
+    this.expect.element('@alertErrorTitle').text.to.equal('Pod Range Too Small');
+    this.expect.element('@alertWarningTitle').to.not.be.present;
+
+    this.setField('#podCIDR', json.tectonic_cluster_cidr);
+    this.expectNoValidationError();
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').to.not.be.present;
+  },
+
   test(json) {
+    this.expect.element('@vpcOptionNewPublic').to.be.selected;
+
+    this.selectOption('#awsHostedZoneId option[value=Z1ILIMNSJGTMO2]');
+    this.selectOption('#awsSplitDNS option[value=off]');
+
     this.click('@advanced');
     this.expect.element('#awsVpcCIDR').to.be.visible;
     this.expect.element('[id="awsControllerSubnets.us-west-1a"]').to.be.visible;
     this.expect.element('[id="awsControllerSubnets.us-west-1c"]').to.be.visible;
     this.expect.element('[id="awsWorkerSubnets.us-west-1a"]').to.be.visible;
     this.expect.element('[id="awsWorkerSubnets.us-west-1a"]').to.be.visible;
-    this
-      .selectOption('#awsHostedZoneId option[value=Z1ILIMNSJGTMO2]')
-      .selectOption('#awsSplitDNS option[value=off]')
-      .setField('#serviceCIDR', json.tectonic_service_cidr);
 
-    this.setField('#podCIDR', '10.2.0.0/15');
-    this.expect.element('@validationError').text.to.equal('AWS subnets must be between /16 and /28.');
-    this.expect.element('@alertErrorTitle').to.not.be.present;
-    this.expect.element('@alertWarningTitle').to.not.be.present;
+    this.testCidrInputs(json);
 
-    this.setField('#podCIDR', '10.2.0.0/16');
-    this.expect.element('@validationError').to.not.be.present;
-    this.expect.element('@alertErrorTitle').to.not.be.present;
-    this.expect.element('@alertWarningTitle').to.not.be.present;
+    this.selectOption('@vpcOptionExistingPublic');
+    this.testCidrInputs(json);
 
-    this.setField('#podCIDR', '10.2.0.0/21');
-    this.expect.element('@validationError').to.not.be.present;
-    this.expect.element('@alertErrorTitle').to.not.be.present;
-    this.expect.element('@alertWarningTitle').text.to.equal('Pod Range Mostly Assigned');
+    this.selectOption('@vpcOptionExistingPrivate');
+    this.testCidrInputs(json);
 
-    this.setField('#podCIDR', '10.2.0.0/22');
-    this.expect.element('@validationError').to.not.be.present;
-    this.expect.element('@alertErrorTitle').text.to.equal('Pod Range Too Small');
-    this.expect.element('@alertWarningTitle').to.not.be.present;
-
-    this.setField('#podCIDR', '10.2.0.0/29');
-    this.expect.element('@validationError').text.to.equal('AWS subnets must be between /16 and /28.');
-    this.expect.element('@alertErrorTitle').text.to.equal('Pod Range Too Small');
-    this.expect.element('@alertWarningTitle').to.not.be.present;
-
-    this.setField('#podCIDR', json.tectonic_cluster_cidr);
-    this.expect.element('@validationError').to.not.be.present;
-    this.expect.element('@alertErrorTitle').to.not.be.present;
-    this.expect.element('@alertWarningTitle').to.not.be.present;
+    this.selectOption('@vpcOptionNewPublic');
 
     return this;
   },
@@ -54,6 +69,8 @@ module.exports = {
     },
     alertWarningTitle: '.alert-info b',
     alertErrorTitle: '.alert-error b',
-    validationError: '.wiz-error-message:not(.hidden)',
+    vpcOptionNewPublic: '.wiz-radio-group:nth-child(1) input[type=radio]',
+    vpcOptionExistingPublic: '.wiz-radio-group:nth-child(2) input[type=radio]',
+    vpcOptionExistingPrivate: '.wiz-radio-group:nth-child(3) input[type=radio]',
   },
 };

--- a/installer/frontend/ui-tests/pages/nodesPage.js
+++ b/installer/frontend/ui-tests/pages/nodesPage.js
@@ -1,10 +1,23 @@
 const nodesPageCommands = {
   test() {
-    this.click('#selfHosted');
+    this.selectOption('input[type=radio]#provisioned');
+    this.expect.element('@provisionedEtcdCount').to.be.present;
+    this.expect.element('@externalEtcdAddress').to.not.be.present;
+
+    this.selectOption('input[type=radio]#external');
+    this.expect.element('@provisionedEtcdCount').to.not.be.present;
+    this.expect.element('@externalEtcdAddress').to.be.present;
+
+    this.selectOption('input[type=radio]#selfHosted');
+    this.expect.element('@provisionedEtcdCount').to.not.be.present;
+    this.expect.element('@externalEtcdAddress').to.not.be.present;
   },
 };
 
 module.exports = {
   commands: [nodesPageCommands],
-  elements: {},
+  elements: {
+    externalEtcdAddress: 'input#externalETCDClient[type=text]',
+    provisionedEtcdCount: 'input[id="etcd--number"][type=number][min="1"]',
+  },
 };

--- a/installer/frontend/ui-tests/pages/platformPage.js
+++ b/installer/frontend/ui-tests/pages/platformPage.js
@@ -1,14 +1,35 @@
+const wizard = require('../utils/wizard');
+
 const platformPageCommands = {
   test(platformEl) {
     this.expect.element('select#platformType').to.be.visible.before(60000);
+
+    this.selectOption('@awsGUI');
+    this.expect.element(wizard.nextStep).to.be.present;
+    this.selectOption('@awsAdvanced');
+    this.expect.element(wizard.nextStep).to.not.be.present;
+    this.selectOption('@azureAdvanced');
+    this.expect.element(wizard.nextStep).to.not.be.present;
+    this.selectOption('@metalGUI');
+    this.expect.element(wizard.nextStep).to.be.present;
+    this.selectOption('@metalAdvanced');
+    this.expect.element(wizard.nextStep).to.not.be.present;
+    this.selectOption('@openstackAdvanced');
+    this.expect.element(wizard.nextStep).to.not.be.present;
+
     this.selectOption(platformEl);
+    this.expect.element(wizard.nextStep).to.be.present;
   },
 };
 
 module.exports = {
   commands: [platformPageCommands],
   elements: {
-    awsPlatform: 'option[value="aws-tf"]',
-    bareMetalPlatform: 'option[value="bare-metal-tf"]',
+    awsAdvanced: 'option[value="aws"]',
+    awsGUI: 'option[value="aws-tf"]',
+    azureAdvanced: 'option[value="azure"]',
+    metalAdvanced: 'option[value="bare-metal"]',
+    metalGUI: 'option[value="bare-metal-tf"]',
+    openstackAdvanced: 'option[value="openstack"]',
   },
 };

--- a/installer/frontend/ui-tests/tests/awsInstaller.js
+++ b/installer/frontend/ui-tests/tests/awsInstaller.js
@@ -32,7 +32,7 @@ module.exports = {
 
   'AWS: Platform': client => {
     const platformPage = client.page.platformPage();
-    platformPage.test('@awsPlatform');
+    platformPage.test('@awsGUI');
     platformPage.expect.element(wizard.nextStep).to.have.attribute('class').which.not.contains('disabled');
     platformPage.click(wizard.nextStep);
   },

--- a/installer/frontend/ui-tests/tests/bareMetalInstaller.js
+++ b/installer/frontend/ui-tests/tests/bareMetalInstaller.js
@@ -32,7 +32,7 @@ module.exports = {
 
   'BM: Platform': client => {
     const platformPage = client.page.platformPage();
-    platformPage.test('@bareMetalPlatform');
+    platformPage.test('@metalGUI');
     platformPage.expect.element(wizard.nextStep).to.have.attribute('class').which.not.contains('disabled');
     platformPage.click(wizard.nextStep);
   },


### PR DESCRIPTION
Test each of the platform options on the first page.
Add AWS credentials page validation error tests.
Add basic tests for AWS Define Nodes page etcd options.
Run pod / service range tests for each VPC option.
Add Console Login page validation error tests.