### PR TITLE
frontend: Add warning if pod IP range might conflict with Docker Bridge

### DIFF
--- a/installer/frontend/components/k8s-cidrs.jsx
+++ b/installer/frontend/components/k8s-cidrs.jsx
@@ -46,12 +46,12 @@ const PodRangeWarning = connect(
 
   if (utilization > 1) {
     return <Alert severity="error">
-      <b>Pod Range Too Small</b><br />
+      <b>Pod range too small</b><br />
       {maxNodes === 0 ? 'No nodes' : `Only ${maxNodes} of your ${nodes} ${pluralize('node', nodes)}`} can fit within the pod range, since each node requires a minimum of 256 IP addresses.
     </Alert>;
   }
   return <Alert>
-    <b>Pod Range Mostly Assigned</b><br />
+    <b>Pod range mostly assigned</b><br />
     Only {maxNodes} {pluralize('node', maxNodes)} can fit within the pod range, since each node requires a minimum of 256 IP addresses. You have selected {nodes} {pluralize('node', nodes)}.
   </Alert>;
 });

--- a/installer/frontend/ui-tests/pages/networkConfigurationPage.js
+++ b/installer/frontend/ui-tests/pages/networkConfigurationPage.js
@@ -10,11 +10,11 @@ const pageCommands = {
     this.setField('#podCIDR', '10.2.0.0/22');
     this.expectNoValidationError();
     this.expect.element('@alertError').to.not.be.present;
-    this.expect.element('@alertWarning').text.to.contain('Pod Range Mostly Assigned');
+    this.expect.element('@alertWarning').text.to.contain('Pod range mostly assigned');
 
     this.setField('#podCIDR', '10.2.0.0/23');
     this.expectNoValidationError();
-    this.expect.element('@alertError').text.to.contain('Pod Range Too Small');
+    this.expect.element('@alertError').text.to.contain('Pod range too small');
     this.expect.element('@alertWarning').to.not.be.present;
 
     this.setField('#podCIDR', json.podCIDR);

--- a/installer/frontend/ui-tests/pages/networkConfigurationPage.js
+++ b/installer/frontend/ui-tests/pages/networkConfigurationPage.js
@@ -1,33 +1,57 @@
+const testDockerBridgeValidation = page => {
+  page.setField('#podCIDR', '172.17.0.0/16');
+  page.expectValidationErrorContains('Overlaps with default Docker Bridge subnet (172.17.0.0/16)');
+  page.expect.element('@alertErrorTitle').to.not.be.present;
+  page.expect.element('@alertWarningTitle').to.not.be.present;
+
+  ['172.18.0.0', '172.31.255.255', '192.168.0.0', '192.168.15.255'].forEach(ip => {
+    page.setField('#podCIDR', `${ip}/16`);
+    page.expectNoValidationError();
+    page.expect.element('@alertErrorTitle').to.not.be.present;
+    page.expect.element('@alertWarningTitle').text.to.equal('Pod range may conflict with Docker Bridge subnet');
+  });
+
+  ['172.32.0.0', '192.168.16.0'].forEach(ip => {
+    page.setField('#podCIDR', `${ip}/16`);
+    page.expectNoValidationError();
+    page.expect.element('@alertErrorTitle').to.not.be.present;
+    page.expect.element('@alertWarningTitle').to.not.be.present;
+  });
+};
+
 const pageCommands = {
   test(json) {
     this.setField('#serviceCIDR', json.serviceCIDR);
 
     this.setField('#podCIDR', '10.2.0.0/21');
     this.expectNoValidationError();
-    this.expect.element('@alertError').to.not.be.present;
-    this.expect.element('@alertWarning').to.not.be.present;
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').to.not.be.present;
 
     this.setField('#podCIDR', '10.2.0.0/22');
     this.expectNoValidationError();
-    this.expect.element('@alertError').to.not.be.present;
-    this.expect.element('@alertWarning').text.to.contain('Pod range mostly assigned');
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').text.to.equal('Pod range mostly assigned');
 
     this.setField('#podCIDR', '10.2.0.0/23');
     this.expectNoValidationError();
-    this.expect.element('@alertError').text.to.contain('Pod range too small');
-    this.expect.element('@alertWarning').to.not.be.present;
+    this.expect.element('@alertErrorTitle').text.to.equal('Pod range too small');
+    this.expect.element('@alertWarningTitle').to.not.be.present;
+
+    testDockerBridgeValidation(this);
 
     this.setField('#podCIDR', json.podCIDR);
     this.expectNoValidationError();
-    this.expect.element('@alertError').to.not.be.present;
-    this.expect.element('@alertWarning').to.not.be.present;
+    this.expect.element('@alertErrorTitle').to.not.be.present;
+    this.expect.element('@alertWarningTitle').to.not.be.present;
   },
 };
 
 module.exports = {
   commands: [pageCommands],
   elements: {
-    alertWarning: '.alert-info',
-    alertError: '.alert-error',
+    alertWarningTitle: '.alert-info b',
+    alertErrorTitle: '.alert-error b',
   },
+  testDockerBridgeValidation,
 };

--- a/installer/frontend/ui-tests/pages/networkingPage.js
+++ b/installer/frontend/ui-tests/pages/networkingPage.js
@@ -15,16 +15,16 @@ const pageCommands = {
     this.setField('#podCIDR', '10.2.0.0/21');
     this.expectNoValidationError();
     this.expect.element('@alertErrorTitle').to.not.be.present;
-    this.expect.element('@alertWarningTitle').text.to.equal('Pod Range Mostly Assigned');
+    this.expect.element('@alertWarningTitle').text.to.equal('Pod range mostly assigned');
 
     this.setField('#podCIDR', '10.2.0.0/22');
     this.expectNoValidationError();
-    this.expect.element('@alertErrorTitle').text.to.equal('Pod Range Too Small');
+    this.expect.element('@alertErrorTitle').text.to.equal('Pod range too small');
     this.expect.element('@alertWarningTitle').to.not.be.present;
 
     this.setField('#podCIDR', '10.2.0.0/29');
     this.expectValidationErrorContains('AWS subnets must be between /16 and /28');
-    this.expect.element('@alertErrorTitle').text.to.equal('Pod Range Too Small');
+    this.expect.element('@alertErrorTitle').text.to.equal('Pod range too small');
     this.expect.element('@alertWarningTitle').to.not.be.present;
 
     this.setField('#podCIDR', json.podCIDR);

--- a/installer/frontend/ui-tests/pages/networkingPage.js
+++ b/installer/frontend/ui-tests/pages/networkingPage.js
@@ -1,3 +1,5 @@
+const networkConfigurationPage = require('./networkConfigurationPage');
+
 const pageCommands = {
   testCidrInputs(json) {
     this.setField('#serviceCIDR', json.serviceCIDR);
@@ -26,6 +28,8 @@ const pageCommands = {
     this.expectValidationErrorContains('AWS subnets must be between /16 and /28');
     this.expect.element('@alertErrorTitle').text.to.equal('Pod range too small');
     this.expect.element('@alertWarningTitle').to.not.be.present;
+
+    networkConfigurationPage.testDockerBridgeValidation(this);
 
     this.setField('#podCIDR', json.podCIDR);
     this.expectNoValidationError();


### PR DESCRIPTION
This just adds a warning message. It is still possible to ignore the warning and continue with the installation.

Also changes the other alert message titles on the same page to sentence case.

### Bare Metal
![screenshot-1](https://user-images.githubusercontent.com/460802/31423385-7991201c-ae8f-11e7-9886-0abd54e4f92d.png)

### AWS
Shown here along with the separate "IP range too small" warning.

![screenshot-2](https://user-images.githubusercontent.com/460802/31423383-7784a35c-ae8f-11e7-9eb7-576ff1d0ad3a.png)