### PR TITLE
frontend: Clean up AWS regions

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -130,9 +130,8 @@ const stateToProps = ({aws, clusterConfig, serverFacts}) => {
   };
 
   // Calculate intersection of AWS regions: those w/coreos images & those the user has access to
-  const coreosRegionsValues = _.map(serverFacts.awsRegions, v => v.value);
-  if (!aws.availableRegions.inFly && !_.isEmpty(aws.availableRegions.value) && !_.isEmpty(coreosRegionsValues)) {
-    const intersection = _.filter(aws.availableRegions.value, v => _.includes(coreosRegionsValues, v));
+  if (!aws.availableRegions.inFly && !_.isEmpty(aws.availableRegions.value) && !_.isEmpty(serverFacts.awsRegions)) {
+    const intersection = _.filter(aws.availableRegions.value, v => _.includes(serverFacts.awsRegions, v));
     // Format for use with <AsyncSelect/>
     regionSelections.value = intersection.sort().map(value => {
       const optgroupKey = value.split('-')[0];

--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -131,7 +131,7 @@ const stateToProps = ({aws, clusterConfig, serverFacts}) => {
 
   // Calculate intersection of AWS regions: those w/coreos images & those the user has access to
   if (!aws.availableRegions.inFly && !_.isEmpty(aws.availableRegions.value) && !_.isEmpty(serverFacts.awsRegions)) {
-    const intersection = _.filter(aws.availableRegions.value, v => _.includes(serverFacts.awsRegions, v));
+    const intersection = _.intersection(aws.availableRegions.value, serverFacts.awsRegions);
     // Format for use with <AsyncSelect/>
     regionSelections.value = intersection.sort().map(value => {
       const optgroupKey = value.split('-')[0];

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -111,17 +111,13 @@ export const commitToServer = (dryRun = false, retry = false, opts = {}) => (dis
 // One-time fetch of initial data from server, followed by firing appropriate actions
 // Guaranteed not to reject.
 export const loadFacts = (dispatch) => {
-  return fetchJSON('/tectonic/facts', { retries: 5 })
+  return fetchJSON('/tectonic/facts', {retries: 5})
     .then(m => {
       addIn(TECTONIC_LICENSE, m.license, dispatch);
       addIn(PULL_SECRET, m.pullSecret, dispatch);
-
-      const awsRegions = _.map(m.amis, ({name}) => {
-        return {label: name, value: name};
-      });
       dispatch({
         type: loadFactsActionTypes.LOADED,
-        payload: {awsRegions},
+        payload: {awsRegions: _.map(m.amis, 'name')},
       });
     },
     err => {


### PR DESCRIPTION
We only actually use the region names from the "amis" API call result, so we can simplify the code a bit by storing just the names in redux.