### PR TITLE
frontend: Remove SubmitDefinition's render state that is never executed

### DIFF
--- a/installer/frontend/components/submit-definition.jsx
+++ b/installer/frontend/components/submit-definition.jsx
@@ -13,47 +13,16 @@ export const SubmitDefinition = withNav(connect(
     ready: state.cluster.ready,
   }),
   {onFinish: commitToServer}
-)(({navNext, navPrevious, phase, response, ready, onFinish}) => {
-  let feature =
-    <div className="wiz-giant-button-container">
-      <button className="btn btn-primary wiz-giant-button"
-        onClick={() => onFinish(false)}>
-        Submit
-      </button>
-    </div>;
-
-  let pager = '';
-
+)(({navPrevious, phase, response, ready, onFinish}) => {
   const inProgress = (phase === commitPhases.REQUESTED ||
                       phase === commitPhases.WAITING ||
                       phase === commitPhases.SUCCEEDED && !ready);
 
+  let btn = <button className="btn btn-primary wiz-giant-button" onClick={() => onFinish(false)}>Submit</button>;
   if (inProgress) {
-    feature =
-      <div className="wiz-giant-button-container">
-        <button className="btn btn-primary wiz-giant-button disabled">
-          <i className="fa fa-spin fa-circle-o-notch"></i>{' '}
-          Checking Your Definition...
-        </button>
-      </div>;
-  }
-
-  if (phase === commitPhases.SUCCEEDED && ready) {
-    feature = (
-      <div>
-        <div className="wiz-herotext wiz-herotext--success">
-          <span className="fa fa-check-circle wiz-herotext-icon"></span> {' '}
-          High Fives! <br /> Your matchbox server was configured successfully!
-        </div>
-      </div>
-    );
-    pager = (
-      <div className="wiz-form__actions">
-        <button className="btn btn-primary wiz-form__actions__next" onClick={navNext}>
-          Next Step
-        </button>
-      </div>
-    );
+    btn = <button className="btn btn-primary wiz-giant-button disabled">
+      <i className="fa fa-spin fa-circle-o-notch"></i> Checking Your Definition...
+    </button>;
   }
 
   const errorMessage = response ? response.toString() : '';
@@ -61,13 +30,10 @@ export const SubmitDefinition = withNav(connect(
     hidden: phase !== commitPhases.FAILED,
   });
 
-  const msg = <span>Congratulations! Your cluster has been defined and will be submitted to Terraform.</span>;
-
   return (
     <div>
       <p>
-        {msg}
-        <span> After submission, the definition cannot be updated. Go <a onClick={!inProgress && navPrevious} className={inProgress && 'disabled'}>back</a> to update or make changes.</span>
+        Congratulations! Your cluster has been defined and will be submitted to Terraform. After submission, the definition cannot be updated. Go <a onClick={!inProgress && navPrevious} className={inProgress && 'disabled'}>back</a> to update or make changes.
       </p>
       <p>
         {/* eslint-disable react/jsx-no-target-blank */}
@@ -75,18 +41,16 @@ export const SubmitDefinition = withNav(connect(
         {/* eslint-enable react/jsx-no-target-blank */}
       </p>
       <br />
-      {feature}
+      <div className="wiz-giant-button-container">
+        {btn}
+      </div>
       <p>
         <b>Advanced mode: </b>
-        <a onClick={() => onFinish(true)} href="#">Manually boot</a> your own cluster. Validate configuration, generate assets, but don't create the cluster.
+        <a onClick={() => onFinish(true)}>Manually boot</a> your own cluster. Validate configuration, generate assets, but don't create the cluster.
       </p>
       <div className={errorClasses}>
         {errorMessage}
       </div>
-      {pager}
     </div>
   );
 }));
-SubmitDefinition.canNavigateForward = ({cluster}) => {
-  return cluster.ready;
-};


### PR DESCRIPTION
After the cluster definition is successfully submitted to the server,
the wizard will always redirect to the Start Installation page, so this
render logic is never used.