### PR TITLE
Bump console to v2.2.3.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -58,7 +58,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.6.2"
     calico                       = "quay.io/calico/node:v2.4.1"
     calico_cni                   = "quay.io/calico/cni:v1.10.0"
-    console                      = "quay.io/coreos/tectonic-console:v2.1.1"
+    console                      = "quay.io/coreos/tectonic-console:v2.2.3"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
- Fix API version for service monitor & alert manager templates. (https://github.com/coreos-inc/bridge/pull/1798)
- Fix infinite loop when filtering pods for a given node. (https://github.com/coreos-inc/bridge/pull/1801)
- Fix memory leak on logs page. (https://github.com/coreos-inc/bridge/pull/1800)
- Fix https://coreosdev.atlassian.net/browse/TECREL-113