### PR TITLE
frontend: Automatically load Tectonic license / pull secret if they exist on disk

### DIFF
--- a/installer/api/api.go
+++ b/installer/api/api.go
@@ -92,10 +92,10 @@ func New(config *Config) (http.Handler, error) {
 	// handlers_tectonic.go
 	mux.Handle("/tectonic/status", logRequests(httpHandler("POST", ctx, tectonicStatusHandler)))
 	mux.Handle("/tectonic/kubeconfig", logRequests(httpHandler("GET", ctx, tectonicKubeconfigHandler)))
+	mux.Handle("/tectonic/facts", logRequests(httpHandler("GET", ctx, tectonicFactsHandler)))
 
 	// handlers_containerlinux.go
 	mux.Handle("/containerlinux/images/matchbox", logRequests(httpHandler("GET", ctx, listMatchboxImagesHandler)))
-	mux.Handle("/containerlinux/images/amis", logRequests(httpHandler("GET", ctx, listAMIImagesHandler)))
 
 	//handlers_latest_release.go
 	mux.Handle("/releases/latest", logRequests(httpHandler("GET", ctx, latestReleaseHandler)))

--- a/installer/api/handlers_containerlinux.go
+++ b/installer/api/handlers_containerlinux.go
@@ -40,13 +40,3 @@ func listMatchboxImagesHandler(w http.ResponseWriter, req *http.Request, _ *Cont
 
 	return writeJSONResponse(w, req, http.StatusOK, response)
 }
-
-// listAMIImagesHandler returns the list of available Container Linux AMIs.
-func listAMIImagesHandler(w http.ResponseWriter, req *http.Request, _ *Context) error {
-	amis, err := containerlinux.ListAMIImages(containerLinuxListTimeout)
-	if err != nil {
-		return newInternalServerError("Failed to query available images: %s", err)
-	}
-
-	return writeJSONResponse(w, req, http.StatusOK, amis)
-}

--- a/installer/api/handlers_tectonic.go
+++ b/installer/api/handlers_tectonic.go
@@ -347,9 +347,18 @@ func tectonicKubeconfigHandler(w http.ResponseWriter, req *http.Request, ctx *Co
 // tectonicFactsHandler gets a list of available Container Linux AMIs as well
 // as the Tectonic license and pull secret if they exist.
 func tectonicFactsHandler(w http.ResponseWriter, req *http.Request, ctx *Context) error {
-	amis, err := containerlinux.ListAMIImages(containerLinuxListTimeout)
-	if err != nil {
-		return newInternalServerError("Failed to query available images: %s", err)
+	var amis []containerlinux.AMI
+	var err error
+
+	// We only need the AMIs list if AWS is enabled
+	for _, platform := range ctx.Config.Platforms {
+		if platform == "aws-tf" {
+			amis, err = containerlinux.ListAMIImages(containerLinuxListTimeout)
+			if err != nil {
+				return newInternalServerError("Failed to query available images: %s", err)
+			}
+			break
+		}
 	}
 
 	ex, err := os.Executable()

--- a/installer/api/handlers_tectonic.go
+++ b/installer/api/handlers_tectonic.go
@@ -20,6 +20,7 @@ import (
 
 	"os"
 
+	"github.com/coreos/tectonic-installer/installer/pkg/containerlinux"
 	"github.com/coreos/tectonic-installer/installer/pkg/terraform"
 	"github.com/dghubble/sessions"
 )
@@ -341,4 +342,35 @@ func tectonicKubeconfigHandler(w http.ResponseWriter, req *http.Request, ctx *Co
 	w.Header().Set("Content-Type", "text/plain")
 	io.Copy(w, cfg)
 	return nil
+}
+
+// tectonicFactsHandler gets a list of available Container Linux AMIs as well
+// as the Tectonic license and pull secret if they exist.
+func tectonicFactsHandler(w http.ResponseWriter, req *http.Request, ctx *Context) error {
+	amis, err := containerlinux.ListAMIImages(containerLinuxListTimeout)
+	if err != nil {
+		return newInternalServerError("Failed to query available images: %s", err)
+	}
+
+	ex, err := os.Executable()
+	if err != nil {
+		return newInternalServerError("Could not retrieve Tectonic facts")
+	}
+
+	license, err := ioutil.ReadFile(filepath.Join(filepath.Dir(ex), "license.txt"))
+	if err != nil {
+		license = nil
+	}
+
+	pullSecret, err := ioutil.ReadFile(filepath.Join(filepath.Dir(ex), "pull_secret.json"))
+	if err != nil {
+		pullSecret = nil
+	}
+
+	type response struct {
+		AMIs       []containerlinux.AMI `json:"amis"`
+		License    string               `json:"license"`
+		PullSecret string               `json:"pullSecret"`
+	}
+	return writeJSONResponse(w, req, http.StatusOK, response{amis, string(license), string(pullSecret)})
 }

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -6,6 +6,7 @@ export const awsActionTypes = {
 };
 
 export const configActionTypes = {
+  ADD_IN: 'CONFIG_ACTION_ADD_IN',
   APPEND: 'CONFIG_ACTION_APPEND',
   REMOVE_AT: 'CONFIG_ACTION_REMOVE_AT',
   SET: 'CONFIG_ACTION_SIMPLE_SET',
@@ -64,6 +65,7 @@ export const FORMS = {};
 
 // TODO (ggreer) standardize on order of params. is dispatch first or last?
 export const configActions = {
+  addIn: (path, value, dispatch) => dispatch({payload: {path, value}, type: configActionTypes.ADD_IN}),
   set: (payload, dispatch) => dispatch({type: configActionTypes.SET, payload}),
   setIn: (path, value, dispatch) => dispatch({payload: {path, value}, type: configActionTypes.SET_IN}),
   batchSetIn: (dispatch, payload) => {

--- a/installer/frontend/components/aws-cluster-info.jsx
+++ b/installer/frontend/components/aws-cluster-info.jsx
@@ -2,14 +2,13 @@ import { connect } from 'react-redux';
 import React from 'react';
 
 import { Input, Connect } from './ui';
-import { TectonicLicense, licenseForm } from './tectonic-license';
+import { TectonicLicense } from './tectonic-license';
 import { AWS_Tags, tagsFields } from './aws-tags';
 import { Form } from '../form';
 import fields from '../fields';
 import { AWS_CLUSTER_INFO, CLUSTER_NAME } from '../cluster-config';
 
 const clusterInfoForm = new Form(AWS_CLUSTER_INFO, [
-  licenseForm,
   tagsFields,
   fields[CLUSTER_NAME],
 ]);
@@ -45,4 +44,5 @@ export const AWS_ClusterInfo = () => <div>
   <clusterInfoForm.Errors />
 </div>;
 
-AWS_ClusterInfo.canNavigateForward = clusterInfoForm.canNavigateForward;
+AWS_ClusterInfo.canNavigateForward = state => clusterInfoForm.canNavigateForward(state) &&
+  TectonicLicense.canNavigateForward(state);

--- a/installer/frontend/components/bm-cluster-info.jsx
+++ b/installer/frontend/components/bm-cluster-info.jsx
@@ -1,15 +1,12 @@
 import React from 'react';
 
 import { Input, Connect } from './ui';
-import { TectonicLicense, licenseForm } from './tectonic-license';
+import { TectonicLicense } from './tectonic-license';
 import { CLUSTER_NAME } from '../cluster-config';
 import { Form } from '../form';
 import fields from '../fields';
 
-const clusterInfoForm = new Form('BM_ClusterInfo', [
-  licenseForm,
-  fields[CLUSTER_NAME],
-]);
+const clusterInfoForm = new Form('BM_ClusterInfo', [fields[CLUSTER_NAME]]);
 
 export const BM_ClusterInfo = () => {
   return (
@@ -30,4 +27,5 @@ export const BM_ClusterInfo = () => {
   );
 };
 
-BM_ClusterInfo.canNavigateForward = clusterInfoForm.canNavigateForward;
+BM_ClusterInfo.canNavigateForward = state => clusterInfoForm.canNavigateForward(state) &&
+  TectonicLicense.canNavigateForward(state);

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -130,6 +130,13 @@ const reducersTogether = combineReducers({
       });
       return object.toJS();
     }
+
+    // Adds a value at a given path or no-op if a value already for the path
+    case configActionTypes.ADD_IN:
+      return _.isEmpty(_.get(state, action.payload.path))
+        ? setIn(state, action.payload.path, action.payload.value)
+        : state;
+
     case configActionTypes.SET_IN:
       return setIn(state, action.payload.path, action.payload.value);
 

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 
-import { getTectonicDomain, toAWS_TF, toBaremetal_TF, DRY_RUN, RETRY } from './cluster-config';
+import { getTectonicDomain, toAWS_TF, toBaremetal_TF, DRY_RUN, PULL_SECRET, RETRY, TECTONIC_LICENSE } from './cluster-config';
 import { clusterReadyActionTypes, configActions, loadFactsActionTypes, serverActionTypes, FORMS } from './actions';
 import { savable } from './reducer';
 import { AWS_TF, BARE_METAL_TF } from './platforms';
 
-const { setIn } = configActions;
+const { addIn, setIn } = configActions;
 
 // Either return parsable JSON, or fail (and assume returned text is an error message)
 const fetchJSON = (url, opts, ...args) => {
@@ -108,12 +108,15 @@ export const commitToServer = (dryRun = false, retry = false, opts = {}) => (dis
   });
 };
 
-// One-time fetch of AMIs from server, followed by firing appropriate actions
+// One-time fetch of initial data from server, followed by firing appropriate actions
 // Guaranteed not to reject.
-const getAMIs = (dispatch) => {
-  return fetchJSON('/containerlinux/images/amis', { retries: 5 })
+export const loadFacts = (dispatch) => {
+  return fetchJSON('/tectonic/facts', { retries: 5 })
     .then(m => {
-      const awsRegions = m.map(({name}) => {
+      addIn(TECTONIC_LICENSE, m.license, dispatch);
+      addIn(PULL_SECRET, m.pullSecret, dispatch);
+
+      const awsRegions = m.amis.map(({name}) => {
         return {label: name, value: name};
       });
       dispatch({
@@ -127,14 +130,4 @@ const getAMIs = (dispatch) => {
         payload: err,
       });
     }).catch(err => console.error(err));
-};
-
-// One-time fetch of facts from server. Abstracts getAMIs.
-// Guaranteed not to reject.
-export const loadFacts = (dispatch) => {
-  if (_.includes(window.config.platforms, AWS_TF)) {
-    return getAMIs(dispatch);
-  }
-  dispatch({type: loadFactsActionTypes.LOADED, payload: {}});
-  return Promise.resolve();
 };

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -116,7 +116,7 @@ export const loadFacts = (dispatch) => {
       addIn(TECTONIC_LICENSE, m.license, dispatch);
       addIn(PULL_SECRET, m.pullSecret, dispatch);
 
-      const awsRegions = m.amis.map(({name}) => {
+      const awsRegions = _.map(m.amis, ({name}) => {
         return {label: name, value: name};
       });
       dispatch({

--- a/installer/frontend/ui-tests/pages/clusterInfoPage.js
+++ b/installer/frontend/ui-tests/pages/clusterInfoPage.js
@@ -4,13 +4,13 @@ const path = require('path');
 const clusterInfoPageCommands = {
   test(json, platform) {
     const parentDir = path.resolve(__dirname, '..');
-    const coreOSLicensePath = path.join(parentDir, 'tectonic-license.txt');
+    const licensePath = path.join(parentDir, 'tectonic-license.txt');
     const configPath = path.join(parentDir, 'config.json');
 
     /* eslint-disable no-sync */
     const tectonic_license = fs.readFileSync(process.env.TF_VAR_tectonic_license_path, 'utf8');
     const pull_secret = fs.readFileSync(process.env.TF_VAR_tectonic_pull_secret_path, 'utf8');
-    fs.writeFileSync(coreOSLicensePath, tectonic_license);
+    fs.writeFileSync(licensePath, tectonic_license);
     fs.writeFileSync(configPath, pull_secret);
     /* eslint-enable no-sync */
 
@@ -25,7 +25,7 @@ const clusterInfoPageCommands = {
     this.setField('@name', json.tectonic_cluster_name);
     this.expectNoValidationError();
 
-    this.setValue('@coreOSLicenseUpload', coreOSLicensePath);
+    this.setValue('@licenseUpload', licensePath);
     this.setValue('@pullSecretUpload', configPath);
 
     if (platform === 'aws') {
@@ -47,13 +47,7 @@ module.exports = {
   commands: [clusterInfoPageCommands],
   elements: {
     name: 'input#clusterName',
-    coreOSLicenseUpload: {
-      selector: '//*[text()[contains(.,"tectonic-license.txt")]]/input[@type="file"]',
-      locateStrategy: 'xpath',
-    },
-    pullSecretUpload: {
-      selector: '//*[text()[contains(.,"config.json")]]/input[@type="file"]',
-      locateStrategy: 'xpath',
-    },
+    licenseUpload: 'input[type="file"]#tectonicLicense',
+    pullSecretUpload: 'input[type="file"]#pullSecret',
   },
 };


### PR DESCRIPTION
Replaces the `/containerlinux/images/amis` API endpoint with a `/tectonic/facts`, which includes all of the initial data needed by the GUI.

Also removes the `textarea`s for the license and pull secret inputs.

The license file / pull secret directory will be made configurable via a command line option / environment variable in a future PR.

Values in state override those returned by `/tectonic/facts`, so
- Uploading a progress file can override any license / pull secret files on disk
- Uploading a different file, then refreshing the page will keep the uploaded file

### AWS
![screenshot-2](https://user-images.githubusercontent.com/460802/31366320-47dab9f0-adab-11e7-8246-589436cf7b63.png)

### Bare Metal
![screenshot-1](https://user-images.githubusercontent.com/460802/31366324-4b373f88-adab-11e7-8bfe-2b787ddc4300.png)