### PR TITLE
Fix Makefile target e2e-docker-image for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ vendor-smoke: $(TOP_DIR)/tests/smoke/glide.yaml
 
 .PHONY: e2e-docker-image
 e2e-docker-image: images/kubernetes-e2e/Dockerfile
-	  @E2E_IMAGE="quay.io/coreos/kube-conformance:$$(grep "ARG E2E_REF" $< | cut -d "=" -f2 | sed 's/+/_/') \
+	  @export E2E_IMAGE="quay.io/coreos/kube-conformance:$$(grep 'ARG E2E_REF' $< | cut -d '=' -f2 | sed 's/+/_/')"; \
 	  echo "Building E2E image $${E2E_IMAGE}"; \
 	  docker build -t $${E2E_IMAGE} $(dir $<)
 


### PR DESCRIPTION
The `e2e-docker-image` make target does not work with Linux and GNU
Make 4.2.1 because `E2E_IMAGE` variable is not passed to both following
commands. This patch exports it, before using it later.

Not sure if this is a idiomatic approach. Happy for any suggestions. 

@ethernetdan @alexsomesan Could you try this out? As far as I know you are both running on Mac?!