### PR TITLE
tests/frontend: Add more Nightwatch tests for bare metal

### DIFF
--- a/installer/frontend/ui-tests/commands/expectValidationErrorContains.js
+++ b/installer/frontend/ui-tests/commands/expectValidationErrorContains.js
@@ -1,4 +1,10 @@
+const wizard = require('../utils/wizard');
+
 exports.command = function(text) {
   this.expect.element('.wiz-error-message:not(.hidden)').text.contains(text);
+
+  // Wizard next button should be disabled when there is a validation error
+  this.expect.element(wizard.nextStep).to.have.attribute('class').which.contains('disabled');
+
   return this;
 };

--- a/installer/frontend/ui-tests/pages/certificateAuthorityPage.js
+++ b/installer/frontend/ui-tests/pages/certificateAuthorityPage.js
@@ -1,3 +1,25 @@
+const pageCommands = {
+  test() {
+    this.expect.element('@optionGenerate').to.be.selected;
+    this.expect.element('@cert').to.not.be.present;
+    this.expect.element('@key').to.not.be.present;
+
+    this.selectOption('@optionUseOwn');
+    this.expect.element('@cert').to.be.visible;
+    this.expect.element('@key').to.be.visible;
+
+    this.selectOption('@optionGenerate');
+    this.expect.element('@cert').to.not.be.present;
+    this.expect.element('@key').to.not.be.present;
+  },
+};
+
 module.exports = {
-  elements: {},
+  commands: [pageCommands],
+  elements: {
+    cert: 'textarea#caCertificate',
+    key: 'textarea#caPrivateKey',
+    optionGenerate: '.wiz-radio-group:nth-child(1) input[type=radio]',
+    optionUseOwn: '.wiz-radio-group:nth-child(2) input[type=radio]',
+  },
 };

