### PR TITLE
frontend: Remove gap between <textarea>s and their validation errors

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -67,6 +67,7 @@ label {
 }
 
 textarea {
+  display: block;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   min-height: 60px;
 }


### PR DESCRIPTION
For all `textarea` fields.

Before | After
--- | ---
<img width="809" alt="screenshot-4" src="https://user-images.githubusercontent.com/460802/30413456-0cac6128-9959-11e7-8aae-61e24034bd29.png"> | <img width="810" alt="screenshot-3" src="https://user-images.githubusercontent.com/460802/30413425-ef6118ac-9958-11e7-9eb5-592fc032810a.png">
