### PR TITLE
frontend: Remove "undefined" CSS class

### DIFF
--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -575,11 +575,10 @@ It should end with:
 export const CertArea = (props) => {
   const invalid = validate.certificate(props.value);
   const areaProps = Object.assign({}, props, {
-    className: props.className + ' wiz-tls-asset-field',
     invalid: invalid,
     placeholder: certPlaceholder,
   });
-  return <FileArea {...areaProps} />;
+  return <FileArea {...areaProps} className="wiz-tls-asset-field" />;
 };
 
 const privateKeyPlaceholder = `Paste your private key here. It should start with:
@@ -593,11 +592,10 @@ It should end with:
 export const PrivateKeyArea = (props) => {
   const invalid = validate.privateKey(props.value);
   const areaProps = Object.assign({}, props, {
-    className: props.className + ' wiz-tls-asset-field',
     invalid: invalid,
     placeholder: privateKeyPlaceholder,
   });
-  return <FileArea {...areaProps} />;
+  return <FileArea {...areaProps} className="wiz-tls-asset-field" />;
 };
 
 export class AsyncSelect extends React.Component {

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -572,14 +572,12 @@ It should end with:
 
 -----END CERTIFICATE-----`;
 
-export const CertArea = (props) => {
-  const invalid = validate.certificate(props.value);
-  const areaProps = Object.assign({}, props, {
-    invalid: invalid,
-    placeholder: certPlaceholder,
-  });
-  return <FileArea {...areaProps} className="wiz-tls-asset-field" />;
-};
+export const CertArea = (props) => <FileArea
+  {...props}
+  className="wiz-tls-asset-field"
+  invalid={validate.certificate(props.value)}
+  placeholder={certPlaceholder}
+/>;
 
 const privateKeyPlaceholder = `Paste your private key here. It should start with:
 
@@ -589,14 +587,12 @@ It should end with:
 
 -----END RSA PRIVATE KEY-----`;
 
-export const PrivateKeyArea = (props) => {
-  const invalid = validate.privateKey(props.value);
-  const areaProps = Object.assign({}, props, {
-    invalid: invalid,
-    placeholder: privateKeyPlaceholder,
-  });
-  return <FileArea {...areaProps} className="wiz-tls-asset-field" />;
-};
+export const PrivateKeyArea = (props) => <FileArea
+  {...props}
+  className="wiz-tls-asset-field"
+  invalid={validate.privateKey(props.value)}
+  placeholder={privateKeyPlaceholder}
+/>;
 
 export class AsyncSelect extends React.Component {
   componentDidMount () {


### PR DESCRIPTION
This removes the CSS class `undefined` that was being output for certificate and private key inputs and also cleans up the code a bit.