### PR TITLE
azure/vnet: Update Ingress LB name to `<cluster>-tectonic-lb`

### DIFF
--- a/modules/azure/vnet/lb-console.tf
+++ b/modules/azure/vnet/lb-console.tf
@@ -25,7 +25,7 @@ resource "azurerm_lb_rule" "console_lb_https" {
   protocol                       = "tcp"
   frontend_port                  = 443
   backend_port                   = 32000
-  frontend_ip_configuration_name = "console"
+  frontend_ip_configuration_name = "tectonic-console"
 }
 
 resource "azurerm_lb_rule" "console_lb_identity" {
@@ -40,7 +40,7 @@ resource "azurerm_lb_rule" "console_lb_identity" {
   protocol                       = "tcp"
   frontend_port                  = 80
   backend_port                   = 32001
-  frontend_ip_configuration_name = "console"
+  frontend_ip_configuration_name = "tectonic-console"
 }
 
 resource "azurerm_lb_probe" "console_lb" {

--- a/modules/azure/vnet/lb.tf
+++ b/modules/azure/vnet/lb.tf
@@ -1,7 +1,7 @@
 resource "azurerm_lb" "tectonic_lb" {
   count = "${var.private_cluster ? 0 : 1}"
 
-  name                = "${var.cluster_name}-api-lb"
+  name                = "${var.cluster_name}-tectonic-lb"
   location            = "${var.location}"
   resource_group_name = "${var.resource_group_name}"
 
@@ -12,13 +12,13 @@ resource "azurerm_lb" "tectonic_lb" {
   }
 
   frontend_ip_configuration {
-    name                          = "console"
+    name                          = "tectonic-console"
     public_ip_address_id          = "${join("" , azurerm_public_ip.console_ip.*.id)}"
     private_ip_address_allocation = "dynamic"
   }
 
   tags = "${merge(map(
-    "Name", "${var.cluster_name}-api-lb",
+    "Name", "${var.cluster_name}-tectonic-lb",
     "tectonicClusterID", "${var.cluster_id}"),
     var.extra_tags)}"
 }


### PR DESCRIPTION
This is a small change to clarify the primary purpose for the load balancer in Azure i.e., to front Tectonic Console and Tectonic Identity.

Originally, the name of the load balancer was `${var.cluster_name}-api-lb` which is misleading, especially in Azure private implementation instances (where the load balancer is not used to front the Kubernetes API).