### PR TITLE
tests/rspec: re-factor cl version

### DIFF
--- a/tests/rspec/lib/container_linux.rb
+++ b/tests/rspec/lib/container_linux.rb
@@ -2,7 +2,7 @@
 
 require 'ssh'
 
-SSH_CMD_CONTAINER_LINUX_VERSION = 'source /usr/share/coreos/release && echo "$COREOS_RELEASE_VERSION"'
+SSH_CMD_CONTAINER_LINUX_VERSION = 'sudo cat /var/lib/update_engine/prefs/aleph-version'
 SSH_CMD_CONTAINER_LINUX_CHANNEL = 'for conf in /usr/share/coreos/update.conf /etc/coreos/update.conf ; \
 do [ -f "$conf" ] && source "$conf" ; done ; echo "$GROUP"'
 

--- a/tests/rspec/lib/ssh.rb
+++ b/tests/rspec/lib/ssh.rb
@@ -12,18 +12,28 @@ def ssh_agent_has_key?
   system('ssh-add -l')
 end
 
-def ssh_exec(ip_address, command)
+def ssh_exec(ip_address, command, max_retries = 5)
+  retries = 0
   status = {}
   stdout = ''
   stderr = ''
-  Net::SSH.start(ip_address, 'core', forward_agent: true, use_agent: true) do |ssh|
-    ssh.exec! command, status: status do |_ch, stream, data|
-      if stream == :stdout
-        stdout = data
-      else
-        stderr = data
+  begin
+    Net::SSH.start(ip_address, 'core', forward_agent: true, use_agent: true) do |ssh|
+      ssh.exec! command, status: status do |_ch, stream, data|
+        if stream == :stdout
+          stdout = data
+        else
+          stderr = data
+        end
       end
     end
+  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, IOError, Net::SSH::ConnectionTimeout, Net::SSH::Disconnect
+    raise "failed to exec '#{command}' in #{max_retries} retries" if retries >= max_retries
+    retries += 1
+    sleep_time = 5 * retries
+    puts "failed to exec '#{command}'; retrying in #{sleep_time} seconds"
+    sleep sleep_time
+    retry
   end
   [stdout, stderr, status[:exit_code]]
 end

--- a/tests/smoke/aws/vars/aws.tfvars.json
+++ b/tests/smoke/aws/vars/aws.tfvars.json
@@ -9,7 +9,6 @@
     "tectonic_ca_key": "",
     "tectonic_container_linux_channel": "stable",
     "tectonic_container_linux_version": "1465.6.0",
-    "tectonic_bootstrap_upgrade_cl": "false",
     "tectonic_etcd_count": "3",
     "tectonic_etcd_servers": [""],
     "tectonic_master_count": "2",


### PR DESCRIPTION
Make the Container Linux version getter resistant to races against CLUO.
By reading /var/lib/update_engine/prefs/aleph-version, we can be sure
that no matter if CLUO runs before or after the SSH command, we will
always know the version of the OS at installation time.

This commit also adds rescues to the SSH commands to ensure that the
executions will be retried if the node is rebooted by CLUO during the
test.

cc @alexsomesan 