### PR TITLE
Use filepath on user provided ingress

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -389,6 +389,48 @@ This field is mandatory if `tectonic_ca_cert` is set.
 EOF
 }
 
+variable "tectonic_ingress_ca_cert_pem_path" {
+  type  = "string"
+  default = ""
+
+  description = <<EOF
+(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+
+The file must have contents the public CA certificate in PEM format, like:
+-----BEGIN CERTIFICATE-----
+<contents of the public CA certificate in PEM format>
+-----END CERTIFICATE-----
+EOF
+}
+
+variable "tectonic_ingress_cert_pem_path" {
+  type = "string"
+  default = ""
+
+  description = <<EOF
+(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+
+The file must have contents the public ingress certificate in PEM format, like:
+-----BEGIN CERTIFICATE-----
+<contents of the public ingress certificate signed by the above CA in PEM format>
+-----END CERTIFICATE-----
+EOF
+}
+
+variable "tectonic_ingress_key_pem_path" {
+  type = "string"
+  default = ""
+
+  description = <<EOF
+(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+
+The file must have contents the private ingress key in PEM format, like:
+-----BEGIN CERTIFICATE-----
+<contents of the private ingress key used to generate the above certificate PEM format>
+-----END CERTIFICATE-----
+EOF
+}
+
 variable "tectonic_vanilla_k8s" {
   default = false
 

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -109,24 +109,6 @@ tectonic_aws_master_root_volume_type = "gp2"
 // If set to false, no public-facing ingress resources will be created.
 // tectonic_aws_public_endpoints = true
 
-// (optional) Tectonic Ingress CA Certificate PEM path
-//-----BEGIN CERTIFICATE-----
-//<contents of the public CA certificate in PEM format>
-//-----END CERTIFICATE-----
-#tectonic_ingress_ca_cert_pem_path = ""
-
-// (optional) Tectonic Ingress Certificate PEM path
-// -----BEGIN CERTIFICATE-----
-//<contents of the public ingress certificate signed by the above CA in PEM format>
-//-----END CERTIFICATE-----
-#tectonic_ingress_cert_pem_path = ""
-
-// (optional) Tectonic Ingress Certificate Key PEM path
-// -----BEGIN CERTIFICATE-----
-//<contents of the private ingress key used to generate the above certificate PEM format>
-//-----END CERTIFICATE-----
-#tectonic_ingress_key_pem_path = ""
-
 // The target AWS region for the cluster.
 tectonic_aws_region = "eu-west-1"
 
@@ -328,3 +310,30 @@ tectonic_vanilla_k8s = false
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.
 tectonic_worker_count = "3"
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/aws/tectonic.tf
+//
+//The file must have contents the public CA certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/aws/tectonic.tf
+//
+//The file must have contents the public ingress certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/aws/tectonic.tf
+//
+//The file must have contents the private ingress key in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -109,6 +109,24 @@ tectonic_aws_master_root_volume_type = "gp2"
 // If set to false, no public-facing ingress resources will be created.
 // tectonic_aws_public_endpoints = true
 
+// (optional) Tectonic Ingress CA Certificate PEM path
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+// (optional) Tectonic Ingress Certificate PEM path
+// -----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+// (optional) Tectonic Ingress Certificate Key PEM path
+// -----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""
+
 // The target AWS region for the cluster.
 tectonic_aws_region = "eu-west-1"
 

--- a/examples/terraform.tfvars.azure
+++ b/examples/terraform.tfvars.azure
@@ -279,3 +279,30 @@ tectonic_vanilla_k8s = false
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.
 tectonic_worker_count = "3"
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/azure/tectonic.tf
+//
+//The file must have contents the public CA certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/azure/tectonic.tf
+//
+//The file must have contents the public ingress certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/azure/tectonic.tf
+//
+//The file must have contents the private ingress key in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""

--- a/examples/terraform.tfvars.gcp
+++ b/examples/terraform.tfvars.gcp
@@ -202,3 +202,30 @@ tectonic_vanilla_k8s = false
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.
 tectonic_worker_count = "3"
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/gcp/tectonic.tf
+//
+//The file must have contents the public CA certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/gcp/tectonic.tf
+//
+//The file must have contents the public ingress certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/gcp/tectonic.tf
+//
+//The file must have contents the private ingress key in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""

--- a/examples/terraform.tfvars.metal
+++ b/examples/terraform.tfvars.metal
@@ -265,3 +265,30 @@ tectonic_vanilla_k8s = false
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.
 tectonic_worker_count = "3"
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/metal/tectonic.tf
+//
+//The file must have contents the public CA certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/metal/tectonic.tf
+//
+//The file must have contents the public ingress certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/metal/tectonic.tf
+//
+//The file must have contents the private ingress key in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""

--- a/examples/terraform.tfvars.openstack-neutron
+++ b/examples/terraform.tfvars.openstack-neutron
@@ -235,3 +235,30 @@ tectonic_vanilla_k8s = false
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.
 tectonic_worker_count = "3"
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/openstack/neutron/main.tf
+//
+//The file must have contents the public CA certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/openstack/neutron/main.tf
+//
+//The file must have contents the public ingress certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/openstack/neutron/main.tf
+//
+//The file must have contents the private ingress key in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -281,3 +281,30 @@ tectonic_vmware_worker_vcpu = "1"
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.
 tectonic_worker_count = "3"
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/vmware/tectonic.tf
+//
+//The file must have contents the public CA certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public CA certificate in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_ca_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/vmware/tectonic.tf
+//
+//The file must have contents the public ingress certificate in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the public ingress certificate signed by the above CA in PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_cert_pem_path = ""
+
+//(optional) The path of the file containing the CA certificate for TLS communication with the ingress controller.
+// NB: Must uncomment relevant section from platforms/vmware/tectonic.tf
+//
+//The file must have contents the private ingress key in PEM format, like:
+//-----BEGIN CERTIFICATE-----
+//<contents of the private ingress key used to generate the above certificate PEM format>
+//-----END CERTIFICATE-----
+#tectonic_ingress_key_pem_path = ""

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -33,6 +33,14 @@ module "ingress_certs" {
   ca_key_pem   = "${module.kube_certs.ca_key_pem}"
 }
 
+//module "ingress_certs" {
+//  source = "../../modules/tls/ingress/user-provided"
+//
+//  ca_cert_pem = "${file(var.tectonic_ingress_ca_cert_pem_path)}"
+//  cert_pem    = "${file(var.tectonic_ingress_cert_pem_path)}"
+//  key_pem     = "${file(var.tectonic_ingress_key_pem_path)}"
+//}
+
 module "identity_certs" {
   source = "../../modules/tls/identity/self-signed"
 

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -316,39 +316,3 @@ Example:
  * `["ingress-nginx"]`
 EOF
 }
-
-variable "tectonic_ingress_ca_cert_pem_path" {
-  type  = "string"
-  default = ""
-
-  description = <<EOF
-(optional) File with contents the public CA certificate in PEM format
------BEGIN CERTIFICATE-----
-<contents of the public CA certificate in PEM format>
------END CERTIFICATE-----
-EOF
-}
-
-variable "tectonic_ingress_cert_pem_path" {
-  type = "string"
-  default = ""
-
-  description = <<EOF
-  (optional) File with contents the public CA certificate in PEM format
------BEGIN CERTIFICATE-----
-<contents of the public ingress certificate signed by the above CA in PEM format>
------END CERTIFICATE-----
-EOF
-}
-
-variable "tectonic_ingress_key_pem_path" {
-  type = "string"
-  default = ""
-
-  description = <<EOF
-(optional) File with contents the public CA certificate in PEM format
------BEGIN CERTIFICATE-----
-<contents of the private ingress key used to generate the above certificate PEM format>
------END CERTIFICATE-----
-EOF
-}

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -316,3 +316,39 @@ Example:
  * `["ingress-nginx"]`
 EOF
 }
+
+variable "tectonic_ingress_ca_cert_pem_path" {
+  type  = "string"
+  default = ""
+
+  description = <<EOF
+(optional) File with contents the public CA certificate in PEM format
+-----BEGIN CERTIFICATE-----
+<contents of the public CA certificate in PEM format>
+-----END CERTIFICATE-----
+EOF
+}
+
+variable "tectonic_ingress_cert_pem_path" {
+  type = "string"
+  default = ""
+
+  description = <<EOF
+  (optional) File with contents the public CA certificate in PEM format
+-----BEGIN CERTIFICATE-----
+<contents of the public ingress certificate signed by the above CA in PEM format>
+-----END CERTIFICATE-----
+EOF
+}
+
+variable "tectonic_ingress_key_pem_path" {
+  type = "string"
+  default = ""
+
+  description = <<EOF
+(optional) File with contents the public CA certificate in PEM format
+-----BEGIN CERTIFICATE-----
+<contents of the private ingress key used to generate the above certificate PEM format>
+-----END CERTIFICATE-----
+EOF
+}

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -37,6 +37,14 @@ module "ingress_certs" {
   ca_key_pem   = "${module.kube_certs.ca_key_pem}"
 }
 
+//module "ingress_certs" {
+//  source = "../../modules/tls/ingress/user-provided"
+//
+//  ca_cert_pem = "${file(var.tectonic_ingress_ca_cert_pem_path)}"
+//  cert_pem    = "${file(var.tectonic_ingress_cert_pem_path)}"
+//  key_pem     = "${file(var.tectonic_ingress_key_pem_path)}"
+//}
+
 module "identity_certs" {
   source = "../../modules/tls/identity/self-signed"
 

--- a/platforms/gcp/tectonic.tf
+++ b/platforms/gcp/tectonic.tf
@@ -53,6 +53,14 @@ module "ingress_certs" {
   ca_key_pem   = "${module.kube_certs.ca_key_pem}"
 }
 
+//module "ingress_certs" {
+//  source = "../../modules/tls/ingress/user-provided"
+//
+//  ca_cert_pem = "${file(var.tectonic_ingress_ca_cert_pem_path)}"
+//  cert_pem    = "${file(var.tectonic_ingress_cert_pem_path)}"
+//  key_pem     = "${file(var.tectonic_ingress_key_pem_path)}"
+//}
+
 module "identity_certs" {
   source = "../../modules/tls/identity/self-signed"
 

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -29,6 +29,14 @@ module "ingress_certs" {
   ca_key_pem   = "${module.kube_certs.ca_key_pem}"
 }
 
+//module "ingress_certs" {
+//  source = "../../modules/tls/ingress/user-provided"
+//
+//  ca_cert_pem = "${file(var.tectonic_ingress_ca_cert_pem_path)}"
+//  cert_pem    = "${file(var.tectonic_ingress_cert_pem_path)}"
+//  key_pem     = "${file(var.tectonic_ingress_key_pem_path)}"
+//}
+
 module "identity_certs" {
   source = "../../modules/tls/identity/self-signed"
 

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -37,6 +37,14 @@ module "ingress_certs" {
   ca_key_pem   = "${module.kube_certs.ca_key_pem}"
 }
 
+//module "ingress_certs" {
+//  source = "../../modules/tls/ingress/user-provided"
+//
+//  ca_cert_pem = "${file(var.tectonic_ingress_ca_cert_pem_path)}"
+//  cert_pem    = "${file(var.tectonic_ingress_cert_pem_path)}"
+//  key_pem     = "${file(var.tectonic_ingress_key_pem_path)}"
+//}
+
 module "identity_certs" {
   source = "../../../modules/tls/identity/self-signed"
 

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -32,6 +32,14 @@ module "ingress_certs" {
   ca_key_pem   = "${module.kube_certs.ca_key_pem}"
 }
 
+//module "ingress_certs" {
+//  source = "../../modules/tls/ingress/user-provided"
+//
+//  ca_cert_pem = "${file(var.tectonic_ingress_ca_cert_pem_path)}"
+//  cert_pem    = "${file(var.tectonic_ingress_cert_pem_path)}"
+//  key_pem     = "${file(var.tectonic_ingress_key_pem_path)}"
+//}
+
 module "identity_certs" {
   source = "../../modules/tls/identity/self-signed"
 


### PR DESCRIPTION
Instead of having to append the contents of the certificates, use file paths

A separate PR would be required to updates the docs; https://github.com/coreos/tectonic-docs/blob/master/Documentation/reference/tls-certificates.md