### PR TITLE
bootkube: Rename kvo-config.yaml to cluster-config.yaml.

### DIFF
--- a/modules/bootkube/resources/manifests/cluster-config.yaml
+++ b/modules/bootkube/resources/manifests/cluster-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kvo-config
+  name: cluster-config
   namespace: tectonic-system
 data:
   kvo-config: |


### PR DESCRIPTION
In the future we will put other configs under a different key,
e.g. 'tuo-config'.

Having them in one configmap helps when we want to update different
configs atomically.