### PR TITLE
Consolidate Azure bootstrapper dependencies

### DIFF
--- a/modules/azure/etcd/output.tf
+++ b/modules/azure/etcd/output.tf
@@ -4,3 +4,7 @@ output "node_names" {
     join(";", formatlist("%s.${var.base_domain}", slice(formatlist("${var.cluster_name}-%s", var.const_internal_node_names), 0, var.etcd_count)))))
   }"]
 }
+
+output "etcd_vm_ids" {
+  value = ["${azurerm_virtual_machine.etcd_node.*.id}"]
+}

--- a/modules/azure/master-as/outputs.tf
+++ b/modules/azure/master-as/outputs.tf
@@ -1,3 +1,3 @@
-output "master-vm-ids" {
+output "master_vm_ids" {
   value = ["${azurerm_virtual_machine.tectonic_master.*.id}"]
 }

--- a/modules/bootstrap-ssh/main.tf
+++ b/modules/bootstrap-ssh/main.tf
@@ -1,6 +1,7 @@
 resource "null_resource" "bootstrapper" {
   triggers {
-    endpoint = "${var.bootstrapping_host}"
+    endpoint    = "${var.bootstrapping_host}"
+    dependecies = "${join("", concat(flatten(var._dependencies)))}"
   }
 
   connection {
@@ -10,11 +11,14 @@ resource "null_resource" "bootstrapper" {
   }
 
   provisioner "file" {
+    when        = "create"
     source      = "./generated"
     destination = "$HOME/tectonic"
   }
 
   provisioner "remote-exec" {
+    when = "create"
+
     inline = [
       "sudo mkdir -p /opt",
       "sudo rm -rf /opt/tectonic",

--- a/modules/bootstrap-ssh/variables.tf
+++ b/modules/bootstrap-ssh/variables.tf
@@ -2,6 +2,6 @@ variable "bootstrapping_host" {
   type = "string"
 }
 
-variable "_deps" {
+variable "_dependencies" {
   type = "list"
 }

--- a/platforms/azure/bootstrap.tf
+++ b/platforms/azure/bootstrap.tf
@@ -8,6 +8,15 @@ module "bootstrapper" {
   source = "../../modules/bootstrap-ssh"
 
   # depends_on         = ["module.etcd_certs", "module.vnet", "module.dns", "module.etcd", "module.masters", "module.bootkube", "module.tectonic", "module.flannel-vxlan", "module.calico-network-policy"]
-  _deps              = ["${module.masters.master-vm-ids}"]
+  _dependencies = [
+    "${module.masters.master_vm_ids}",
+    "${module.etcd.etcd_vm_ids}",
+    "${module.etcd_certs.id}",
+    "${module.bootkube.id}",
+    "${module.tectonic.id}",
+    "${module.flannel-vxlan.id}",
+    "${module.calico-network-policy.id}",
+  ]
+
   bootstrapping_host = "${local.bootstrapping_host}"
 }

--- a/platforms/azure/bootstrap.tf
+++ b/platforms/azure/bootstrap.tf
@@ -7,7 +7,6 @@ locals {
 module "bootstrapper" {
   source = "../../modules/bootstrap-ssh"
 
-  # depends_on         = ["module.etcd_certs", "module.vnet", "module.dns", "module.etcd", "module.masters", "module.bootkube", "module.tectonic", "module.flannel-vxlan", "module.calico-network-policy"]
   _dependencies = [
     "${module.masters.master_vm_ids}",
     "${module.etcd.etcd_vm_ids}",


### PR DESCRIPTION
With this change we make sure that the bootstrapping module kicks off only after all it's dependencies have been created.
Previously this was accomplished by a 'depends_on' keyword but since the bootstrapper has now been moved to it's own module, that approach no longer works (Terraform limitation).