### PR TITLE
Update tectonic builder Jenkins job parameter description

### DIFF
--- a/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
+++ b/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
@@ -9,7 +9,7 @@ job("builders/tectonic-builder-docker-image") {
   label 'worker&&ec2'
 
   parameters {
-    stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream Terraform download url, defaults to CoreOS custom Terraform release (github.com/coreos/terraform)')
+    stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream Terraform download url, defaults to upstream Terraform release')
     stringParam('TECTONIC_BUILDER_TAG', '', 'Tectonic Builder Docker tag')
     booleanParam('DRY_RUN', true, 'Just build the docker image')
   }


### PR DESCRIPTION
The tectonic builder does not default to the CoreOS terraform version
anymore since #2041. This updates the documentation of the parameter.