### PR TITLE
Automate e2e image building and bump conformance test version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,12 @@ vendor-smoke: $(TOP_DIR)/tests/smoke/glide.yaml
 	@cd $(TOP_DIR)/tests/smoke && glide up -v
 	@cd $(TOP_DIR)/tests/smoke && glide-vc --use-lock-file --no-tests --only-code
 
+.PHONY: e2e-docker-image
+e2e-docker-image: images/kubernetes-e2e/Dockerfile
+	  @E2E_IMAGE="quay.io/coreos/kube-conformance:$$(grep "ARG E2E_REF" $< | cut -d "=" -f2 | sed 's/+/_/') \
+	  echo "Building E2E image $${E2E_IMAGE}"; \
+	  docker build -t $${E2E_IMAGE} $(dir $<)
+
 .PHONY: smoke-test-env-docker-image
 smoke-test-env-docker-image:
 	docker build -t quay.io/coreos/tectonic-smoke-test-env -f images/tectonic-smoke-test-env/Dockerfile .

--- a/images/kubernetes-e2e/Dockerfile
+++ b/images/kubernetes-e2e/Dockerfile
@@ -1,0 +1,25 @@
+ARG GO_VERSION=1.9
+FROM golang:${GO_VERSION}
+
+# install e2e dependencies
+RUN apt-get update && apt-get install -y rsync && rm -rf /var/lib/apt/lists/*
+
+# Git Repository Configuration
+ARG E2E_REPO=https://github.com/coreos/kubernetes
+ARG E2E_REF=v1.7.5+coreos.0
+
+# clone Kubernetes repository
+RUN mkdir -p ${GOPATH}/src/k8s.io && \
+      git clone --branch ${E2E_REF} --depth 1 --single-branch ${E2E_REPO} ${GOPATH}/src/k8s.io/kubernetes
+WORKDIR ${GOPATH}/src/k8s.io/kubernetes
+
+# install build dependencies
+RUN go get -u github.com/jteeuwen/go-bindata/go-bindata
+
+# build all test dependencies
+RUN GOLDFLAGS="--s -w" make all WHAT="cmd/kubectl vendor/github.com/onsi/ginkgo/ginkgo test/e2e/e2e.test"
+
+# testing defaults
+ENV KUBE_OS_DISTRIBUTION=coreos KUBERNETES_CONFORMANCE_TEST=Y HOME=/go/src/k8s.io/kubernetes SKEW=false FOCUS=Conformance
+CMD KUBECONFIG=/kubeconfig go run hack/e2e.go -- -v --test --check-version-skew=${SKEW} --test_args="--ginkgo.focus=\[${FOCUS}\] ${TEST_ARGS}"
+

--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -8,7 +8,7 @@ export CLUSTER="tf-${PLATFORM}-${BUILD_ID}"
 export TF_VAR_tectonic_pull_secret_path=${TF_VAR_tectonic_pull_secret_path}
 export TF_VAR_tectonic_license_path=${TF_VAR_tectonic_license_path}
 export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.39
-export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.7.1_coreos.0
+export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.7.5_coreos.0
 export TF_VAR_tectonic_base_domain="tectonic.dev.coreos.systems"
 
 # Create an env var file
@@ -44,7 +44,7 @@ EOF
 trap cleanup EXIT
 
 export KUBECTL=${WORKSPACE}/kubectl
-curl -o "${KUBECTL}" https://storage.googleapis.com/kubernetes-release/release/v1.6.3/bin/linux/amd64/kubectl && chmod +x "${KUBECTL}"
+curl -o "${KUBECTL}" https://storage.googleapis.com/kubernetes-release/release/v1.7.5/bin/linux/amd64/kubectl && chmod +x "${KUBECTL}"
 
 function kubectl() {
     local i=0


### PR DESCRIPTION
This PR:
* Adds Dockerfile and make recipe for building an image that contains the Kubernetes E2E and required dependencies. The Dockerfile defaults to a specific commit but can be overwritten with `--build-arg`.
* Bumps conformance test script to uses tests from v1.7.5+coreos.0