### PR TITLE
tests: Remove PHONY flag from bin/smoke Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,6 @@ structure-check:
 	@if $(MAKE) examples && ! git diff --exit-code; then echo "outdated examples (run 'make examples' to fix)"; exit 1; fi
 
 SMOKE_SOURCES := $(shell find $(TOP_DIR)/tests/smoke -name '*.go')
-.PHONY: bin/smoke
 bin/smoke: $(SMOKE_SOURCES)
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test ./tests/smoke/ -c -o bin/smoke
 


### PR DESCRIPTION
`/bin/smoke` represents an actual file which is compiled with this
recipe. Removing the `PHONY` flag enables Make to decide on its own when
to rebuild. If the source files are less recent than the compiled
binary, there is no need to rebuild the binary, thereby saving time for
local and CI test execution.

@cpanato @squat What do you think?

See
https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html