### PR TITLE
Bump console to v2.2.2.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -58,7 +58,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.6.2"
     calico                       = "quay.io/calico/node:v2.4.1"
     calico_cni                   = "quay.io/calico/cni:v1.10.0"
-    console                      = "quay.io/coreos/tectonic-console:v2.2.1"
+    console                      = "quay.io/coreos/tectonic-console:v2.2.2"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
Works around a memory leak on the log page. Root cause is a bug in v8: https://bugs.chromium.org/p/v8/issues/detail?id=2869
