### PR TITLE
node-agent: bump to v1.7.5-kvo.3.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -74,7 +74,7 @@ variable "tectonic_container_images" {
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
     kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.3-kvo.3"
-    node_agent                   = "quay.io/coreos/node-agent:v1.7.3-kvo.3"
+    node_agent                   = "quay.io/coreos/node-agent:v1.7.5-kvo.3"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:3517908b1a1837e78cfd041a0e51e61c7835d85f"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"


### PR DESCRIPTION
This contains a fix to prevent spurious updates to Node objects for
clusters that have never gone through an upgrade.