### PR TITLE
payload.json: Add node selector and toleration for tco so it runs on master node.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -48,7 +48,7 @@ variable "tectonic_container_images" {
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
     kube_state_metrics           = "quay.io/coreos/kube-state-metrics:v1.0.0"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
-    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.3-kvo.4"
+    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.3-kvo.5"
     node_agent                   = "quay.io/coreos/node-agent:v1.7.3-kvo.3"
     node_exporter                = "quay.io/prometheus/node-exporter:v0.14.0"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:3517908b1a1837e78cfd041a0e51e61c7835d85f"
@@ -72,7 +72,7 @@ variable "tectonic_versions" {
   default = {
     alertmanager  = "v0.8.0"
     etcd          = "3.1.8"
-    kubernetes    = "1.7.3+tectonic.3"
+    kubernetes    = "1.7.3+tectonic.4"
     monitoring    = "1.5.2"
     prometheus    = "v1.7.1"
     tectonic      = "1.7.3-tectonic.3"

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
@@ -17,6 +17,12 @@ spec:
         k8s-app: tectonic-channel-operator
         tectonic-app-version-name: tectonic-cluster
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: tectonic-channel-operator
         image: ${tectonic_channel_operator_image}

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -125,7 +125,7 @@
                   "--cache-images=true",
                   "--version-mapping=/upgrade-spec.json"
                 ],
-                "image": "quay.io/coreos/kube-version-operator:v1.7.3-kvo.4",
+                "image": "quay.io/coreos/kube-version-operator:v1.7.3-kvo.5",
                 "name": "kube-version-operator"
               }
             ],
@@ -331,7 +331,7 @@
         "name": "kubernetes",
         "namespace": "tectonic-system"
       },
-      "version": "1.7.3+tectonic.3"
+      "version": "1.7.3+tectonic.4"
     },
     {
       "metadata": {

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -65,11 +65,21 @@
                 "name": "coreos-pull-secret"
               }
             ],
+            "nodeSelector": {
+              "node-role.kubernetes.io/master": ""
+            },
             "restartPolicy": "Always",
             "securityContext": {
               "runAsNonRoot": true,
               "runAsUser": 65534
             },
+            "tolerations": [
+              {
+                "effect": "NoSchedule",
+                "key": "node-role.kubernetes.io/master",
+                "operator": "Exists"
+              }
+            ],
             "volumes": [
               {
                 "hostPath": {


### PR DESCRIPTION
Otherwise, if the workers are all rhel nodes, then it will have an issue
finding ssl certs that are required for hitting the core update server.