### PR TITLE
tests: Make cluster base domain configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ tests/smoke: bin/smoke smoke-test-env-docker-image
 	-e TF_VAR_tectonic_azure_location \
 	-e TF_VAR_tectonic_license_path \
 	-e TF_VAR_tectonic_pull_secret_path \
-	-e TF_VAR_base_domain \
+	-e TF_VAR_tectonic_base_domain \
 	-e TECTONIC_TESTS_DONT_CLEAN_UP \
 	--cap-add NET_ADMIN \
 	--device /dev/net/tun \

--- a/tests/README.md
+++ b/tests/README.md
@@ -73,7 +73,7 @@ AWS_SECRET_ACCESS_KEY
 TF_VAR_tectonic_aws_region
 TF_VAR_tectonic_license_path
 TF_VAR_tectonic_pull_secret_path
-TF_VAR_base_domain
+TF_VAR_tectonic_base_domain
 ```
 
 ### 2. Launch the tests

--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -24,6 +24,12 @@ class AwsCluster < Cluster
   def env_variables
     variables = super
     variables['PLATFORM'] = 'aws'
+
+    # Unless base domain is provided by the user:
+    unless ENV.key?('TF_VAR_tectonic_base_domain')
+      variables['TF_VAR_tectonic_base_domain'] = 'tectonic.dev.coreos.systems'
+    end
+
     variables
   end
 

--- a/tests/rspec/lib/azure_cluster.rb
+++ b/tests/rspec/lib/azure_cluster.rb
@@ -25,6 +25,12 @@ class AzureCluster < Cluster
     variables['PLATFORM'] = 'azure'
     variables['TF_VAR_tectonic_azure_location'] = @random_location
     variables['TF_VAR_tectonic_azure_client_secret'] = ENV['ARM_CLIENT_SECRET']
+
+    # To use Azure-provided DNS, `tectonic_base_domain` should be set to `""`
+    unless ENV.key?('TF_VAR_tectonic_base_domain')
+      variables['TF_VAR_tectonic_base_domain'] = ''
+    end
+
     variables
   end
 

--- a/tests/smoke/aws/vars/aws-ca.tfvars.json
+++ b/tests/smoke/aws/vars/aws-ca.tfvars.json
@@ -7,8 +7,6 @@
 
     "tectonic_etcd_servers": [""],
 
-    "tectonic_base_domain": "tectonic.dev.coreos.systems",
-
     "tectonic_container_linux_channel": "stable",
 
     "tectonic_ca_cert": "../../examples/fake-creds/ca.crt",

--- a/tests/smoke/aws/vars/aws-exp.tfvars.json
+++ b/tests/smoke/aws/vars/aws-exp.tfvars.json
@@ -3,8 +3,6 @@
 
     "tectonic_master_count": "1",
 
-    "tectonic_base_domain": "tectonic.dev.coreos.systems",
-
     "tectonic_container_linux_channel": "stable",
 
     "tectonic_ca_cert": "",

--- a/tests/smoke/aws/vars/aws-net-canal.tfvars.json
+++ b/tests/smoke/aws/vars/aws-net-canal.tfvars.json
@@ -3,8 +3,6 @@
 
     "tectonic_master_count": "1",
 
-    "tectonic_base_domain": "tectonic.dev.coreos.systems",
-
     "tectonic_container_linux_channel": "stable",
 
     "tectonic_ca_cert": "",

--- a/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
+++ b/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
@@ -5,7 +5,6 @@
     "tectonic_aws_master_ec2_type": "m4.large",
     "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
     "tectonic_aws_worker_ec2_type": "m4.large",
-    "tectonic_base_domain": "tectonic.dev.coreos.systems",
     "tectonic_ca_cert": "",
     "tectonic_ca_key": "",
     "tectonic_container_linux_channel": "stable",

--- a/tests/smoke/aws/vars/aws.tfvars.json
+++ b/tests/smoke/aws/vars/aws.tfvars.json
@@ -4,7 +4,6 @@
     "tectonic_aws_master_ec2_type": "m4.large",
     "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
     "tectonic_aws_worker_ec2_type": "m4.large",
-    "tectonic_base_domain": "tectonic.dev.coreos.systems",
     "tectonic_ca_cert": "",
     "tectonic_ca_key": "",
     "tectonic_container_linux_channel": "stable",

--- a/tests/smoke/azure/vars/basic.tfvars
+++ b/tests/smoke/azure/vars/basic.tfvars
@@ -6,7 +6,6 @@
     "tectonic_azure_private_cluster": "false",
     "tectonic_azure_worker_storage_type": "Standard_LRS",
     "tectonic_azure_worker_vm_size": "Standard_D1_v2",
-    "tectonic_base_domain": "",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_container_linux_channel": "stable",
     "tectonic_etcd_count": "1",

--- a/tests/smoke/azure/vars/example.tfvars
+++ b/tests/smoke/azure/vars/example.tfvars
@@ -1,6 +1,5 @@
 {
     "tectonic_azure_private_cluster": "false",
-    "tectonic_base_domain": "",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_container_linux_channel": "stable",
     "tectonic_etcd_count": "0",

--- a/tests/smoke/azure/vars/experimental.tfvars
+++ b/tests/smoke/azure/vars/experimental.tfvars
@@ -6,7 +6,6 @@
     "tectonic_azure_private_cluster": "false",
     "tectonic_azure_worker_storage_type": "Standard_LRS",
     "tectonic_azure_worker_vm_size": "Standard_D1_v2",
-    "tectonic_base_domain": "",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_container_linux_channel": "stable",
     "tectonic_etcd_count": "0",

--- a/tests/smoke/azure/vars/external-experimental.tfvars
+++ b/tests/smoke/azure/vars/external-experimental.tfvars
@@ -14,7 +14,6 @@
     "tectonic_azure_private_cluster": "false",
     "tectonic_azure_worker_storage_type": "Standard_LRS",
     "tectonic_azure_worker_vm_size": "Standard_D1_v2",
-    "tectonic_base_domain": "",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_container_linux_channel": "stable",
     "tectonic_etcd_count": "0",

--- a/tests/smoke/azure/vars/external.tfvars
+++ b/tests/smoke/azure/vars/external.tfvars
@@ -13,7 +13,6 @@
     "tectonic_azure_master_vm_size": "Standard_D2_v2",
     "tectonic_azure_worker_storage_type": "Standard_LRS",
     "tectonic_azure_worker_vm_size": "Standard_D1_v2",
-    "tectonic_base_domain": "",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_container_linux_channel": "stable",
     "tectonic_etcd_count": "2",


### PR DESCRIPTION
A user should be able to configure the tectonic_base_domain variable
via environment variables without touching the tfvars files. E.g.
external contributors do not have access to the
`tectonic.dev.coreos.systems` domain.

//CC @coresolve @derekparker