### PR TITLE
 modules/tectonic: add kube_dns_service_ip variable

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -96,7 +96,8 @@ resource "template_dir" "tectonic" {
     certificates_strategy = "${var.ca_generated == "true" ? "installerGeneratedCA" : "userProvidedCA"}"
     identity_api_service  = "${var.identity_api_service}"
 
-    image_re = "${var.image_re}"
+    image_re            = "${var.image_re}"
+    kube_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
   }
 }
 

--- a/modules/tectonic/resources/manifests/cluster-config.yaml
+++ b/modules/tectonic/resources/manifests/cluster-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-config
   namespace: tectonic-system
 data:
-  tuo-config:
+  tuo-config: |
     apiVersion: v1
     kind: ClusterConfig
     identityConfig:
@@ -29,7 +29,7 @@ data:
       installerPlatform: ${platform}
       kubeAPIserverURL: ${kube_apiserver_url}
       tectonicVersion: ${tectonic_version}
-  addon-config:
+  addon-config: |
       apiVersion: v1
       kind: AddonConfig
       heapsterConfig:

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -151,3 +151,8 @@ variable "identity_client_cert_pem" {
 variable "identity_client_key_pem" {
   type = "string"
 }
+
+variable "service_cidr" {
+  description = "A CIDR notation IP range from which to assign service cluster IPs"
+  type        = "string"
+}

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -115,6 +115,7 @@ module "tectonic" {
 
   base_address       = "${var.tectonic_aws_private_endpoints ? module.masters.ingress_internal_fqdn : module.masters.ingress_external_fqdn}"
   kube_apiserver_url = "https://${var.tectonic_aws_private_endpoints ? module.masters.api_internal_fqdn : module.masters.api_external_fqdn}:443"
+  service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.
   container_images      = "${var.tectonic_container_images}"

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -100,6 +100,7 @@ module "tectonic" {
 
   base_address       = "${module.vnet.ingress_fqdn}"
   kube_apiserver_url = "https://${module.vnet.api_fqdn}:443"
+  service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.
   container_images      = "${var.tectonic_container_images}"

--- a/platforms/gcp/tectonic.tf
+++ b/platforms/gcp/tectonic.tf
@@ -125,8 +125,8 @@ module "tectonic" {
   license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
   pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
 
-  admin_email         = "${var.tectonic_admin_email}"
-  admin_password_hash = "${var.tectonic_admin_password_hash}"
+  admin_email    = "${var.tectonic_admin_email}"
+  admin_password = "${var.tectonic_admin_password}"
 
   update_channel = "${var.tectonic_update_channel}"
   update_app_id  = "${var.tectonic_update_app_id}"

--- a/platforms/gcp/tectonic.tf
+++ b/platforms/gcp/tectonic.tf
@@ -115,6 +115,7 @@ module "tectonic" {
 
   base_address       = "${module.dns.kube_ingress_fqdn}"
   kube_apiserver_url = "https://${module.dns.kube_apiserver_fqdn}:443"
+  service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.
   container_images      = "${var.tectonic_container_images}"

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -97,6 +97,7 @@ module "tectonic" {
 
   base_address       = "${var.tectonic_metal_ingress_domain}"
   kube_apiserver_url = "https://${var.tectonic_metal_controller_domain}:443"
+  service_cidr       = "${var.tectonic_service_cidr}"
 
   # Address of the Tectonic console (without protocol)
   container_images      = "${var.tectonic_container_images}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -100,6 +100,7 @@ module "tectonic" {
 
   base_address       = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}"
   kube_apiserver_url = "https://${var.tectonic_cluster_name}-k8s.${var.tectonic_base_domain}:443"
+  service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.
   container_images      = "${var.tectonic_container_images}"

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -95,6 +95,7 @@ module "tectonic" {
 
   base_address       = "${var.tectonic_vmware_ingress_domain}"
   kube_apiserver_url = "https://${var.tectonic_vmware_controller_domain}:443"
+  service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.
   container_images      = "${var.tectonic_container_images}"


### PR DESCRIPTION
This fixes a regression introduced in #2014.

Additionally:
platforms/gcp: replace admin_password_hash with admin_password

bcrypt support landed in #1771 but the change was not promoted to GCP.
This fixes it.