### PR TITLE
frontend: Fix to not modify state when saving progress

### DIFF
--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -18,7 +18,7 @@ import { Header } from './header';
 import { Footer } from './footer';
 
 const downloadState = (state) => {
-  const toSave = savable(state);
+  const toSave = _.cloneDeep(savable(state));
 
   // Extra field data doesn't need to be saved
   _.unset(toSave, 'clusterConfig.extra');


### PR DESCRIPTION
Clone state before saving it so that `clusterConfig.extra` doesn't get unset in the original state object.