### PR TITLE
Remove duplicate updateStrategy

### DIFF
--- a/modules/bootkube/resources/manifests/pod-checkpointer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpointer.yaml
@@ -7,10 +7,6 @@ metadata:
     tier: control-plane
     k8s-app: pod-checkpointer
 spec:
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
In the pod-checkpointer manifest the updateStrategy is defined twice.
This patch removes one definition.

@alexsomesan am I overlooking something here?