### PR TITLE
Bump Tectonic Console to v2.1.1

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -58,7 +58,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.6.2"
     calico                       = "quay.io/calico/node:v2.4.1"
     calico_cni                   = "quay.io/calico/cni:v1.10.0"
-    console                      = "quay.io/coreos/tectonic-console:v2.0.3"
+    console                      = "quay.io/coreos/tectonic-console:v2.1.1"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
Changes include:

- Only show Network Policies in sidebar if the cluster has Calico.
- Fix styling for nodes without CLUO (mostly RHEL workers).
- Support cascading deletes ([example screenshot](https://user-images.githubusercontent.com/523368/30987565-599d0ac0-a44c-11e7-98e0-ae47fa2ae8b9.png))
- Support zooming & panning in line graphs.
- Update API success gauge on dashboard to use a query that's more likely to return useful data.
- Allow downloading a kubeconfig for a given Service Account.
- Various bug fixes & styling tweaks.
