### PR TITLE
kvo: bump to v1.7.5-kvo.12

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -73,7 +73,7 @@ variable "tectonic_container_images" {
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
-    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.5-kvo.10"
+    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.5-kvo.12"
     node_agent                   = "quay.io/coreos/node-agent:v1.7.5-kvo.3"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:3517908b1a1837e78cfd041a0e51e61c7835d85f"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"

--- a/modules/update-payload/payload.json
+++ b/modules/update-payload/payload.json
@@ -125,7 +125,7 @@
                   "--cache-images=true",
                   "--version-mapping=/upgrade-spec.json"
                 ],
-                "image": "quay.io/coreos/kube-version-operator:v1.7.5-kvo.10",
+                "image": "quay.io/coreos/kube-version-operator:v1.7.5-kvo.12",
                 "name": "kube-version-operator"
               }
             ],


### PR DESCRIPTION
Fixes upgrades failing from as-yet-unreleased `1.7.3+tectonic.4`.
Also bumps console to `v2.2.3`