### PR TITLE
config.tf: Update tectonic-cluo-operator from v0.2.0 to v0.2.1

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -81,7 +81,7 @@ variable "tectonic_container_images" {
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.5.3"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
     tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.6.0"
-    tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.0"
+    tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.1"
   }
 }
 
@@ -114,7 +114,7 @@ variable "tectonic_versions" {
     monitoring    = "1.6.0"
     tectonic      = "1.7.5-tectonic.1"
     tectonic-etcd = "0.0.1"
-    cluo          = "0.2.0"
+    cluo          = "0.2.1"
   }
 }
 

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -167,7 +167,7 @@
                   "--operator-name=tectonic-cluo-operator",
                   "--appversion-name=tectonic-cluo-operator"
                 ],
-                "image": "quay.io/coreos/tectonic-cluo-operator:v0.2.0",
+                "image": "quay.io/coreos/tectonic-cluo-operator:v0.2.1",
                 "name": "tectonic-cluo-operator",
                 "resources": {
                   "limits": {
@@ -334,7 +334,7 @@
         "name": "tectonic-cluo-operator",
         "namespace": "tectonic-system"
       },
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     {
       "metadata": {


### PR DESCRIPTION
* Adds master toleration to the `update-operator` to fix issue where Container Linux updates get stalled on clusters with one worker
* Updates the tectonic-torcx image with minor fixes
* See https://github.com/coreos-inc/tectonic-cluo-operator/pull/12