### PR TITLE
Bump monitoring

### DIFF
--- a/Documentation/variables/config.md
+++ b/Documentation/variables/config.md
@@ -17,6 +17,7 @@ This document gives an overview of variables used in all platforms of the Tecton
 | tectonic_cluster_cidr | This declares the IP range to assign Kubernetes pod IPs in CIDR notation. | string | `10.2.0.0/16` |
 | tectonic_cluster_name | The name of the cluster. If used in a cloud-environment, this will be prepended to `tectonic_base_domain` resulting in the URL to the Tectonic console.<br><br>Note: This field MUST be set manually prior to creating the cluster. Warning: Special characters in the name like '.' may cause errors on OpenStack platforms due to resource name constraints. | string | - |
 | tectonic_config_version | (internal) This declares the version of the global configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
+| tectonic_container_base_images | (internal) Base images of the components to use | map | `<map>` |
 | tectonic_container_images | (internal) Container images to use | map | `<map>` |
 | tectonic_ddns_key_algorithm | (optional) This only applies if you use the modules/dns/ddns module.<br><br>Specifies the RFC2136 Dynamic DNS server key algorithm. | string | `` |
 | tectonic_ddns_key_name | (optional) This only applies if you use the modules/dns/ddns module.<br><br>Specifies the RFC2136 Dynamic DNS server key name. | string | `` |

--- a/config.tf
+++ b/config.tf
@@ -88,7 +88,7 @@ variable "tectonic_container_images" {
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.5.3"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
     tectonic_monitoring_auth     = "quay.io/coreos/tectonic-monitoring-auth:v0.0.1"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.5.2"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.6.0"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.1.3"
   }
 }
