### PR TITLE
tests/rspec/lib: retry if ssh times out

### DIFF
--- a/tests/rspec/lib/ssh.rb
+++ b/tests/rspec/lib/ssh.rb
@@ -27,7 +27,8 @@ def ssh_exec(ip_address, command, max_retries = 5)
         end
       end
     end
-  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, IOError, Net::SSH::ConnectionTimeout, Net::SSH::Disconnect
+  rescue Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::ETIMEDOUT, IOError, Net::SSH::ConnectionTimeout,
+         Net::SSH::Disconnect
     raise "failed to exec '#{command}' in #{max_retries} retries" if retries >= max_retries
     retries += 1
     sleep_time = 5 * retries


### PR DESCRIPTION
@cpanato this commit adds `Errno::ETIMEDOUT` to the list of caught exceptions as observed here: https://jenkins-tectonic-installer.prod.coreos.systems/blue/organizations/jenkins/tectonic-installer/detail/PR-2107/5/pipeline#step-378-log-233