--- a/installer/frontend/ui-tests/pages/clusterDnsPage.js
+++ b/installer/frontend/ui-tests/pages/clusterDnsPage.js
@@ -1,13 +1,23 @@
-const clusterDnsPageCommands = {
+const pageCommands = {
   test(json) {
     this
+      .setField('@controllerDomain', '%')
+      .expectValidationErrorContains('Invalid domain name')
+      .setField('@controllerDomain', '')
+      .expectValidationErrorContains('This field is required')
       .setField('@controllerDomain', json.tectonic_metal_controller_domain)
-      .setField('@tectonicDomain', json.tectonic_metal_ingress_domain);
+      .expectNoValidationError()
+      .setField('@tectonicDomain', '%')
+      .expectValidationErrorContains('Invalid domain name')
+      .setField('@tectonicDomain', '')
+      .expectValidationErrorContains('This field is required')
+      .setField('@tectonicDomain', json.tectonic_metal_ingress_domain)
+      .expectNoValidationError();
   },
 };
 
 module.exports = {
-  commands: [clusterDnsPageCommands],
+  commands: [pageCommands],
   elements: {
     controllerDomain: 'input#controllerDomain',
     tectonicDomain: 'input#tectonicDomain',

--- a/installer/frontend/ui-tests/pages/defineMastersPage.js
+++ b/installer/frontend/ui-tests/pages/defineMastersPage.js
@@ -1,15 +1,42 @@
-const defineMastersPageCommands = {
+const pageCommands = {
   test(json) {
+    this.click('@deleteIcon0');
+    this.expect.element('@alertError').text.to.contain('At least 1 Master is required');
+
     this
-      .setField('@masters0', json.tectonic_metal_controller_macs[0])
-      .setField('@hosts0', json.tectonic_metal_controller_domains[0]);
+      .click('@addMore')
+      .setField('@mac0', 'abc')
+      .expectValidationErrorContains('Invalid MAC address')
+      .setField('@mac0', json.tectonic_metal_controller_macs[0])
+      .setField('@hosts0', '%')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@hosts0', json.tectonic_metal_controller_domains[0])
+      .expectNoValidationError()
+      .click('@addMore')
+      .setField('@mac1', json.tectonic_metal_controller_macs[0])
+      .expectValidationErrorContains('MACs must be unique')
+      .click('@deleteIcon1')
+      .click('@addMore')
+      .setField('@hosts1', json.tectonic_metal_controller_domains[0])
+      .expectValidationErrorContains('Hostnames must be unique')
+      .click('@deleteIcon1')
+      .expectNoValidationError();
   },
 };
 
 module.exports = {
-  commands: [defineMastersPageCommands],
+  commands: [pageCommands],
   elements: {
-    masters0: 'input[id="masters.0.mac"]',
+    mac0: 'input[id="masters.0.mac"]',
     hosts0: 'input[id="masters.0.host"]',
+    deleteIcon0: '.row:nth-child(1) i.fa-minus-circle',
+    mac1: 'input[id="masters.1.mac"]',
+    hosts1: 'input[id="masters.1.host"]',
+    deleteIcon1: '.row:nth-child(2) i.fa-minus-circle',
+    addMore: {
+      selector: '//*[text()[contains(.,"Add More")]]',
+      locateStrategy: 'xpath',
+    },
+    alertError: '.alert-error',
   },
 };

--- a/installer/frontend/ui-tests/pages/defineWorkersPage.js
+++ b/installer/frontend/ui-tests/pages/defineWorkersPage.js
@@ -1,24 +1,40 @@
-const defineWorkersPageCommands = {
+const pageCommands = {
   test(json) {
+    this.click('@deleteIcon0');
+    this.expect.element('@alertError').text.to.contain('At least 1 Worker is required');
+
     this
-      .setField('@workers0', json.tectonic_metal_worker_macs[0])
-      .setField('@hosts0', json.tectonic_metal_worker_domains[0])
       .click('@addMore')
-      .setField('@workers1', json.tectonic_metal_worker_macs[1])
-      .setField('@hosts1', json.tectonic_metal_worker_domains[1]);
+      .setField('@mac0', 'abc')
+      .expectValidationErrorContains('Invalid MAC address')
+      .setField('@mac0', json.tectonic_metal_worker_macs[0])
+      .setField('@hosts0', '%')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@hosts0', json.tectonic_metal_worker_domains[0])
+      .expectNoValidationError()
+      .click('@addMore')
+      .setField('@mac1', json.tectonic_metal_worker_macs[0])
+      .expectValidationErrorContains('MACs must be unique')
+      .setField('@mac1', json.tectonic_metal_worker_macs[1])
+      .setField('@hosts1', json.tectonic_metal_worker_domains[0])
+      .expectValidationErrorContains('Hostnames must be unique')
+      .setField('@hosts1', json.tectonic_metal_worker_domains[1])
+      .expectNoValidationError();
   },
 };
 
 module.exports = {
-  commands: [defineWorkersPageCommands],
+  commands: [pageCommands],
   elements: {
-    workers0: 'input[id="workers.0.mac"]',
+    mac0: 'input[id="workers.0.mac"]',
     hosts0: 'input[id="workers.0.host"]',
-    workers1: 'input[id="workers.1.mac"]',
+    deleteIcon0: '.row:nth-child(1) i.fa-minus-circle',
+    mac1: 'input[id="workers.1.mac"]',
     hosts1: 'input[id="workers.1.host"]',
     addMore: {
       selector: '//*[text()[contains(.,"Add More")]]',
       locateStrategy: 'xpath',
     },
+    alertError: '.alert-error',
   },
 };

--- a/installer/frontend/ui-tests/pages/etcdConnectionPage.js
+++ b/installer/frontend/ui-tests/pages/etcdConnectionPage.js
@@ -1,3 +1,29 @@
+const pageCommands = {
+  test() {
+    this.expect.element('@optionProvisioned').to.be.selected;
+    this.expect.element('@address').to.not.be.present;
+
+    this.selectOption('@optionSelfHosted');
+    this.expect.element('@address').to.not.be.present;
+
+    this
+      .selectOption('@optionExternal')
+      .setField('@address', 'abc')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@address', 'example.com:1234')
+      .expectNoValidationError();
+
+    this.selectOption('@optionProvisioned');
+    this.expect.element('@address').to.not.be.present;
+  },
+};
+
 module.exports = {
-  elements: {},
+  commands: [pageCommands],
+  elements: {
+    address: 'input[type=text]#externalETCDClient',
+    optionProvisioned: 'input[type=radio]#provisioned',
+    optionSelfHosted: 'input[type=radio]#selfHosted',
+    optionExternal: 'input[type=radio]#external',
+  },
 };

--- a/installer/frontend/ui-tests/pages/matchboxAddressPage.js
+++ b/installer/frontend/ui-tests/pages/matchboxAddressPage.js
@@ -1,13 +1,19 @@
-const matchboxPageCommands = {
+const pageCommands = {
   test(json) {
     this
+      .setField('@matchboxHTTP', 'abc')
+      .expectValidationErrorContains('Invalid format')
       .setField('@matchboxHTTP', json.tectonic_metal_matchbox_http_url.replace(/^https?:\/\//i, ''))
-      .setField('@matchboxRPC', json.tectonic_metal_matchbox_rpc_endpoint);
+      .expectNoValidationError()
+      .setField('@matchboxRPC', 'abc')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@matchboxRPC', json.tectonic_metal_matchbox_rpc_endpoint)
+      .expectNoValidationError();
   },
 };
 
 module.exports = {
-  commands: [matchboxPageCommands],
+  commands: [pageCommands],
   elements: {
     matchboxHTTP: 'input#matchboxHTTP',
     matchboxRPC: 'input#matchboxRPC',

--- a/installer/frontend/ui-tests/pages/matchboxCredentialsPage.js
+++ b/installer/frontend/ui-tests/pages/matchboxCredentialsPage.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const matchBoxCredentialsPageCommands = {
+const pageCommands = {
   test(json) {
     const parentDir = path.resolve(__dirname, '..');
     const caCertPath = path.join(parentDir, 'ca-cert.txt');
@@ -13,22 +13,31 @@ const matchBoxCredentialsPageCommands = {
     fs.writeFileSync(clientCertPath, json.tectonic_metal_matchbox_client_cert);
     fs.writeFileSync(clientKeyPath, json.tectonic_metal_matchbox_client_key);
     /* eslint-enable no-sync */
+
     this
-      .setValue('@caCertificate', caCertPath)
-      .setValue('@clientCertificate', clientCertPath)
-      .setValue('@clientKey', clientKeyPath);
+      .setValue('@caCert', clientKeyPath)
+      .expectValidationErrorContains('Invalid certificate')
+      .setValue('@caCert', caCertPath)
+      .expectNoValidationError()
+      .setValue('@clientCert', clientKeyPath)
+      .expectValidationErrorContains('Invalid certificate')
+      .setValue('@clientCert', clientCertPath)
+      .expectNoValidationError()
+      .setValue('@clientKey', caCertPath)
+      .expectValidationErrorContains('Invalid private key')
+      .setValue('@clientKey', clientKeyPath)
+      .expectNoValidationError();
   },
 };
 
 module.exports = {
-  commands: [matchBoxCredentialsPageCommands],
+  commands: [pageCommands],
   elements: {
-    name: 'input#clusterName',
-    caCertificate: {
+    caCert: {
       selector: '(//*[text()="Upload"]/input[@type="file"])[1]',
       locateStrategy: 'xpath',
     },
-    clientCertificate: {
+    clientCert: {
       selector: '(//*[text()="Upload"]/input[@type="file"])[2]',
       locateStrategy: 'xpath',
     },

--- a/installer/frontend/ui-tests/pages/networkConfigurationPage.js
+++ b/installer/frontend/ui-tests/pages/networkConfigurationPage.js
@@ -1,12 +1,33 @@
-const networkConfigurationPageCommands = {
-  enterCIDRs(json) {
-    this
-      .setField('#podCIDR', json.tectonic_cluster_cidr)
-      .setField('#serviceCIDR', json.tectonic_service_cidr);
+const pageCommands = {
+  test(json) {
+    this.setField('#serviceCIDR', json.tectonic_service_cidr);
+
+    this.setField('#podCIDR', '10.2.0.0/21');
+    this.expectNoValidationError();
+    this.expect.element('@alertError').to.not.be.present;
+    this.expect.element('@alertWarning').to.not.be.present;
+
+    this.setField('#podCIDR', '10.2.0.0/22');
+    this.expectNoValidationError();
+    this.expect.element('@alertError').to.not.be.present;
+    this.expect.element('@alertWarning').text.to.contain('Pod Range Mostly Assigned');
+
+    this.setField('#podCIDR', '10.2.0.0/23');
+    this.expectNoValidationError();
+    this.expect.element('@alertError').text.to.contain('Pod Range Too Small');
+    this.expect.element('@alertWarning').to.not.be.present;
+
+    this.setField('#podCIDR', json.tectonic_cluster_cidr);
+    this.expectNoValidationError();
+    this.expect.element('@alertError').to.not.be.present;
+    this.expect.element('@alertWarning').to.not.be.present;
   },
 };
 
 module.exports = {
-  commands: [networkConfigurationPageCommands],
-  elements: {},
+  commands: [pageCommands],
+  elements: {
+    alertWarning: '.alert-info',
+    alertError: '.alert-error',
+  },
 };

--- a/installer/frontend/ui-tests/pages/networkingPage.js
+++ b/installer/frontend/ui-tests/pages/networkingPage.js
@@ -1,4 +1,4 @@
-const networkingPageCommands = {
+const pageCommands = {
   testCidrInputs(json) {
     this.setField('#serviceCIDR', json.tectonic_service_cidr);
 
@@ -55,13 +55,11 @@ const networkingPageCommands = {
     this.testCidrInputs(json);
 
     this.selectOption('@vpcOptionNewPublic');
-
-    return this;
   },
 };
 
 module.exports = {
-  commands: [networkingPageCommands],
+  commands: [pageCommands],
   elements: {
     advanced: {
       selector: '//*[text()[contains(.,"Advanced Settings")]]',

--- a/installer/frontend/ui-tests/pages/sshKeysPage.js
+++ b/installer/frontend/ui-tests/pages/sshKeysPage.js
@@ -1,22 +1,27 @@
 const fs = require('fs');
 const path = require('path');
 
-const sshKeysPageCommands = {
+const pageCommands = {
   test(json) {
     const parentDir = path.resolve(__dirname, '..');
-    const sshKeysPath = path.join(parentDir, 'ssh-keys.txt');
+    const sshKeyPath = path.join(parentDir, 'ssh-keys.txt');
 
     /* eslint-disable no-sync */
-    fs.writeFileSync(sshKeysPath, json.tectonic_ssh_authorized_key);
+    fs.writeFileSync(sshKeyPath, json.tectonic_ssh_authorized_key);
 
-    this.setValue('@publicKey', sshKeysPath);
+    this
+      .setField('@key', 'abc')
+      .expectValidationErrorContains('Invalid SSH pubkey')
+      .setValue('@upload', sshKeyPath)
+      .expectNoValidationError();
   },
 };
 
 module.exports = {
-  commands: [sshKeysPageCommands],
+  commands: [pageCommands],
   elements: {
-    publicKey: {
+    key: 'textarea#sshAuthorizedKey',
+    upload: {
       selector: '(//*[text()="Upload"]/input[@type="file"])',
       locateStrategy: 'xpath',
     },

--- a/installer/frontend/ui-tests/utils/wizard.js
+++ b/installer/frontend/ui-tests/utils/wizard.js
@@ -30,9 +30,8 @@ const testPage = (page, platform, json, nextInitiallyDisabled = true) => {
   // Save progress link exists
   page.expect.element('.wiz-form__header a').text.which.contains('Save progress');
 
-  if (page.test) {
-    page.test(json, platform);
-  }
+  page.test(json, platform);
+
   page.expect.element(nextStep).to.have.attribute('class').which.not.contains('disabled');
   return page.click(nextStep);
 };


### PR DESCRIPTION
Bare metal tests now run at least some basic tests for every screen. (Edit: Except for the Starting Installation and Installation Complete screens, which currently have no Nightwatch tests.)