### PR TITLE
Always set HOME env when running Terraform

### DIFF
--- a/installer/pkg/terraform/executor.go
+++ b/installer/pkg/terraform/executor.go
@@ -138,7 +138,6 @@ func (ex *Executor) AddEnvironmentVariables(envVars map[string]string) {
 	for k, v := range envVars {
 		ex.envVariables[k] = v
 	}
-	ex.envVariables["HOME"] = os.Getenv("HOME")
 }
 
 // AddCredentials is a convenience function that converts the given Credentials
@@ -178,6 +177,7 @@ func (ex *Executor) Execute(args ...string) (int, chan struct{}, error) {
 	// ssh changes its behavior based on these. pass them through so ssh-agent & stuff works
 	cmd.Env = append(cmd.Env, fmt.Sprintf("DISPLAY=%s", os.Getenv("DISPLAY")))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
+	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", os.Getenv("HOME")))
 	for _, v := range os.Environ() {
 		if strings.HasPrefix(v, "SSH_") {
 			cmd.Env = append(cmd.Env, v)


### PR DESCRIPTION
Once we updated Jenkins images to TF 0.10.4 we started seeing this failure.

It's caused by Terraform trying to determine the HOME folder to look for 3rd party plugins (default behaviour). Since there is no home set, it falls back to shelling out to `getent` POSIX tool which is not available.

This fixes current build step test failures similar to:
```
?   	github.com/coreos/tectonic-installer/installer/api	[no test files]
?   	github.com/coreos/tectonic-installer/installer/assets	[no test files]
?   	github.com/coreos/tectonic-installer/installer/cmd/installer	[no test files]
ok  	github.com/coreos/tectonic-installer/installer/pkg/aws	0.004s	coverage: 40.8% of statements
?   	github.com/coreos/tectonic-installer/installer/pkg/containerlinux	[no test files]
?   	github.com/coreos/tectonic-installer/installer/pkg/tectonic	[no test files]
--- FAIL: TestExecutorSimple (0.24s)
	assertions.go:225: 
                        
	Error Trace:	executor_test.go:81
		
	Error:		Expected nil, but got: &errors.errorString{s:"exit status 1"}
		
	assertions.go:225: 
                        
	Error Trace:	executor_test.go:82
		
	Error:		Not equal: "Success" (expected)
			        != "Failure" (actual)
		
	assertions.go:225: 
                        
	Error Trace:	executor_test.go:98
		
	Error:		Expected nil, but got: &errors.errorString{s:"exit status 1"}
		
	assertions.go:225: 
                        
	Error Trace:	executor_test.go:99
		
	Error:		Not equal: "Success" (expected)
			        != "Failure" (actual)
		
	assertions.go:225: 
                        
	Error Trace:	executor_test.go:102
		
	Error:		Expected value not to be nil.
		
	assertions.go:225: 
                        
	Error Trace:	executor_test.go:115
		
	Error:		Expected value not to be nil.
		
FAIL
```