### PR TITLE
Add check for see if bootstrap failed and then run Forensic script

### DIFF
--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -9,9 +9,6 @@ require 'name_generator'
 require 'password_generator'
 require 'ssh'
 
-SSH_CMD_BOOTKUBE_FAILED = 'systemctl is-failed bootkube'
-SSH_CMD_TECTONIC_FAILED = 'systemctl is-failed tectonic'
-
 # Cluster represents a k8s cluster
 class Cluster
   attr_reader :tfvars_file, :kubeconfig, :manifest_path, :build_path,
@@ -164,7 +161,6 @@ class Cluster
     command = "test -e /opt/tectonic/init_#{service}.done"
 
     ips.each do |ip|
-      bootstrap_failed?
       _, _, finished = ssh_exec(ip, command, 20)
       if finished.zero?
         puts "#{service} service finished successfully"
@@ -173,12 +169,5 @@ class Cluster
     end
 
     false
-  end
-
-  def bootstrap_failed?(ip)
-    _, _, bootkube_failed_exitstatus = ssh_exec(ip, SSH_CMD_BOOTKUBE_FAILED, 20)
-    _, _, tectonic_failed_exitstatus = ssh_exec(ip, SSH_CMD_TECTONIC_FAILED, 20)
-    raise 'BootKube failed to start' if bootkube_failed_exitstatus.zero?
-    raise 'Tectonic failed to start' if tectonic_failed_exitstatus.zero?
   end
 end

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -13,7 +13,12 @@ require 'webdriver_helpers'
 RSpec.shared_examples 'withRunningCluster' do |tf_vars_path|
   before(:all) do
     @cluster = ClusterFactory.from_tf_vars(TFVarsFile.new(tf_vars_path))
-    @cluster.start
+    begin
+      @cluster.start
+    rescue => e
+      Forensic.run(@cluster)
+      raise "Aborting execution due startup failed. Error: #{e}"
+    end
   end
 
   after(:each) do |example|


### PR DESCRIPTION
If bootkube or Tectonic failed to start we abort the test execution but before that, we run forensics script to get some information.

cc @squat 