### PR TITLE
tests: do not check the host key when ssh 

### DIFF
--- a/tests/rspec/lib/ssh.rb
+++ b/tests/rspec/lib/ssh.rb
@@ -18,7 +18,8 @@ def ssh_exec(ip_address, command, max_retries = 5)
   stdout = ''
   stderr = ''
   begin
-    Net::SSH.start(ip_address, 'core', forward_agent: true, use_agent: true) do |ssh|
+    Net::SSH.start(ip_address, 'core', forward_agent: true, use_agent: true,
+                                       verify_host_key: Net::SSH::Verifiers::Null.new) do |ssh|
       ssh.exec! command, status: status do |_ch, stream, data|
         if stream == :stdout
           stdout = data


### PR DESCRIPTION
sometimes we receive the same IP for the machines we created and if it runs in the same slave if can throw this exception: Net::SSH::HostKeyMismatch to avoid that we are not checking the key
 
solution: clean the know_hosts in the end of the test



Jira: https://jira.prod.coreos.systems/browse/INST-552