### PR TITLE
platforms/aws: Use separate ELB attachment resources

### DIFF
--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -53,7 +53,6 @@ resource "aws_autoscaling_group" "workers" {
   max_size             = "${var.instance_count * 3}"
   min_size             = "${var.instance_count}"
   launch_configuration = "${aws_launch_configuration.worker_conf.id}"
-  load_balancers       = ["${var.load_balancers}"]
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
   tags = [
@@ -78,6 +77,13 @@ resource "aws_autoscaling_group" "workers" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_autoscaling_attachment" "workers" {
+  count = "${length(var.load_balancers)}"
+
+  autoscaling_group_name = "${aws_autoscaling_group.workers.name}"
+  elb                    = "${var.load_balancers[count.index]}"
 }
 
 resource "aws_iam_instance_profile" "worker_profile" {


### PR DESCRIPTION
This uses standalone resources to attach extra ELBs to workers rather
than doing it inline on the ASG resource.  Attaching the ELBs inline
means it isn't possible to configure other attachments outside the ASG
definition.

I haven't actually had time to test this yet. Will do that soon.