### PR TITLE
tests: Bump wait_for_bootstrapping timeout

### DIFF
--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -144,8 +144,8 @@ class Cluster
   def wait_for_bootstrapping
     from = Time.now
     loop do
-      _, _, bootkube_exitstatus = ssh_exec(master_ip_address, SSH_CMD_BOOTKUBE_DONE)
-      _, _, tectonic_exitstatus = ssh_exec(master_ip_address, SSH_CMD_TECTONIC_DONE)
+      _, _, bootkube_exitstatus = ssh_exec(master_ip_address, SSH_CMD_BOOTKUBE_DONE, 20)
+      _, _, tectonic_exitstatus = ssh_exec(master_ip_address, SSH_CMD_TECTONIC_DONE, 20)
       break if bootkube_exitstatus.zero? && tectonic_exitstatus.zero?
       elapsed = Time.now - from
       puts 'Waiting for bootstrapping to complete...' if (elapsed.round % 5).zero?


### PR DESCRIPTION
The bootkube and tectonic systemd services can take up to 10 minutes to
start. This patch bumps the retry value to prevent timeouts in our CI.

@squat We have seen multiple timeouts like [this](https://jenkins-tectonic-installer.prod.coreos.systems/blue/organizations/jenkins/tectonic-installer/detail/PR-2137/10/pipeline/). I guess the machines are restarting during `wait_for_bootstrapping`. Bumping the timeout might be a quick fix. What do you think?