### PR TITLE
frontend: Upgrades plugin used to get the version of installer

### DIFF
--- a/installer/frontend/package.json
+++ b/installer/frontend/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-git-version": "github:coreos/babel-plugin-git-version-build",
+    "babel-plugin-git-version": "github:coreos/babel-plugin-git-version-build#3f828164febc6b2f486f043fef75157989e97315",
     "babyparse": "0.4.x",
     "bcryptjs": "2.x",
     "classnames": "2.2.x",

--- a/installer/frontend/yarn.lock
+++ b/installer/frontend/yarn.lock
@@ -414,9 +414,9 @@ babel-plugin-check-es2015-constants@^6.3.13:
   dependencies:
     babel-runtime "^6.22.0"
 
-"babel-plugin-git-version@github:coreos/babel-plugin-git-version-build":
-  version "0.2.2"
-  resolved "https://codeload.github.com/coreos/babel-plugin-git-version-build/tar.gz/6a4838f386b359f81dc441a241389acdb0e9b140"
+"babel-plugin-git-version@github:coreos/babel-plugin-git-version-build#3f828164febc6b2f486f043fef75157989e97315":
+  version "0.2.3"
+  resolved "https://codeload.github.com/coreos/babel-plugin-git-version-build/tar.gz/3f828164febc6b2f486f043fef75157989e97315"
 
 babel-plugin-istanbul@^4.0.0:
   version "4.1.4"


### PR DESCRIPTION
Fixes https://coreosdev.atlassian.net/browse/TECREL-85

Previously the command run to get tag for displaying the version was `git describe`, which was only returning annotated tags and require tags to signed. This new build of the plugin runs `git describe --tags` which should return an unsigned tag.
https://github.com/coreos/babel-plugin-git-version-build/commit/3f828164febc6b2f486f043fef75157989e97315