### PR TITLE
frontend: Clean up use of configActions' set() and setIn()

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -69,6 +69,7 @@ export const FORMS = {};
 
 // TODO (ggreer) standardize on order of params. is dispatch first or last?
 export const configActions = {
+  set: (payload, dispatch) => dispatch({type: configActionTypes.SET, payload}),
   setIn: (path, value, dispatch) => dispatch({payload: {path, value}, type: configActionTypes.SET_IN}),
   batchSetIn: (dispatch, payload) => {
     const values = dispatch({payload, type: configActionTypes.BATCH_SET_IN});

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 
-import { configActionTypes, eventErrorsActionTypes } from '../actions';
+import { configActions, eventErrorsActionTypes } from '../actions';
 import { Field, Form } from '../form';
 import { compareVersions } from '../utils';
 import { validate } from '../validate';
@@ -39,20 +39,14 @@ const dispatchToProps = dispatch => ({
         error: null,
       },
     });
-    dispatch({
-      type: configActionTypes.SET,
-      payload: {matchboxHTTP: value},
-    });
+    configActions.set({matchboxHTTP: value}, dispatch);
   },
   getOsToUse: matchboxHTTP => {
     if (validate.hostPort(matchboxHTTP)) {
       return;
     }
 
-    dispatch({
-      type: configActionTypes.SET,
-      payload: {bootCfgInfly: true},
-    });
+    configActions.set({bootCfgInfly: true}, dispatch);
 
     const endpointURL = `http://${matchboxHTTP}/assets/coreos`;
     return fetch(`/containerlinux/images/matchbox?endpoint=${encodeURIComponent(endpointURL)}`)
@@ -70,11 +64,7 @@ const dispatchToProps = dispatch => ({
         }
 
         const useVersion = available.map(v => v.version).sort(compareVersions).pop();
-
-        dispatch({
-          type: configActionTypes.SET,
-          payload: {[BM_OS_TO_USE]: useVersion},
-        });
+        configActions.set({[BM_OS_TO_USE]: useVersion}, dispatch);
 
         return Promise.resolve(true);
       })
@@ -86,12 +76,9 @@ const dispatchToProps = dispatch => ({
             error: err,
           },
         });
-        dispatch({
-          type: configActionTypes.SET,
-          payload: {[BM_OS_TO_USE]: DEFAULT_CLUSTER_CONFIG[BM_OS_TO_USE]},
-        });
+        configActions.set({[BM_OS_TO_USE]: DEFAULT_CLUSTER_CONFIG[BM_OS_TO_USE]}, dispatch);
       })
-      .then(() => dispatch({type: configActionTypes.SET, payload: {bootCfgInfly: false}}));
+      .then(() => configActions.set({bootCfgInfly: false}, dispatch));
   },
 });
 

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -557,14 +557,7 @@ const stateToIsDeselected = ({clusterConfig}, {field}) => {
 
 export const Deselect = connect(
   stateToIsDeselected,
-  dispatch => ({
-    setField: (k, v) => {
-      dispatch({
-        type: configActionTypes.SET_IN,
-        payload: {value: v, path: k},
-      });
-    },
-  })
+  dispatch => ({setField: (k, v) => configActions.setIn(k, v, dispatch)})
 )(({field, isDeselected, setField}) => <span className="deselect">
   <CheckBox id={field} value={!isDeselected} onValue={v => setField(field, !v)} />
 </span>);

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -335,7 +335,7 @@ const stateToProps = ({clusterConfig, dirty}, {field}) => ({
 });
 
 const dispatchToProps = (dispatch, {field}) => ({
-  setField: (path, value, invalid) => dispatch(configActions.updateField(path, value, invalid)),
+  updateField: (path, value, invalid) => dispatch(configActions.updateField(path, value, invalid)),
   makeDirty: () => markIDDirty(dispatch, field),
   makeClean: () => dispatch({type: dirtyActionTypes.CLEAN, payload: field }),
   refreshExtraData: () => dispatch(configActions.refreshExtraData(field)),
@@ -345,10 +345,10 @@ const dispatchToProps = (dispatch, {field}) => ({
 
 class Connect_ extends React.Component {
   handleValue (v) {
-    const { children, field, setField } = this.props;
+    const { children, field, updateField } = this.props;
     const child = React.Children.only(children);
 
-    setField(field, v);
+    updateField(field, v);
     if (child.props.onValue) {
       child.props.onValue(v);
     }


### PR DESCRIPTION
Add `configActions.set()` and use where possible.

Change `Deselect` component to use `configActions.setIn()`.

Rename `setField()` to `updateField()` to show that it is different from the other `setField()` functions defined in the same file.