### PR TITLE
modules/ignition: ensure --cloud-provider is set

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -32,7 +32,7 @@ data "template_file" "kubelet" {
   template = "${file("${path.module}/resources/services/kubelet.service")}"
 
   vars {
-    cloud_provider        = "${var.cloud_provider != "" ? "--cloud-provider=${var.cloud_provider}" : ""}"
+    cloud_provider        = "${var.cloud_provider}"
     cloud_provider_config = "${var.cloud_provider_config != "" ? "--cloud-config=/etc/kubernetes/cloud/config" : ""}"
     cluster_dns_ip        = "${var.kube_dns_service_ip}"
     cni_bin_dir_flag      = "${var.kubelet_cni_bin_dir != "" ? "--cni-bin-dir=${var.kubelet_cni_bin_dir}" : ""}"

--- a/modules/ignition/resources/services/kubelet.service
+++ b/modules/ignition/resources/services/kubelet.service
@@ -36,7 +36,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster-dns=${cluster_dns_ip} \
   --cluster-domain=cluster.local \
   --client-ca-file=/etc/kubernetes/ca.crt \
-  ${cloud_provider} \
+  --cloud-provider=${cloud_provider} \
   ${cloud_provider_config} \
   --anonymous-auth=false
 


### PR DESCRIPTION
The default behavior of the kubelet's `--cloud-provider` flag is
changing in the upcomint k8s releases:

* v1.8 - auto detection of cloud provider using cAdvisor is deprecated but
still remains the default.
* v1.9 - auto detection of cloudprovider is still supported but no longer
the default, the new default will be no provider.
* v1.10 - auto detecting cloud provider is removed

For consistent non-autodetection behavior we need to ensure that we
always set the cloud-provider flag, even if it is explicitly set to no
provider.

cc @s-urbaniak @aaronlevy 