### PR TITLE
Enable PodSecurityPolicy by default

### DIFF
--- a/modules/bootkube/resources/manifests/02-permissive-policy.yaml
+++ b/modules/bootkube/resources/manifests/02-permissive-policy.yaml
@@ -1,0 +1,158 @@
+---
+# Permissive policy allowing for any pod to run.
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: system-tectonic-permissive
+spec:
+  privileged: true
+  hostNetwork: true
+  hostPID: true
+  hostIPC: true
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  hostPorts:
+  - min: 0
+    max: 65535
+  volumes:
+  - '*'
+  allowedCapabilities:
+  - '*'
+
+---
+# Limited policy notably preventing privileged containers and containers wish to use host networking.
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: system-tectonic-limited
+spec:
+  privileged: false
+  hostNetwork: false
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  volumes:
+  - '*' 
+  allowedCapabilities: 
+  - '*'
+
+---
+# Role allowing the usage of full permissive PSP
+# Should be bound by a RoleBinding inside of kube-system and tectonic-system
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: permissive-psp-access
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["system-tectonic-permissive"]
+    verbs: ["use"]
+
+---
+# Role allowing the usage of limited PSP
+# Should be bound by a ClusterRoleBinding for the controller-manager to ensure it has this PSP
+# to resolve to by default.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: limited-psp-access
+rules:
+  - apiGroups: ["extensions"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["system-tectonic-limited"]
+    verbs: ["use"]
+
+---
+# Allow kube-controller-manager to have permissive PSP access in tectonic-system namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: permissive-psp-access
+  namespace: tectonic-system
+subjects:
+- kind: ServiceAccount
+  name: replicaset-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: replication-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: job-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: daemonset-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: statefulset-controller
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: permissive-psp-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Allow kube-controller-manager to have permissive PSP access in kube-system namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: permissive-psp-access
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: replicaset-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: replication-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: job-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: daemon-set-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: statefulset-controller
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: permissive-psp-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Allow kube-controller-manager to have limit PSP access in all namespaces
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: limited-psp-access
+subjects:
+- kind: ServiceAccount
+  name: replicaset-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: replication-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: job-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: daemon-set-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: statefulset-controller
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: limited-psp-access
+  apiGroup: rbac.authorization.k8s.io

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -41,7 +41,7 @@ spec:
         - --storage-backend=etcd3
         - --allow-privileged=true
         - --service-cluster-ip-range=${service_cidr}
-        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
+        - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,PodSecurityPolicy
         - --tls-ca-file=/etc/kubernetes/secrets/ca.crt
         - --tls-cert-file=/etc/kubernetes/secrets/apiserver.crt
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -49,6 +49,7 @@ spec:
         - --node-monitor-grace-period=${node_monitor_grace_period}
         - --pod-eviction-timeout=${pod_eviction_timeout}
         - --cloud-provider=${cloud_provider}
+        - --use-service-account-credentials
         ${cloud_provider_config_flag}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This commit enables the PodSecurityPolicy (PSP) admission controller in
Tectonic by amending it to the admission-controller flag of the
kube-apiserver. The --use-service-account-credentials flag has been added to the
kube-controller-manager, ensuring it runs with all individual
ServiceAccounts provided by k8s [0].

A 'permissive' and 'limited' PSP have been added for use by the
kube-controller-manager. The permissive PSP has no restrictions on
pods to create. The limited policy is the same as permissive with
the following added restrictions.

  - Pods may not run as privileged [1]
  - Pods may not run using host networking [2]

A ClusterRole allowing the verb 'use' for each PSP resource ('permissive',
'limited') has been created for binding to. Binding to means the
ServiceAccount will be able to resolve against that PSP when attempting
to create a pod. A ClusterRoleBinding has been created for the
limited PSP ClusterRole. Making all pod creations in all namespaces
require to match the rules set in the limited PSP. RoleBindings have
been created in kube-system and tectonic-system for the permissive PSP.
Making all pods created in the kube-system or tectonic-system namespace
able to resolve against the permissive PSP, containing no restrictions.
All mentioned bindings include the Subjects for every ServiceAccount
that uses the 'create' verb on the 'pod' resource. The following
ServiceAccounts (from the kube-system namespace) are bound.

  - replicaset-controller
  - replication-controller
  - job-controller
  - daemon-set-controller
  - statefulset-controller

This change will prevent users from being able to create pods in
namespaces as their user account won't have access to 'use' any PSP.
They will have to rely on high-level constructs, which they normally
would, to create pods such as StatefulSets or Deployments. When rights
are desired beyond that of the limited PSP, admins will need to add new
PSPs and likely change RBAC rules [3].

Resolves: #2101

[0]: https://kubernetes.io/docs/admin/authorization/rbac/#controller-roles
[1]: https://kubernetes.io/docs/concepts/workloads/pods/pod/#privileged-mode-for-pod-containers
[2]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-network
[3]: https://github.com/kubernetes/examples/blob/master/staging/podsecuritypolicy/rbac/README.md

## TODO:

- Documentation