### PR TITLE
frontend: Add command line option to specify the secrets directory

### DIFF
--- a/installer/api/api.go
+++ b/installer/api/api.go
@@ -28,6 +28,10 @@ type Config struct {
 	// Whether the server was started with --dev
 	DevMode bool
 
+	// If not "", search this directory for Tectonic license and pull secret
+	// files rather than the installer executable directory
+	SecretsDir string
+
 	// Cookie Sessions
 	CookieSigningSecret string
 

--- a/installer/cmd/installer/main.go
+++ b/installer/cmd/installer/main.go
@@ -21,6 +21,7 @@ func main() {
 		address             string
 		logLevel            string
 		platforms           platformsValue
+		secretsDir          string
 		cookieSigningSecret string
 		disableSecureCookie bool
 		openBrowser         bool
@@ -47,6 +48,8 @@ func main() {
 	flags.platforms = platformsValue{names: knownPlatforms}
 	flag.Var(&flags.platforms, "platforms", "comma separated list of platforms to support")
 
+	flag.StringVar(&flags.secretsDir, "secrets-dir", "", "search this directory for Tectonic license and pull secret files rather than the installer executable directory")
+
 	// parse command-line and environment variable arguments
 	flag.Parse()
 	if err := flagutil.SetFlagsFromEnv(flag.CommandLine, "INSTALLER"); err != nil {
@@ -71,6 +74,7 @@ func main() {
 		AssetDir:            flags.assetDir,
 		DevMode:             flags.devMode,
 		Platforms:           flags.platforms.names,
+		SecretsDir:          flags.secretsDir,
 		CookieSigningSecret: flags.cookieSigningSecret,
 		DisableSecureCookie: flags.disableSecureCookie,
 	})


### PR DESCRIPTION
If present, this directory will be searched for the Tectonic license and pull secret files to auto-load into the GUI. Otherwise, the installer executable directory will be used.