### PR TITLE
tests: Fix ssh mount and pass tectonic email + password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ tests/smoke: bin/smoke smoke-test-env-docker-image
 	-w "${CURDIR}/tests/rspec" \
 	-v "${TF_VAR_tectonic_license_path}":"${TF_VAR_tectonic_license_path}" \
 	-v "${TF_VAR_tectonic_pull_secret_path}":"${TF_VAR_tectonic_pull_secret_path}" \
-	-v "${HOME}/.ssh:${HOME}/.ssh:ro" \
+	-v "${HOME}/.ssh:/root/.ssh:ro" \
 	-v "${TF_VAR_tectonic_azure_ssh_key}":"${TF_VAR_tectonic_azure_ssh_key}" \
 	-e CLUSTER \
 	-e AWS_ACCESS_KEY_ID \
@@ -191,6 +191,8 @@ tests/smoke: bin/smoke smoke-test-env-docker-image
 	-e TF_VAR_tectonic_license_path \
 	-e TF_VAR_tectonic_pull_secret_path \
 	-e TF_VAR_tectonic_base_domain \
+	-e TF_VAR_tectonic_admin_email \
+	-e TF_VAR_tectonic_admin_password \
 	-e TECTONIC_TESTS_DONT_CLEAN_UP \
 	--cap-add NET_ADMIN \
 	--device /dev/net/tun \


### PR DESCRIPTION
1. Mount the hosts ssh key into the correct home folder inside the
Docker container.
2. Pass tectonic_admin_email and tectonic_admin_password into the Docker
container.