### PR TITLE
Bump to go 1.9.1 in Dockerfiles

### DIFF
--- a/images/kubernetes-e2e/Dockerfile
+++ b/images/kubernetes-e2e/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.9
+ARG GO_VERSION=1.9.1
 FROM golang:${GO_VERSION}
 
 # install e2e dependencies

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -16,7 +16,7 @@
 # docker push quay.io/coreos/tectonic-builder:<next-semver>-upstream-terraform
 ###
 
-FROM golang:1.9-stretch
+FROM golang:1.9.1-stretch
 
 ### For golang testing stuff
 RUN go get -u github.com/golang/lint/golint

--- a/images/tectonic-installer/Dockerfile
+++ b/images/tectonic-installer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.0-stretch
+FROM golang:1.9.1-stretch
 
 ENV TERRAFORM_VERSION="0.10.7"
 


### PR DESCRIPTION
1.9.1 fixes the recent vulnerabilities in go, see:
https://groups.google.com/forum/m/#!topic/golang-nuts/sHfMg4gZNps

I would like to put these changes up for discussion. Should we fix our Dockerfile base images to specific patch versions, or just pin the minor version?