@@ -101,7 +101,7 @@ variable "tectonic_versions" {
     alertmanager  = "v0.8.0"
     etcd          = "3.1.8"
     kubernetes    = "1.7.3+tectonic.1"
-    monitoring    = "1.5.2"
+    monitoring    = "1.6.0"
     prometheus    = "v1.7.1"
     tectonic      = "1.7.3-tectonic.2"
     tectonic-etcd = "0.0.1"

--- a/config.tf
+++ b/config.tf
@@ -94,6 +94,8 @@ variable "tectonic_container_base_images" {
     config_reload            = "quay.io/coreos/configmap-reload"
     addon_resizer            = "quay.io/coreos/addon-resizer"
     kube_state_metrics       = "quay.io/coreos/kube-state-metrics"
+    grafana                  = "quay.io/coreos/grafana-monitoring"
+    grafana_watcher          = "quay.io/coreos/grafana-watcher"
     prometheus_operator      = "quay.io/coreos/prometheus-operator"
     prometheus_config_reload = "quay.io/coreos/prometheus-config-reloader"
     prometheus               = "quay.io/prometheus/prometheus"

--- a/config.tf
+++ b/config.tf
@@ -54,12 +54,10 @@ variable "tectonic_container_images" {
 
   default = {
     addon_resizer                = "gcr.io/google_containers/addon-resizer:2.1"
-    alertmanager                 = "quay.io/prometheus/alertmanager:v0.8.0"
     awscli                       = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
     bootkube                     = "quay.io/coreos/bootkube:v0.6.2"
     calico                       = "quay.io/calico/node:v2.4.1"
     calico_cni                   = "quay.io/calico/cni:v1.10.0"
-    config_reload                = "quay.io/coreos/configmap-reload:v0.0.1"
     console                      = "quay.io/coreos/tectonic-console:v1.9.3"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
@@ -74,22 +72,33 @@ variable "tectonic_container_images" {
     kubedns                      = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4"
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4"
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4"
-    kube_state_metrics           = "quay.io/coreos/kube-state-metrics:v1.0.0"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
     kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.3-kvo.3"
     node_agent                   = "quay.io/coreos/node-agent:v1.7.3-kvo.3"
-    node_exporter                = "quay.io/prometheus/node-exporter:v0.14.0"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:3517908b1a1837e78cfd041a0e51e61c7835d85f"
-    prometheus                   = "quay.io/prometheus/prometheus:v1.7.1"
-    prometheus_config_reload     = "quay.io/coreos/prometheus-config-reloader:v0.0.2"
-    prometheus_operator          = "quay.io/coreos/prometheus-operator:v0.11.1"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.5.3"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
-    tectonic_monitoring_auth     = "quay.io/coreos/tectonic-monitoring-auth:v0.0.1"
     tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.6.0"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.1.3"
+  }
+}
+
+variable "tectonic_container_base_images" {
+  description = "(internal) Base images of the components to use"
+  type        = "map"
+
+  default = {
+    tectonic_monitoring_auth = "quay.io/coreos/tectonic-monitoring-auth"
+    config_reload            = "quay.io/coreos/configmap-reload"
+    addon_resizer            = "quay.io/coreos/addon-resizer"
+    kube_state_metrics       = "quay.io/coreos/kube-state-metrics"
+    prometheus_operator      = "quay.io/coreos/prometheus-operator"
+    prometheus_config_reload = "quay.io/coreos/prometheus-config-reloader"
+    prometheus               = "quay.io/prometheus/prometheus"
+    alertmanager             = "quay.io/prometheus/alertmanager"
+    node_exporter            = "quay.io/prometheus/node-exporter"
   }
 }
 
@@ -98,11 +107,9 @@ variable "tectonic_versions" {
   type        = "map"
 
   default = {
-    alertmanager  = "v0.8.0"
     etcd          = "3.1.8"
     kubernetes    = "1.7.3+tectonic.1"
     monitoring    = "1.6.0"
-    prometheus    = "v1.7.1"
     tectonic      = "1.7.3-tectonic.2"
     tectonic-etcd = "0.0.1"
     cluo          = "0.1.3"

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -34,6 +34,8 @@ resource "template_dir" "tectonic" {
     prometheus_base_image               = "${var.container_base_images["prometheus"]}"
     alertmanager_base_image             = "${var.container_base_images["alertmanager"]}"
     node_exporter_base_image            = "${var.container_base_images["node_exporter"]}"
+    grafana_base_image                  = "${var.container_base_images["grafana"]}"
+    grafana_watcher_base_image          = "${var.container_base_images["grafana_watcher"]}"
 
     kubernetes_version             = "${var.versions["kubernetes"]}"
     monitoring_version             = "${var.versions["monitoring"]}"
@@ -64,8 +66,9 @@ resource "template_dir" "tectonic" {
 
     tectonic_monitoring_auth_cookie_secret = "${base64encode(random_id.tectonic_monitoring_auth_cookie_secret.b64)}"
 
-    alertmanager_callback     = "https://${var.base_address}/alertmanager/auth/callback"
-    prometheus_callback       = "https://${var.base_address}/prometheus/auth/callback"
+    alertmanager_callback = "https://${var.base_address}/alertmanager/auth/callback"
+    prometheus_callback   = "https://${var.base_address}/prometheus/auth/callback"
+    grafana_callback      = "https://${var.base_address}/grafana/auth/callback"
 
     ingress_kind     = "${var.ingress_kind}"
     ingress_ca_cert  = "${base64encode(var.ingress_ca_cert_pem)}"

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -10,7 +10,6 @@ resource "template_dir" "tectonic" {
 
   vars {
     addon_resizer_image                = "${var.container_images["addon_resizer"]}"
-    config_reload_image                = "${var.container_images["config_reload"]}"
     console_image                      = "${var.container_images["console"]}"
     error_server_image                 = "${var.container_images["error_server"]}"
     heapster_image                     = "${var.container_images["heapster"]}"
@@ -18,14 +17,7 @@ resource "template_dir" "tectonic" {
     ingress_controller_image           = "${var.container_images["ingress_controller"]}"
     kube_version_operator_image        = "${var.container_images["kube_version_operator"]}"
     node_agent_image                   = "${var.container_images["node_agent"]}"
-    node_exporter_image                = "${var.container_images["node_exporter"]}"
-    kube_state_metrics_image           = "${var.container_images["kube_state_metrics"]}"
-    prometheus_operator_image          = "${var.container_images["prometheus_operator"]}"
     etcd_operator_image                = "${var.container_images["etcd_operator"]}"
-    tectonic_monitoring_auth_image     = "${var.container_images["tectonic_monitoring_auth"]}"
-    prometheus_image                   = "${var.container_images["prometheus"]}"
-    prometheus_config_reload_image     = "${var.container_images["prometheus_config_reload"]}"
-    alertmanager_image                 = "${var.container_images["alertmanager"]}"
     stats_emitter_image                = "${var.container_images["stats_emitter"]}"
     stats_extender_image               = "${var.container_images["stats_extender"]}"
     tectonic_channel_operator_image    = "${var.container_images["tectonic_channel_operator"]}"
@@ -33,10 +25,18 @@ resource "template_dir" "tectonic" {
     tectonic_etcd_operator_image       = "${var.container_images["tectonic_etcd_operator"]}"
     tectonic_cluo_operator_image       = "${var.container_images["tectonic_cluo_operator"]}"
 
+    tectonic_monitoring_auth_base_image = "${var.container_base_images["tectonic_monitoring_auth"]}"
+    config_reload_base_image            = "${var.container_base_images["config_reload"]}"
+    addon_resizer_base_image            = "${var.container_base_images["addon_resizer"]}"
+    kube_state_metrics_base_image       = "${var.container_base_images["kube_state_metrics"]}"
+    prometheus_operator_base_image      = "${var.container_base_images["prometheus_operator"]}"
+    prometheus_config_reload_base_image = "${var.container_base_images["prometheus_config_reload"]}"
+    prometheus_base_image               = "${var.container_base_images["prometheus"]}"
+    alertmanager_base_image             = "${var.container_base_images["alertmanager"]}"
+    node_exporter_base_image            = "${var.container_base_images["node_exporter"]}"
+
     kubernetes_version             = "${var.versions["kubernetes"]}"
     monitoring_version             = "${var.versions["monitoring"]}"
-    prometheus_version             = "${var.versions["prometheus"]}"
-    alertmanager_version           = "${var.versions["alertmanager"]}"
     tectonic_version               = "${var.versions["tectonic"]}"
     etcd_version                   = "${var.versions["etcd"]}"
     tectonic_etcd_operator_version = "${var.versions["tectonic-etcd"]}"
@@ -64,9 +64,7 @@ resource "template_dir" "tectonic" {
 
     tectonic_monitoring_auth_cookie_secret = "${base64encode(random_id.tectonic_monitoring_auth_cookie_secret.b64)}"
 
-    alertmanager_external_url = "https://${var.base_address}/alertmanager"
     alertmanager_callback     = "https://${var.base_address}/alertmanager/auth/callback"
-    prometheus_external_url   = "https://${var.base_address}/prometheus"
     prometheus_callback       = "https://${var.base_address}/prometheus/auth/callback"
 
     ingress_kind     = "${var.ingress_kind}"

--- a/modules/tectonic/resources/manifests/identity/configmap.yaml
+++ b/modules/tectonic/resources/manifests/identity/configmap.yaml
@@ -33,6 +33,7 @@ data:
       - '${console_callback}'
       - '${prometheus_callback}'
       - '${alertmanager_callback}'
+      - '${grafana_callback}'
       name: 'Tectonic Console'
       secret: ${console_secret}
     - id: ${kubectl_client_id}

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -6,12 +6,19 @@ metadata:
 data:
   config.yaml: |+
     prometheusOperator:
-      baseImage: ${replace(prometheus_operator_image,image_re,"$1")}
-      prometheusConfigReloaderBaseImage: ${replace(prometheus_config_reload_image,image_re,"$1")}
-      configReloaderBaseImage: ${replace(config_reload_image,image_re,"$1")}
+      baseImage: ${prometheus_operator_base_image}
+      prometheusConfigReloaderBaseImage: ${prometheus_config_reload_base_image}
+      configReloaderBaseImage: ${config_reload_base_image}
     prometheusK8s:
-      baseImage: ${replace(prometheus_image,image_re,"$1")}
+      baseImage: ${prometheus_base_image}
     alertmanagerMain:
-      baseImage: ${replace(alertmanager_image,image_re,"$1")}
+      baseImage: ${alertmanager_base_image}
     ingress:
       baseAddress: ${console_base_host}
+    auth:
+      baseImage: ${tectonic_monitoring_auth_base_image}
+    nodeExporter:
+      baseImage: ${node_exporter_base_image}
+    kubeStateMetrics:
+      baseImage: ${kube_state_metrics_base_image}
+      addonResizerBaseImage: ${addon_resizer_base_image}

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -7,6 +7,11 @@ variable "container_images" {
   type        = "map"
 }
 
+variable "container_base_images" {
+  description = "Container base images to use. Leave blank for defaults."
+  type        = "map"
+}
+
 variable "versions" {
   description = "Versions of the components to use. Leave blank for defaults."
   type        = "map"

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -282,7 +282,7 @@
                   "-logtostderr=true",
                   "-v=4"
                 ],
-                "image": "quay.io/coreos/tectonic-prometheus-operator:v1.5.2",
+                "image": "quay.io/coreos/tectonic-prometheus-operator:v1.6.0",
                 "name": "tectonic-prometheus-operator",
                 "resources": {
                   "limits": {
@@ -354,7 +354,7 @@
         "name": "tectonic-monitoring",
         "namespace": "tectonic-system"
       },
-      "version": "1.5.2"
+      "version": "1.6.0"
     }
   ]
 }

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -121,8 +121,9 @@ module "tectonic" {
   kube_apiserver_url = "https://${var.tectonic_aws_private_endpoints ? module.masters.api_internal_fqdn : module.masters.api_external_fqdn}:443"
 
   # Platform-independent variables wiring, do not modify.
-  container_images = "${var.tectonic_container_images}"
-  versions         = "${var.tectonic_versions}"
+  container_images      = "${var.tectonic_container_images}"
+  container_base_images = "${var.tectonic_container_base_images}"
+  versions              = "${var.tectonic_versions}"
 
   license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
   pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -94,8 +94,9 @@ module "tectonic" {
   kube_apiserver_url = "https://${module.vnet.api_fqdn}:443"
 
   # Platform-independent variables wiring, do not modify.
-  container_images = "${var.tectonic_container_images}"
-  versions         = "${var.tectonic_versions}"
+  container_images      = "${var.tectonic_container_images}"
+  container_base_images = "${var.tectonic_container_base_images}"
+  versions              = "${var.tectonic_versions}"
 
   license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
   pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -99,8 +99,9 @@ module "tectonic" {
   kube_apiserver_url = "https://${var.tectonic_metal_controller_domain}:443"
 
   # Address of the Tectonic console (without protocol)
-  container_images = "${var.tectonic_container_images}"
-  versions         = "${var.tectonic_versions}"
+  container_images      = "${var.tectonic_container_images}"
+  container_base_images = "${var.tectonic_container_base_images}"
+  versions              = "${var.tectonic_versions}"
 
   license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
   pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -106,8 +106,9 @@ module "tectonic" {
   kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
 
   # Platform-independent variables wiring, do not modify.
-  container_images = "${var.tectonic_container_images}"
-  versions         = "${var.tectonic_versions}"
+  container_images      = "${var.tectonic_container_images}"
+  container_base_images = "${var.tectonic_container_base_images}"
+  versions              = "${var.tectonic_versions}"
 
   license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
   pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -97,8 +97,9 @@ module "tectonic" {
   kube_apiserver_url = "https://${var.tectonic_vmware_controller_domain}:443"
 
   # Platform-independent variables wiring, do not modify.
-  container_images = "${var.tectonic_container_images}"
-  versions         = "${var.tectonic_versions}"
+  container_images      = "${var.tectonic_container_images}"
+  container_base_images = "${var.tectonic_container_base_images}"
+  versions              = "${var.tectonic_versions}"
 
   license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
   pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"


### PR DESCRIPTION
What this PR does:

- bump TPO/AppVersion to latest `v1.6.0`
- remove residue of the recent removal of the monitoring manifests, that are now fully mananged by the TPO, and instead of maintaining a list of container images including versions, now only base images are maintained
- add Grafana OIDC callback for Dex (respective PR for the KVO https://github.com/coreos-inc/kube-version-operator/pull/260)

I already tested bringing up a fresh cluster with this and will now also test the upgrade from the september (`1.7.3-tectonic.2`) release.

@s-urbaniak @alexsomesan 