### PR TITLE
tests: run kill-api-server test last

### DIFF
--- a/tests/smoke/cluster_test.go
+++ b/tests/smoke/cluster_test.go
@@ -68,15 +68,16 @@ var (
 func testCluster(t *testing.T) {
 	// wait for all nodes to become available
 	t.Run("AllNodesRunning", testAllNodesRunning)
-	t.Run("GetIdentityLogs", testGetIdentityLogs)
-	t.Run("AllPodsRunning", testAllPodsRunning)
-	t.Run("KillAPIServer", testKillAPIServer)
 	t.Run("AllResourcesCreated", testAllResourcesCreated)
+	t.Run("AllPodsRunning", testAllPodsRunning)
+	t.Run("GetIdentityLogs", testGetIdentityLogs)
 
 	ne := os.Getenv(networkingEnv)
 	if ne == "canal" || ne == "calico" {
 		t.Run("NetworkPolicy", testNetworkPolicy)
 	}
+
+	t.Run("KillAPIServer", testKillAPIServer)
 }
 
 func testAllPodsRunning(t *testing.T) {


### PR DESCRIPTION
This PR changes the order of the smoke test execution.
1. Check if all nodes are running
2. Check if all resources got created
3. Check if all pods are running
----
6. Kill the API server


We are not running the golang smoke tests in parallel (See [smoke-tests.rb](https://github.com/mxinden/tectonic-installer/blob/f67aec72e82bc2befb031f6e8a0faae32a34e1ed/tests/rspec/lib/smoke_test.rb#L16) `-test.parallel=1`).

