### PR TITLE
frontend: Fix Terraform destroy error message being too long

### DIFF
--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -298,7 +298,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
           <div className="col-xs-12 wiz-launch-progress">
             <Step done={statusMsg === 'success'} error={tfError}>
               {tfError
-                ? <span><span className="wiz-running-fg">{tfTitle}:</span> [Failure] Terraform {action} failed</span>
+                ? <span><span className="wiz-running-fg">{tfTitle}:</span> [Failure] {_.startCase(action)} failed</span>
                 : tfTitle}
               {output && !isApplySuccess &&
                 <div className="pull-right" style={{fontSize: '13px'}}>


### PR DESCRIPTION
Remove "Terraform" so that the text fits.

Before | After
--- | ---
![destroy](https://user-images.githubusercontent.com/460802/30470599-5b2e118e-9a30-11e7-8ab1-2c3fb8c58acf.png) | ![destroy2](https://user-images.githubusercontent.com/460802/30470601-5c7fe0d0-9a30-11e7-8a81-3c706faf9e24.png)
![screenshot-2](https://user-images.githubusercontent.com/460802/30470605-5ef7bc7a-9a30-11e7-9dc2-34ea32aec614.png) | ![screenshot-1](https://user-images.githubusercontent.com/460802/30470603-5dc9a976-9a30-11e7-9382-e98f61dba5f1.png)
