### PR TITLE
Update nginx ingress controller to 0.9-beta.15

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -67,7 +67,7 @@ variable "tectonic_container_images" {
     heapster                     = "gcr.io/google_containers/heapster:v1.4.1"
     hyperkube                    = "quay.io/coreos/hyperkube:v1.7.6_coreos.0"
     identity                     = "quay.io/coreos/dex:v2.7.1"
-    ingress_controller           = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.12"
+    ingress_controller           = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15"
     kenc                         = "quay.io/coreos/kenc:0.0.2"
     kubedns                      = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"


### PR DESCRIPTION
**Image:**  `gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15`

*New Features:*

- Opentracing support for NGINX
- Setting upstream vhost for nginx
- Allow custom global configuration at multiple levels
- Add support for proxy protocol decoding and encoding in TCP services
- Add OCSP support
- Configurable ssl_verify_client

Complete changelog [here](https://github.com/kubernetes/ingress/blob/master/controllers/nginx/Changelog.md)
