### PR TITLE
frontend: Remove most DEFAULT_CLUSTER_CONFIG initial entries

### DIFF
--- a/installer/frontend/__tests__/protocols.js
+++ b/installer/frontend/__tests__/protocols.js
@@ -7,14 +7,20 @@ import path from 'path';
 import { reducer } from '../reducer';
 import { restoreActionTypes } from '../actions';
 import { commitToServer } from '../server';
+import '../components/aws-cloud-credentials';
 import '../components/aws-cluster-info';
 import '../components/aws-define-nodes';
+import '../components/aws-submit-keys';
 import '../components/aws-vpc';
-import '../components/etcd';
-import '../components/bm-sshkeys';
-import '../components/bm-nodeforms';
+import '../components/bm-credentials';
 import '../components/bm-hostname';
+import '../components/bm-matchbox';
+import '../components/bm-nodeforms';
+import '../components/bm-sshkeys';
+import '../components/certificate-authority';
 import '../components/cluster-type';
+import '../components/etcd';
+import '../components/users';
 
 const structureOnly = (obj) => {
   const toString = Object.prototype.toString;

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 
 import { DEFAULT_CLUSTER_CONFIG } from './cluster-config';
+
 export const awsActionTypes = {
   SET: 'AWS_SET',
 };

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -153,13 +153,6 @@ export const DEFAULT_CLUSTER_CONFIG = {
   inFly: {}, // to store inFly
   extra: {}, // extraneous, non-value data for this field
   bootCfgInfly: false, // TODO (ggreer): total hack. clean up after release
-  [ADMIN_EMAIL]: '',
-  [ADMIN_PASSWORD]: '',
-  [AWS_ACCESS_KEY_ID]: '',
-  [AWS_REGION]: '',
-  [AWS_SECRET_ACCESS_KEY]: '',
-  [AWS_SESSION_TOKEN]: '',
-  [AWS_SSH]: '',
   [AWS_VPC_ID]: '',
   [AWS_VPC_CIDR]: '10.0.0.0/16',
   [AWS_CONTROLLER_SUBNETS]: {},
@@ -167,23 +160,10 @@ export const DEFAULT_CLUSTER_CONFIG = {
   [DESELECTED_FIELDS]: {},
   [AWS_WORKER_SUBNETS]: {},
   [AWS_WORKER_SUBNET_IDS]: {},
-  [BM_MATCHBOX_CA]: '',
-  [BM_MATCHBOX_CLIENT_CERT]: '',
-  [BM_MATCHBOX_CLIENT_KEY]: '',
   [BM_MATCHBOX_HTTP]: '',
-  [BM_MATCHBOX_RPC]: '',
   [BM_OS_TO_USE]: '',
-  [BM_TECTONIC_DOMAIN]: '',
-  [CA_CERTIFICATE]: '',
-  [CA_PRIVATE_KEY]: '',
-  [CA_TYPE]: '',
-  [CLUSTER_NAME]: '',
-  [CONTROLLER_DOMAIN]: '',
   [DRY_RUN]: false,
-  [PULL_SECRET]: '',
   [RETRY]: false, // whether we're retrying a terraform apply
-  [STS_ENABLED]: false,
-  [TECTONIC_LICENSE]: '',
   [UPDATER]: {
     server: 'https://tectonic.update.core-os.net',
     channel: 'tectonic-1.6',

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -2,9 +2,7 @@ import _ from 'lodash';
 import { combineReducers } from 'redux';
 import { fromJS } from 'immutable';
 
-import {
-  DEFAULT_CLUSTER_CONFIG,
-} from './cluster-config';
+import { DEFAULT_CLUSTER_CONFIG } from './cluster-config';
 
 import {
   awsActionTypes,


### PR DESCRIPTION
The `Field` constructor adds the field's default value to `DEFAULT_CLUSTER_CONFIG`, so we don't need to also define those defaults when `DEFAULT_CLUSTER_CONFIG` is initialized.

Some fields remain for several different reasons. They should be refactored away over time.