### PR TITLE
aws: fix deprecated property name for iam roles

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -87,13 +87,13 @@ resource "aws_iam_instance_profile" "master_profile" {
 
   role = "${var.master_iam_role == "" ?
     join("|", aws_iam_role.master_role.*.name) :
-    join("|", data.aws_iam_role.master_role.*.role_name)
+    join("|", data.aws_iam_role.master_role.*.name)
   }"
 }
 
 data "aws_iam_role" "master_role" {
-  count     = "${var.master_iam_role == "" ? 0 : 1}"
-  role_name = "${var.master_iam_role}"
+  count = "${var.master_iam_role == "" ? 0 : 1}"
+  name  = "${var.master_iam_role}"
 }
 
 resource "aws_iam_role" "master_role" {

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -85,13 +85,13 @@ resource "aws_iam_instance_profile" "worker_profile" {
 
   role = "${var.worker_iam_role == "" ?
     join("|", aws_iam_role.worker_role.*.name) :
-    join("|", data.aws_iam_role.worker_role.*.role_name)
+    join("|", data.aws_iam_role.worker_role.*.name)
   }"
 }
 
 data "aws_iam_role" "worker_role" {
-  count     = "${var.worker_iam_role == "" ? 0 : 1}"
-  role_name = "${var.worker_iam_role}"
+  count = "${var.worker_iam_role == "" ? 0 : 1}"
+  name  = "${var.worker_iam_role}"
 }
 
 resource "aws_iam_role" "worker_role" {


### PR DESCRIPTION
Cherry pick of https://github.com/coreos/tectonic-installer/pull/2012 into the 1.7.5 branch.