### PR TITLE
azure: make vnet subnet cidr extend bits configurable

### DIFF
--- a/modules/azure/vnet/variables.tf
+++ b/modules/azure/vnet/variables.tf
@@ -28,6 +28,10 @@ variable "vnet_cidr_block" {
   type = "string"
 }
 
+variable "vnet_cidr_block_subnet_extend_bits" {
+  type = "string"
+}
+
 variable "location" {
   type = "string"
 }

--- a/modules/azure/vnet/vnet-subnets.tf
+++ b/modules/azure/vnet/vnet-subnets.tf
@@ -16,7 +16,7 @@ resource "azurerm_subnet" "master_subnet" {
   name                      = "${var.cluster_name}_master_subnet"
   resource_group_name       = "${var.external_vnet_id == "" ? var.resource_group_name : replace(var.external_vnet_id, "${var.const_id_to_group_name_regex}", "$1")}"
   virtual_network_name      = "${var.external_vnet_id == "" ? join("",azurerm_virtual_network.tectonic_vnet.*.name) : replace(var.external_vnet_id, "${var.const_id_to_group_name_regex}", "$2")}"
-  address_prefix            = "${cidrsubnet(var.vnet_cidr_block, 4, 0)}"
+  address_prefix            = "${cidrsubnet(var.vnet_cidr_block, var.vnet_cidr_block_subnet_extend_bits, 0)}"
   network_security_group_id = "${var.external_nsg_master_id == "" ? azurerm_network_security_group.master.id : var.external_nsg_master_id}"
 }
 
@@ -25,6 +25,6 @@ resource "azurerm_subnet" "worker_subnet" {
   name                      = "${var.cluster_name}_worker_subnet"
   resource_group_name       = "${var.external_vnet_id == "" ? var.resource_group_name : replace(var.external_vnet_id, "${var.const_id_to_group_name_regex}", "$1")}"
   virtual_network_name      = "${var.external_vnet_id == "" ? join("",azurerm_virtual_network.tectonic_vnet.*.name) : replace(var.external_vnet_id, "${var.const_id_to_group_name_regex}", "$2") }"
-  address_prefix            = "${cidrsubnet(var.vnet_cidr_block, 4, 1)}"
+  address_prefix            = "${cidrsubnet(var.vnet_cidr_block, var.vnet_cidr_block_subnet_extend_bits, 1)}"
   network_security_group_id = "${var.external_nsg_worker_id == "" ? azurerm_network_security_group.worker.id : var.external_nsg_worker_id}"
 }

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -19,12 +19,13 @@ module "resource_group" {
 module "vnet" {
   source = "../../modules/azure/vnet"
 
-  location            = "${var.tectonic_azure_location}"
-  resource_group_name = "${module.resource_group.name}"
-  cluster_name        = "${var.tectonic_cluster_name}"
-  cluster_id          = "${module.tectonic.cluster_id}"
-  base_domain         = "${var.tectonic_base_domain}"
-  vnet_cidr_block     = "${var.tectonic_azure_vnet_cidr_block}"
+  location                           = "${var.tectonic_azure_location}"
+  resource_group_name                = "${module.resource_group.name}"
+  cluster_name                       = "${var.tectonic_cluster_name}"
+  cluster_id                         = "${module.tectonic.cluster_id}"
+  base_domain                        = "${var.tectonic_base_domain}"
+  vnet_cidr_block                    = "${var.tectonic_azure_vnet_cidr_block}"
+  vnet_cidr_block_subnet_extend_bits = "${var.vnet_cidr_block_subnet_extend_bits}"
 
   etcd_count           = "${local.etcd_count}"
   master_count         = "${var.tectonic_master_count}"

--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -111,6 +111,15 @@ service range or a private datacenter connected via ExpressRoute."
 EOF
 }
 
+variable "tectonic_azure_vnet_cidr_block" {
+  type    = "string"
+  default = "4"
+
+  description = <<EOF
+(optional) Bits to extend the given Virtual Network CIDR block prefix to split into the master and worker subnets.
+EOF
+}
+
 variable "tectonic_azure_external_vnet_id" {
   type    = "string"
   default = ""


### PR DESCRIPTION
I don't really know if this is useful to anyone else or not. But when I spun up a cluster in Azure on a smaller CIDR than a `/16`, this ran into problems because it expect to just extend it by 4 by default. It's not an even split. So I made it configurable. 

However, I probably will go down the route of making my own subnets instead.