### PR TITLE
modules/aws/vpc - Allow us to customise master node SSH sources

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -29,6 +29,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_master_root_volume_iops | The amount of provisioned IOPS for the root block device of master nodes. Ignored if the volume type is not io1. | string | `100` |
 | tectonic_aws_master_root_volume_size | The size of the volume in gigabytes for the root block device of master nodes. | string | `30` |
 | tectonic_aws_master_root_volume_type | The type of volume for the root block device of master nodes. | string | `gp2` |
+| tectonic_aws_master_ssh_allowed_ips | (optional) This configures trusted subnets for SSH access to the master nodes.<br><br>Example: `"10.0.0.0/16"` | list | `<list>` |
 | tectonic_aws_private_endpoints | (optional) If set to true, create private-facing ingress resources (ELB, A-records). If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone. | string | `true` |
 | tectonic_aws_profile | (optional) This declares the AWS credentials profile to use. | string | `default` |
 | tectonic_aws_public_endpoints | (optional) If set to true, create public-facing ingress resources (ELB, A-records). If set to false, no public-facing ingress resources will be created. | string | `true` |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -108,6 +108,11 @@ tectonic_aws_master_root_volume_size = "30"
 // The type of volume for the root block device of master nodes.
 tectonic_aws_master_root_volume_type = "gp2"
 
+// (optional) This configures trusted subnets for SSH access to the master nodes.
+// 
+// Example: `"10.0.0.0/16"`
+// tectonic_aws_master_ssh_allowed_ips = ""
+
 // (optional) If set to true, create private-facing ingress resources (ELB, A-records).
 // If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
 // tectonic_aws_private_endpoints = true

--- a/modules/aws/vpc/sg-master.tf
+++ b/modules/aws/vpc/sg-master.tf
@@ -33,7 +33,7 @@ resource "aws_security_group_rule" "master_ingress_ssh" {
   security_group_id = "${aws_security_group.master.id}"
 
   protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = ["${var.master_ssh_allowed_ips}"]
   from_port   = 22
   to_port     = 22
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -76,3 +76,8 @@ variable "custom_dns_name" {
   default     = ""
   description = "DNS prefix used to construct the console and API server endpoints."
 }
+
+variable "master_ssh_allowed_ips" {
+  description = "List of CIDR blocks of IPs allowed to SSH to master nodes"
+  default     = ["0.0.0.0/0"]
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -34,6 +34,8 @@ module "vpc" {
   private_master_endpoints = "${var.tectonic_aws_private_endpoints}"
   public_master_endpoints  = "${var.tectonic_aws_public_endpoints}"
 
+  master_ssh_allowed_ips = "${var.tectonic_aws_master_ssh_allowed_ips}"
+
   # VPC layout settings.
   #
   # The following parameters control the layout of the VPC accross availability zones.

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -280,6 +280,17 @@ Example:
 EOF
 }
 
+variable "tectonic_aws_master_ssh_allowed_ips" {
+  type    = "list"
+  default = ["0.0.0.0/0"]
+
+  description = <<EOF
+(optional) This configures trusted subnets for SSH access to the master nodes.
+
+Example: `"10.0.0.0/16"`
+EOF
+}
+
 variable "tectonic_aws_worker_custom_subnets" {
   type    = "map"
   default = {}


### PR DESCRIPTION
I would like to pass in trusted subnets for ssh access to our master nodes, rather than the entire dirty IPv4 internet.