### PR TITLE
RSpec AWS VPC fixture - run Terraform init

### DIFF
--- a/tests/rspec/.rubocop.yml
+++ b/tests/rspec/.rubocop.yml
@@ -1,0 +1,8 @@
+Metrics/AbcSize:
+  Enabled: false
+Metrics/LineLength:
+  Max: 120
+Metrics/ClassLength:
+  Max: 200
+Metrics/MethodLength:
+  Max: 30

--- a/tests/rspec/lib/aws_vpc.rb
+++ b/tests/rspec/lib/aws_vpc.rb
@@ -43,6 +43,8 @@ class AWSVPC
 
   def create
     Dir.chdir('../../contrib/internal-cluster') do
+      succeeded = system(env_variables, 'terraform init')
+      raise 'could not init Terraform to create VPC' unless succeeded
       succeeded = system(env_variables, 'terraform apply')
       raise 'could not create vpc with Terraform' unless succeeded
 


### PR DESCRIPTION
This fixes the fixture VPC creation using Terraform 0.10.x