### PR TITLE
Add kvo config configmap

### DIFF
--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -108,6 +108,9 @@ resource "template_dir" "bootkube" {
     master_count              = "${var.master_count}"
     node_monitor_grace_period = "${var.node_monitor_grace_period}"
     pod_eviction_timeout      = "${var.pod_eviction_timeout}"
+
+    cloud_provider_profile = "${var.cloud_provider != "" ? "${var.cloud_provider}" : "metal"}"
+    cloud_config_path      = "${var.cloud_config_path}"
   }
 }
 

--- a/modules/bootkube/resources/manifests/01-tectonic-namespace.yaml
+++ b/modules/bootkube/resources/manifests/01-tectonic-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tectonic-system # Create the namespace first.

--- a/modules/bootkube/resources/manifests/kvo-config.yaml
+++ b/modules/bootkube/resources/manifests/kvo-config.yaml
@@ -20,3 +20,5 @@ data:
       cluster_cidr: ${cluster_cidr}
       etcd_servers: ${etcd_servers}
       service_cidr: ${service_cidr}
+    inititalConfig: |
+      initial_master_count: ${master_count}

--- a/modules/bootkube/resources/manifests/kvo-config.yaml
+++ b/modules/bootkube/resources/manifests/kvo-config.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kvo-config
+  namespace: tectonic-system
+data:
+  kvo-config: |
+    apiVersion: v1
+    kind: KubeVersionOperatorConfig
+    authConfig: |
+      oidc_client_id: ${oidc_client_id}
+      oidc_issuer_url: ${oidc_issuer_url}
+      oidc_groups_claim: ${oidc_groups_claim}
+      oidc_username_claim: ${oidc_username_claim}
+    cloudProviderConfig: |
+      cloud_config_path: ${cloud_config_path}
+      cloud_provider_profile: ${cloud_provider_profile}
+    networkConfig: |
+      advertise_address: ${advertise_address}
+      cluster_cidr: ${cluster_cidr}
+      etcd_servers: ${etcd_servers}
+      service_cidr: ${service_cidr}

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -129,3 +129,8 @@ variable "pod_eviction_timeout" {
   type        = "string"
   default     = "5m"
 }
+
+variable "cloud_config_path" {
+  description = "The path to the secret file that contains the cloud config contents. Either be empty ('') or ('/etc/kubernetes/cloud/config')."
+  type        = "string"
+}

--- a/modules/tectonic/resources/manifests/namespace.yaml
+++ b/modules/tectonic/resources/manifests/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: tectonic-system

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -119,10 +119,6 @@ set -e
 # wait for Kubernetes pods
 wait_for_pods kube-system
 
-# Creating resources
-echo "Creating Tectonic Namespace"
-kubectl create -f namespace.yaml
-
 echo "Creating Initial Roles"
 kubectl delete -f rbac/role-admin.yaml
 

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -66,6 +66,8 @@ module "bootkube" {
   node_monitor_grace_period = "2m"
 
   pod_eviction_timeout = "220s"
+
+  cloud_config_path = ""
 }
 
 module "tectonic" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -37,6 +37,8 @@ module "bootkube" {
   experimental_enabled = "${var.tectonic_experimental}"
 
   master_count = "${var.tectonic_master_count}"
+
+  cloud_config_path = "/etc/kubernetes/cloud"
 }
 
 module "tectonic" {

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -43,6 +43,8 @@ module "bootkube" {
   experimental_enabled = "${var.tectonic_experimental}"
 
   master_count = "${length(var.tectonic_metal_controller_names)}"
+
+  cloud_config_path = ""
 }
 
 module "tectonic" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -44,6 +44,8 @@ module "bootkube" {
   experimental_enabled = "${var.tectonic_experimental}"
 
   master_count = "${var.tectonic_master_count}"
+
+  cloud_config_path = ""
 }
 
 module "tectonic" {

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -44,6 +44,8 @@ module "bootkube" {
   experimental_enabled = "${var.tectonic_experimental}"
 
   master_count = "${var.tectonic_master_count}"
+
+  cloud_config_path = ""
 }
 
 module "tectonic" {


### PR DESCRIPTION
Create kvo config configmap when the cluster starts.
The kvo config contains install time options, it will be consumed by kvo during upgrade.