### PR TITLE
Rspec azure wait for cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,8 +49,8 @@ def quay_creds = [
 ]
 
 def default_builder_image = 'quay.io/coreos/tectonic-builder:v1.39'
-def tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v5.0'
-
+def tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v5.1'
+ 
 pipeline {
   agent none
   options {

--- a/modules/azure/master-as/outputs.tf
+++ b/modules/azure/master-as/outputs.tf
@@ -1,0 +1,3 @@
+output "master-vm-ids" {
+  value = ["${azurerm_virtual_machine.tectonic_master.*.id}"]
+}

--- a/modules/bootstrap-ssh/variables.tf
+++ b/modules/bootstrap-ssh/variables.tf
@@ -1,3 +1,7 @@
 variable "bootstrapping_host" {
   type = "string"
 }
+
+variable "_deps" {
+  type = "list"
+}

--- a/platforms/azure/bootstrap.tf
+++ b/platforms/azure/bootstrap.tf
@@ -8,5 +8,6 @@ module "bootstrapper" {
   source = "../../modules/bootstrap-ssh"
 
   # depends_on         = ["module.etcd_certs", "module.vnet", "module.dns", "module.etcd", "module.masters", "module.bootkube", "module.tectonic", "module.flannel-vxlan", "module.calico-network-policy"]
+  _deps              = ["${module.masters.master-vm-ids}"]
   bootstrapping_host = "${local.bootstrapping_host}"
 }

--- a/tests/rspec/Gemfile
+++ b/tests/rspec/Gemfile
@@ -2,5 +2,6 @@
 
 source 'https://rubygems.org'
 
+gem 'net-ssh', '~>4.2.0'
 gem 'rspec', '~>3.0'
 gem 'rubocop', '~>0.49.1'

--- a/tests/rspec/Gemfile.lock
+++ b/tests/rspec/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     ast (2.3.0)
     diff-lcs (1.3)
+    net-ssh (4.2.0)
     parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -37,8 +38,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  net-ssh (~> 4.2.0)
   rspec (~> 3.0)
   rubocop (~> 0.49.1)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/tests/rspec/lib/azure_cluster.rb
+++ b/tests/rspec/lib/azure_cluster.rb
@@ -23,7 +23,7 @@ class AzureCluster < Cluster
     from = Time.now
     Net::SSH.start(ssh_ip, 'core') do |ssh|
       loop do
-        puts "Waiting for bootstrapping to complete..."
+        puts 'Waiting for bootstrapping to complete...'
         raise 'timeout waiting for bootstrapping' if Time.now - from > 1200 # 20 mins timeout
         bootkube_done = ssh.exec!(SSH_CMD_BOOTKUBE_DONE).exitstatus.zero?
         tectonic_done = ssh.exec!(SSH_CMD_TECTONIC_DONE).exitstatus.zero?
@@ -31,7 +31,7 @@ class AzureCluster < Cluster
         sleep(5)
       end
     end
-    puts "HOORAY! The cluster is up"
+    puts 'HOORAY! The cluster is up'
   end
 
   def master_ip_address

--- a/tests/rspec/lib/azure_cluster.rb
+++ b/tests/rspec/lib/azure_cluster.rb
@@ -2,10 +2,43 @@
 
 require 'cluster'
 require 'azure_support'
+require 'net/ssh'
+
+SSH_CMD_BOOTKUBE_DONE = "journalctl --no-pager -u bootkube | grep -q 'Started Bootstrap a Kubernetes cluster.'"
+SSH_CMD_TECTONIC_DONE = "journalctl --no-pager -u tectonic | grep -q 'Started Bootstrap a Tectonic cluster.'"
 
 # AzureCluster represents a k8s cluster on Azure cloud provider
+#
 class AzureCluster < Cluster
   extend AzureSupport
+
+  def start
+    super
+    # Wait for bootstrapping to complete
+    wait_for_bootstrapping
+  end
+
+  def wait_for_bootstrapping
+    ssh_ip = master_ip_address
+    from = Time.now
+    Net::SSH.start(ssh_ip, 'core') do |ssh|
+      loop do
+        puts "Waiting for bootstrapping to complete..."
+        raise 'timeout waiting for bootstrapping' if Time.now - from > 1200 # 20 mins timeout
+        bootkube_done = ssh.exec!(SSH_CMD_BOOTKUBE_DONE).exitstatus.zero?
+        tectonic_done = ssh.exec!(SSH_CMD_TECTONIC_DONE).exitstatus.zero?
+        break if bootkube_done && tectonic_done
+        sleep(5)
+      end
+    end
+    puts "HOORAY! The cluster is up"
+  end
+
+  def master_ip_address
+    Dir.chdir(@build_path) do
+      `echo 'module.vnet.api_ip_addresses[0]' | terraform console ../../platforms/azure`.chomp
+    end
+  end
 
   def env_variables
     variables = super


### PR DESCRIPTION
With this change we ensure that the bootstrapping process has completed before we run tests on Azure clusters.