### PR TITLE
updater: Add toleration and node selector for tco to schedule it to master.

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
@@ -17,6 +17,12 @@ spec:
         k8s-app: tectonic-channel-operator
         tectonic-app-version-name: tectonic-cluster
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: tectonic-channel-operator
         image: ${tectonic_channel_operator_image}

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -65,11 +65,21 @@
                 "name": "coreos-pull-secret"
               }
             ],
+            "nodeSelector": {
+              "node-role.kubernetes.io/master": ""
+            },
             "restartPolicy": "Always",
             "securityContext": {
               "runAsNonRoot": true,
               "runAsUser": 65534
             },
+            "tolerations": [
+              {
+                "effect": "NoSchedule",
+                "key": "node-role.kubernetes.io/master",
+                "operator": "Exists"
+              }
+            ],
             "volumes": [
               {
                 "hostPath": {


### PR DESCRIPTION
This is because tco replies on ssl certs path that doesn't exist on rhel nodes.