### PR TITLE
Increase Memory Limits

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-cluo-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-cluo-operator.yaml
@@ -28,7 +28,7 @@ spec:
         resources:
           limits:
             cpu: 20m
-            memory: 50Mi
+            memory: 100Mi
           requests:
             cpu: 20m
             memory: 50Mi


### PR DESCRIPTION

Today we ran  into an issue where the `tectonic-cluo-operator` was requesting `80Mi` and kept OOMing due to memory limits. Increasing the limit to `100Mi`allowed the `tectonic-cluo-operator` pod to start and after a few moments the memory limit dropped down to `40Mi`.

It might be worth increasing the hard limits just to account for any overhead.