### PR TITLE
frontend: Remove unused "sequenceActionTypes"

### DIFF
--- a/installer/frontend/__tests__/examples/tectonic-baremetal.progress
+++ b/installer/frontend/__tests__/examples/tectonic-baremetal.progress
@@ -44,6 +44,5 @@
       "channel": "tectonic-1.6",
       "appID": "6bc7b986-4654-4a0f-94b3-84ce6feb1db4"
     }
-  },
-  "sequence": 4
+  }
 }

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -39,10 +39,6 @@ export const restoreActionTypes = {
   RESTORE_STATE: 'RESTORE_RESTORE_STATE',
 };
 
-export const sequenceActionTypes = {
-  INCREMENT: 'SEQUENCE_INCREMENT',
-};
-
 export const serverActionTypes = {
   COMMIT_REQUESTED: 'COMMIT_REQUESTED',
   COMMIT_SENT: 'COMMIT_SENT',

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -15,7 +15,6 @@ import {
   loadFactsActionTypes,
   restoreActionTypes,
   serverActionTypes,
-  sequenceActionTypes,
   commitPhases,
 } from './actions';
 
@@ -299,20 +298,6 @@ const reducersTogether = combineReducers({
       return state;
     }
   },
-
-  // A value guaranteed to monotonically increase. Should be saved/restored.
-  sequence: (state, action) => {
-    if (state === undefined) {
-      return 0;
-    }
-
-    switch (action.type) {
-    case sequenceActionTypes.INCREMENT:
-      return state + 1;
-    default:
-      return state;
-    }
-  },
 });
 
 function filterClusterConfig(cc = {}) {
@@ -371,6 +356,6 @@ export const reducer = (state, action) => {
 
 // Preserves only the savable bits of state
 export const savable = (state) => {
-  const {dirty, clusterConfig, sequence} = state;
-  return {dirty, clusterConfig, sequence};
+  const {dirty, clusterConfig} = state;
+  return {dirty, clusterConfig};
 };


### PR DESCRIPTION
This appears to no longer be doing anything useful.