### PR TITLE
aws: fix deprecated property name for iam roles

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -87,13 +87,13 @@ resource "aws_iam_instance_profile" "master_profile" {
 
   role = "${var.master_iam_role == "" ?
     join("|", aws_iam_role.master_role.*.name) :
-    join("|", data.aws_iam_role.master_role.*.role_name)
+    join("|", data.aws_iam_role.master_role.*.name)
   }"
 }
 
 data "aws_iam_role" "master_role" {
-  count     = "${var.master_iam_role == "" ? 0 : 1}"
-  role_name = "${var.master_iam_role}"
+  count = "${var.master_iam_role == "" ? 0 : 1}"
+  name  = "${var.master_iam_role}"
 }
 
 resource "aws_iam_role" "master_role" {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -91,13 +91,13 @@ resource "aws_iam_instance_profile" "worker_profile" {
 
   role = "${var.worker_iam_role == "" ?
     join("|", aws_iam_role.worker_role.*.name) :
-    join("|", data.aws_iam_role.worker_role.*.role_name)
+    join("|", data.aws_iam_role.worker_role.*.name)
   }"
 }
 
 data "aws_iam_role" "worker_role" {
-  count     = "${var.worker_iam_role == "" ? 0 : 1}"
-  role_name = "${var.worker_iam_role}"
+  count = "${var.worker_iam_role == "" ? 0 : 1}"
+  name  = "${var.worker_iam_role}"
 }
 
 resource "aws_iam_role" "worker_role" {


### PR DESCRIPTION
It seems these property names were changed recently which causes a breakage when setting the master/worker IAM Role overrides in 1.7.5-RC4

```
$ terraform plan -var-file=build/${CLUSTER}/terraform.tfvars platforms/aws
There are warnings related to your configuration. If no errors occurred,
Terraform will continue despite these warnings. It is a good idea to resolve
these warnings in the near future.

Warnings:

  * module.masters.data.aws_iam_role.master_role: "role_name": [DEPRECATED] Use `name` instead
  * module.workers.data.aws_iam_role.worker_role: "role_name": [DEPRECATED] Use `name` instead

2 error(s) occurred:

* module.masters.data.aws_iam_role.master_role: "name": required field is not set
* module.workers.data.aws_iam_role.worker_role: "name": required field is not set
```