### PR TITLE
modules/bootkube: add managed-by annotations.

### DIFF
--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     tier: control-plane
     k8s-app: kube-apiserver
+    tectonic-operators.coreos.com/managed-by: kube-version-operator
 spec:
   updateStrategy:
     rollingUpdate:
@@ -19,6 +20,7 @@ spec:
       annotations:
         checkpointer.alpha.coreos.com/checkpoint: "true"
         scheduler.alpha.kubernetes.io/critical-pod: ""
+        tectonic-operators.coreos.com/managed-by: kube-version-operator
     spec:
       containers:
       - name: kube-apiserver

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     tier: control-plane
     k8s-app: kube-controller-manager
+    tectonic-operators.coreos.com/managed-by: kube-version-operator
 spec:
   replicas: ${master_count}
   strategy:
@@ -22,6 +23,7 @@ spec:
         tier: control-plane
         k8s-app: kube-controller-manager
         pod-anti-affinity: kube-controller-manager-${kubernetes_version}
+        tectonic-operators.coreos.com/managed-by: kube-version-operator
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:

--- a/modules/bootkube/resources/manifests/kube-proxy.yaml
+++ b/modules/bootkube/resources/manifests/kube-proxy.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     tier: node
     k8s-app: kube-proxy
+    tectonic-operators.coreos.com/managed-by: kube-version-operator
 spec:
   updateStrategy:
     rollingUpdate:
@@ -16,6 +17,7 @@ spec:
       labels:
         tier: node
         k8s-app: kube-proxy
+        tectonic-operators.coreos.com/managed-by: kube-version-operator
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:

--- a/modules/bootkube/resources/manifests/kube-scheduler.yaml
+++ b/modules/bootkube/resources/manifests/kube-scheduler.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     tier: control-plane
     k8s-app: kube-scheduler
+    tectonic-operators.coreos.com/managed-by: kube-version-operator
 spec:
   replicas: ${master_count}
   strategy:
@@ -22,6 +23,7 @@ spec:
         tier: control-plane
         k8s-app: kube-scheduler
         pod-anti-affinity: kube-scheduler-${kubernetes_version}
+        tectonic-operators.coreos.com/managed-by: kube-version-operator
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:


### PR DESCRIPTION
This marks the objects that are (and will continue to be) managed by the
KVO as such. This uses the standard `managed-by` annotation that is
declared in the x-operator.