### PR TITLE
Bump docker image versions in Jenkins jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,8 +31,8 @@ quay_creds = [
   )
 ]
 
-default_builder_image = 'quay.io/coreos/tectonic-builder:v1.40-upstream-terraform'
-tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v5.6'
+default_builder_image = 'quay.io/coreos/tectonic-builder:v1.41'
+tectonic_smoke_test_env_image = 'quay.io/coreos/tectonic-smoke-test-env:v5.7'
 
 pipeline {
   agent none

--- a/tests/conformance/conformance.sh
+++ b/tests/conformance/conformance.sh
@@ -7,8 +7,8 @@ export PLATFORM=aws
 export CLUSTER="tf-${PLATFORM}-${BUILD_ID}"
 export TF_VAR_tectonic_pull_secret_path=${TF_VAR_tectonic_pull_secret_path}
 export TF_VAR_tectonic_license_path=${TF_VAR_tectonic_license_path}
-export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.39
-export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.7.5_coreos.0
+export TECTONIC_BUILDER=quay.io/coreos/tectonic-builder:v1.41
+export KUBE_CONFORMANCE=quay.io/coreos/kube-conformance:v1.7.5_coreos.0_golang1.9.1
 export TF_VAR_tectonic_base_domain="tectonic.dev.coreos.systems"
 
 # Create an env var file


### PR DESCRIPTION
With 41906a25 we bumped the go version in our Docker images. This
updates the tags in our test automation Jenkins jobs to the newest
images on quay.