### PR TITLE
tests: Improve wait_for_bootstrapping

### DIFF
--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -45,19 +45,22 @@ class AwsCluster < Cluster
     super
   end
 
-  def master_ip_address
-    ssh_master_ip = nil
+  def master_ip_addresses
+    ssh_master_ips = []
     Dir.chdir(@build_path) do
       terraform_state = `terraform state show module.masters.aws_autoscaling_group.masters`.chomp.split("\n")
       terraform_state.each do |value|
         attributes = value.split('=')
         next unless attributes[0].strip.eql?('id')
         instances_id = AwsSupport.sorted_auto_scaling_instances(attributes[1].strip.chomp, @aws_region)
-        ssh_master_ip = AwsSupport.preferred_instance_ip_address(instances_id[0], @aws_region)
-        break
+        ssh_master_ips.push AwsSupport.preferred_instance_ip_address(instances_id[0], @aws_region)
       end
     end
-    ssh_master_ip
+    ssh_master_ips
+  end
+
+  def master_ip_address
+    master_ip_addresses[0]
   end
 
   def check_prerequisites

--- a/tests/rspec/lib/azure_cluster.rb
+++ b/tests/rspec/lib/azure_cluster.rb
@@ -2,6 +2,7 @@
 
 require 'cluster'
 require 'azure_support'
+require 'json'
 
 # AzureCluster represents a k8s cluster on Azure cloud provider
 #
@@ -14,10 +15,15 @@ class AzureCluster < Cluster
     super(tfvars_file)
   end
 
-  def master_ip_address
+  def master_ip_addresses
     Dir.chdir(@build_path) do
-      `echo 'module.vnet.api_ip_addresses[0]' | terraform console ../../platforms/azure`.chomp
+      ips_raw = `echo 'jsonencode(module.vnet.api_ip_addresses)' | terraform console ../../platforms/azure`.chomp
+      JSON.parse(ips_raw)
     end
+  end
+
+  def master_ip_address
+    master_ip_addresses[0]
   end
 
   def env_variables


### PR DESCRIPTION
The Tectonic installer CI had repeatedly failed with timeouts waiting
for the bootkube and tectonic service to finish.

This patch includes the following improvements:
- The bootkube and tectonic systemd unit is only deployed on one master
node. Instead of relying on the fact, that we choose the right master
node to check if the services finished, we check all of them and return
true if the services succeeded on one of them
- Instead of checking for success via:
`systemctl is-active <service>`, we check whether the
`init_<service>.done` file exists. `is-active` returns non zero when the
bootstrap succeeded but the node restarted in the meantime. The
`init_<service>.done` file is only written when the service exits with a
non-zero exit code [1]

[1] See `ExecStartPost`
https://www.freedesktop.org/software/systemd/man/systemd.service.html