### PR TITLE
Bump Terraform to 0.10.7

### DIFF
--- a/Documentation/dev/gcp/README.md
+++ b/Documentation/dev/gcp/README.md
@@ -4,7 +4,7 @@ Use this guide to manually install a Tectonic cluster on a GCP account.
 
 ## Prerequsities
 
-- **Terraform:** >= v0.10.4
+- **Terraform:** >= v0.10.7
 - **DNS**: Ensure that the DNS zone is already created and available in [Cloud DNS](https://console.cloud.google.com/net-services/dns) for the account. For example if the `tectonic_base_domain` is set to `kube.example.com` a Cloud DNS zone must exist with the nameservers configured for that domain.
 Tectonic Account: Register for a Tectonic Account, which is free for up to 10 nodes. You must provide the cluster license and pull secret during installation.
 - **Tectonic Account** - Register for a [Tectonic Account](https://coreos.com/tectonic), which is free for up to 10 nodes. You must provide the cluster license and pull secret during installation.

--- a/config.tf
+++ b/config.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.10.4"
+  required_version = ">= 0.10.7"
 }
 
 provider "archive" {

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod 777 -R /go
 
 ### Install Shellcheck, Terraform, NodeJS and Yarn
 ENV SHELLCHECK_VERSION="v0.4.6"
-ENV TERRAFORM_VERSION="v0.10.4-coreos.1"
+ENV TERRAFORM_VERSION="v0.10.7"
 ENV NODE_VERSION="v8.1.2"
 ENV YARN_VERSION="v0.24.6"
 ENV MATCHBOXVERSION="v0.6.1"
@@ -59,7 +59,7 @@ RUN apt-get update && \
 # Install Terraform
 # TERRAFORM_URL enables us to build the upstream-terraform Tectonic builder
 # image (See README.md/##Upstream-and-CoreOS-Terraform)
-ARG TERRAFORM_URL=https://github.com/coreos/terraform/releases/download/${TERRAFORM_VERSION}/linux_amd64.zip
+ARG TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN curl -L ${TERRAFORM_URL} | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
 
 # Install NodeJS

--- a/images/tectonic-installer/Dockerfile
+++ b/images/tectonic-installer/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.9.0-stretch
 
-ENV TERRAFORM_VERSION="0.10.4"
+ENV TERRAFORM_VERSION="0.10.7"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y -q \

--- a/images/tectonic-smoke-test-env/Dockerfile
+++ b/images/tectonic-smoke-test-env/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4-slim
 
-ENV TERRAFORM_VERSION="v0.10.4-coreos.1"
+ENV TERRAFORM_VERSION="v0.10.7"
 
 COPY ./tests/rspec/Gemfile* /tmp/app/
 
@@ -17,7 +17,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
     mv ./kubectl /bin/kubectl
 
 # Install Terraform
-RUN curl -L https://github.com/coreos/terraform/releases/download/${TERRAFORM_VERSION}/linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
+RUN curl -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
 
 # Install Chrome for installer gui tests
 # Use Chrome beta because v60 or higher is needed for headless mode

--- a/tests/smoke/bare-metal/smoke.sh
+++ b/tests/smoke/bare-metal/smoke.sh
@@ -30,7 +30,7 @@ BIN_DIR="$ROOT/bin_test"
 
 MATCHBOX_VERSION=v0.6.1
 KUBECTL_VERSION=v1.6.4
-TERRAFORM_VERSION=0.10.4
+TERRAFORM_VERSION=0.10.7
 
 KUBECTL_URL="https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
 TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"


### PR DESCRIPTION
As part of this bump I've also flipped the TF download location back to the official upstream release. 

We used to maintain a CoreOS fork with specific tweaks for overriding some tight timeouts to help our smoke tests. Those changes were actually isolated to the AWS provider which got split out into it's own repo. Also, with the recent improvements to the test framework we're not being blocked by those particular flakes anymore.

/cc: @sym3tri 