### PR TITLE
frontend: Increase GUI test timeout to allow time for generating assets

### DIFF
--- a/installer/frontend/ui-tests/tests/awsInstaller.js
+++ b/installer/frontend/ui-tests/tests/awsInstaller.js
@@ -48,7 +48,7 @@ module.exports = {
   'AWS: Submit': client => {
     const submitPage = client.page.submitPage();
     submitPage.click('@manuallyBoot');
-    submitPage.expect.element('a[href="/terraform/assets"]').to.be.visible;
+    submitPage.expect.element('a[href="/terraform/assets"]').to.be.visible.before(30000);
     client.getCookie('tectonic-installer', result => {
       tfvarsUtil.returnTerraformTfvars(client.launch_url, result.value, (err, actualJson) => {
         if (err) {

--- a/installer/frontend/ui-tests/tests/bareMetalInstaller.js
+++ b/installer/frontend/ui-tests/tests/bareMetalInstaller.js
@@ -52,7 +52,7 @@ module.exports = {
   'BM: Submit': client => {
     const submitPage = client.page.submitPage();
     submitPage.click('@manuallyBoot');
-    submitPage.expect.element('a[href="/terraform/assets"]').to.be.visible;
+    submitPage.expect.element('a[href="/terraform/assets"]').to.be.visible.before(30000);
     client.getCookie('tectonic-installer', result => {
       tfvarsUtil.returnTerraformTfvars(client.launch_url, result.value, (err, actualJson) => {
         if (err) {


### PR DESCRIPTION
Because we now include some Terraform plugins in the build dir / assets.zip, this step now takes longer.