### PR TITLE
config.tf: bump dex to v2.7.0

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -66,7 +66,7 @@ variable "tectonic_container_images" {
     flannel_cni                  = "quay.io/coreos/flannel-cni:v0.2.0"
     heapster                     = "gcr.io/google_containers/heapster:v1.4.1"
     hyperkube                    = "quay.io/coreos/hyperkube:v1.7.5_coreos.0"
-    identity                     = "quay.io/coreos/dex:v2.6.1"
+    identity                     = "quay.io/coreos/dex:v2.7.0"
     ingress_controller           = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.12"
     kenc                         = "quay.io/coreos/kenc:0.0.2"
     kubedns                      = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4"


### PR DESCRIPTION
The features of Dex v.7.0 is listed here: https://github.com/coreos/dex/releases/tag/v2.7.0