### PR TITLE
modules/aws,vmware: finalize unified kubelet version bootstrapping

### DIFF
--- a/modules/aws/master-asg/resources/init-assets.sh
+++ b/modules/aws/master-asg/resources/init-assets.sh
@@ -33,11 +33,4 @@ rm /var/tmp/tectonic.zip
 # make files in /opt/tectonic available atomically
 mv /var/tmp/tectonic /opt/tectonic
 
-# Populate the kubelet.env file.
-mkdir -p /etc/kubernetes
-# shellcheck disable=SC2154
-echo "KUBELET_IMAGE_URL=${kubelet_image_url}" > /etc/kubernetes/kubelet.env
-# shellcheck disable=SC2154
-echo "KUBELET_IMAGE_TAG=${kubelet_image_tag}" >> /etc/kubernetes/kubelet.env
-
 exit 0

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -16,7 +16,6 @@ data "ignition_config" "node" {
     var.ign_locksmithd_service_id,
     var.ign_k8s_node_bootstrap_service_id,
     var.ign_kubelet_service_id,
-    var.ign_kubelet_env_service_id,
     var.ign_bootkube_service_id,
     var.ign_tectonic_service_id,
     var.ign_bootkube_path_unit_id,

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -1,7 +1,3 @@
-provider "vsphere" {
-  version = "0.2.2"
-}
-
 module "etcd" {
   source         = "../../modules/vmware/etcd"
   instance_count = "${var.tectonic_experimental ? 0 : var.tectonic_etcd_count }"

--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -1,4 +1,5 @@
 provider "vsphere" {
+  version              = "0.2.2"
   vsphere_server       = "${var.tectonic_vmware_server}"
   allow_unverified_ssl = "${var.tectonic_vmware_sslselfsigned}"
 }


### PR DESCRIPTION
- AWS still provisioned kubelet.env in init-assets.sh
- VMware had stale references to the old kubelet env service

Fixes #INST-112