### PR TITLE
platforms/openstack/neutron: Add flag to disable worker floating IPs

### DIFF
--- a/Documentation/variables/openstack-neutron.md
+++ b/Documentation/variables/openstack-neutron.md
@@ -6,6 +6,7 @@ This document gives an overview of variables used in the Openstack/Neutron platf
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
+| tectonic_openstack_disable_floatingip | Disable floating ip assignments for k8s nodes. Warning: Enabling this option removes direct internet access, which prevents NodePorts from working. | string | `false` |
 | tectonic_openstack_dns_nameservers | The nameservers used by the nodes and the generated OpenStack subnet resource.<br><br>Example: `["8.8.8.8", "8.8.4.4"]` | list | `<list>` |
 | tectonic_openstack_etcd_flavor_id | (optional) The flavor id for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.<br><br>Note: Set either tectonic_openstack_etcd_flavor_name or tectonic_openstack_etcd_flavor_id. Note: This value is ignored for self-hosted etcd. | string | `` |
 | tectonic_openstack_etcd_flavor_name | (optional) The flavor name for etcd instances as given in `openstack flavor list`. Specifies the size (CPU/Memory/Drive) of the VM.<br><br>Note: Set either tectonic_openstack_etcd_flavor_name or tectonic_openstack_etcd_flavor_id. Note: This value is ignored for self-hosted etcd. | string | `` |

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -129,6 +129,11 @@ tectonic_license_path = ""
 // This applies only to cloud platforms.
 tectonic_master_count = "1"
 
+// Disable floating ip assignments for k8s nodes.
+// Warning: Enabling this option removes direct internet access,
+// which prevents NodePorts from working.
+tectonic_openstack_disable_floatingip = false
+
 // The nameservers used by the nodes and the generated OpenStack subnet resource.
 // 
 // Example: `["8.8.8.8", "8.8.4.4"]`

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -271,7 +271,7 @@ module "dns" {
   worker_count              = "${var.tectonic_worker_count}"
   worker_ips                = "${openstack_networking_port_v2.worker.*.all_fixed_ips}"
   worker_public_ips         = "${openstack_networking_floatingip_v2.worker.*.address}"
-  worker_public_ips_enabled = true
+  worker_public_ips_enabled = "${var.tectonic_openstack_disable_floatingip ? false : true}"
 
   tectonic_experimental = "${var.tectonic_experimental}"
   tectonic_vanilla_k8s  = "${var.tectonic_vanilla_k8s}"

--- a/platforms/openstack/neutron/network.tf
+++ b/platforms/openstack/neutron/network.tf
@@ -87,7 +87,7 @@ resource "openstack_networking_port_v2" "worker" {
 }
 
 resource "openstack_networking_floatingip_v2" "worker" {
-  count = "${var.tectonic_worker_count}"
+  count = "${var.tectonic_openstack_disable_floatingip ? 0 : var.tectonic_worker_count}"
   pool  = "${var.tectonic_openstack_floatingip_pool}"
 }
 

--- a/platforms/openstack/neutron/nodes.tf
+++ b/platforms/openstack/neutron/nodes.tf
@@ -106,7 +106,7 @@ resource "openstack_compute_instance_v2" "worker_node" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "worker" {
-  count = "${var.tectonic_worker_count}"
+  count = "${var.tectonic_openstack_disable_floatingip ? 0 : var.tectonic_worker_count}"
 
   floating_ip = "${openstack_networking_floatingip_v2.worker.*.address[count.index]}"
   instance_id = "${openstack_compute_instance_v2.worker_node.*.id[count.index]}"

--- a/platforms/openstack/neutron/variables.tf
+++ b/platforms/openstack/neutron/variables.tf
@@ -151,3 +151,13 @@ Please look at the OpenStack documentation for more details:
 https://developer.openstack.org/api-ref/networking/v2/index.html?expanded=create-a-load-balancer-detail#lbaas-2-0-stable
 EOF
 }
+
+variable "tectonic_openstack_disable_floatingip" {
+  default = false
+
+  description = <<EOF
+Disable floating ip assignments for k8s nodes.
+Warning: Enabling this option removes direct internet access,
+which prevents NodePorts from working.
+EOF
+}


### PR DESCRIPTION
For context, a production OpenStack cluster would be expected to use some combination of Ingress and LoadBalancer resources rather than NodePorts to access Services. Assigning a public IP address to every worker is redundant in this case.