### PR TITLE
Upgrade Console to v2.0.0

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -58,7 +58,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.6.2"
     calico                       = "quay.io/calico/node:v2.4.1"
     calico_cni                   = "quay.io/calico/cni:v1.10.0"
-    console                      = "quay.io/coreos/tectonic-console:v1.9.3"
+    console                      = "quay.io/coreos/tectonic-console:v2.0.0"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
New things added since v1.9.3:

- Graphs that show cluster health.
- Show CRDs.
- Support latest operators (TCO, etcd, KVO, prom).
- Better messages for cluster settings that users don't have access to.
- Creating Network policies now shows a sidebar with helpful examples.
- Split up initial JavaScript bundle for faster loading.
- Support for creating/listing/editing Resource Quotas.
- Support for creating/listing/editing Persistent Volumes & PVCs.

Bug fixes include:

- RBAC namespace filters now work.
- Fixes for Microsoft Edge.
