### PR TITLE
tests: Log network interfaces before and after destroy

### DIFF
--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -7,13 +7,14 @@ require 'name_generator'
 require 'password_generator'
 require 'securerandom'
 require 'ssh'
+require 'tfstate_file'
 require 'tfvars_file'
 require 'timeout'
 
 # Cluster represents a k8s cluster
 class Cluster
   attr_reader :tfvars_file, :kubeconfig, :manifest_path, :build_path,
-              :tectonic_admin_email, :tectonic_admin_password
+              :tectonic_admin_email, :tectonic_admin_password, :tfstate_file
 
   def initialize(tfvars_file)
     @tfvars_file = tfvars_file
@@ -27,6 +28,8 @@ class Cluster
     @build_path = File.join(File.realpath('../../'), "build/#{@name}")
     @manifest_path = File.join(@build_path, 'generated')
     @kubeconfig = File.join(manifest_path, 'auth/kubeconfig')
+    @tfstate_file = TFStateFile.new(@build_path)
+
     check_prerequisites
     localconfig
     prepare_assets

--- a/tests/rspec/lib/tfstate_file.rb
+++ b/tests/rspec/lib/tfstate_file.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# TFStateFile represents a Terraform state file
+class TFStateFile
+  def initialize(build_path)
+    @build_path = build_path
+  end
+
+  def value(address, wanted_key)
+    file_exists?
+
+    Dir.chdir(@build_path) do
+      state = `terraform state show #{address}`.chomp.split("\n")
+      state.each do |value|
+        key, value = value.split('=')
+        key = key.strip.chomp
+        value = value.strip.chomp
+        return value if key == wanted_key
+      end
+    end
+
+    msg = "could not find value for key \"#{wanted_key}\" in tfstate file #{@build_path}"
+    raise TFStateFileValueForKeyDoesNotExist, msg
+  end
+
+  def file_exists?
+    tfstate_file = File.join(@build_path, 'terraform.tfstate')
+    raise "tfstate file #{tfstate_file} does not exist" unless File.exist? tfstate_file
+  end
+end
+
+class TFStateFileValueForKeyDoesNotExist < StandardError; end


### PR DESCRIPTION
For better upstream Terraform debugging we would like to log the network
interfaces related to the VPC. For further details see:
https://github.com/terraform-providers/terraform-provider-aws/pull/1051


@erikkn This change will add something along the lines of this to the test log:
``` json
{
    "NetworkInterfaces": 
           ...
}
```
The goal would be to be able to analyse this with the Elastic search project. Should I log any particular keyword before or after so we can extract it from the logs? 