### PR TITLE
modules/tectonic: ensure tectonic.service fails

### DIFF
--- a/modules/tectonic/resources/tectonic-rkt.sh
+++ b/modules/tectonic/resources/tectonic-rkt.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # shellcheck disable=SC2086,SC2154
 /usr/bin/rkt run \


### PR DESCRIPTION
Recently we started seeing clusters failing to come up because the
tectonic.service systemd unit did not run correctly. The journal would
show that rkt had failed to mount resolv.conf into the container and
thus failed to run the container but still systemd showed that
tectonic.service has completed successfully. This caused clusters to
show their bootstrapping as "complete" even though none of the Tectonic
manifests had been submitted to the API. The cause of this mistake is
two-fold:

1. rkt is failing to bind mount a file for some reason; and
2. systemd is marking the unit as successful.

This commit fixes issue number 2 by ensuring that if rkt fails to fun,
the `tectonic-rkt.sh` script exits with a non-zero exit status and
systemd will correctly mark the unit as failed.

cc @cpanato 