### PR TITLE
tests/rspec/lib: ensure CL version is available

### DIFF
--- a/tests/rspec/lib/container_linux.rb
+++ b/tests/rspec/lib/container_linux.rb
@@ -2,9 +2,15 @@
 
 require 'ssh'
 
-SSH_CMD_CONTAINER_LINUX_VERSION = 'sudo cat /var/lib/update_engine/prefs/aleph-version'
-SSH_CMD_CONTAINER_LINUX_CHANNEL = 'for conf in /usr/share/coreos/update.conf /etc/coreos/update.conf ; \
-do [ -f "$conf" ] && source "$conf" ; done ; echo "$GROUP"'
+SSH_CMD_CONTAINER_LINUX_VERSION = 'if sudo [ -f /var/lib/update_engine/prefs/aleph-version ]; then \
+  sudo cat /var/lib/update_engine/prefs/aleph-version; \
+else \
+  source /usr/share/coreos/release && echo "$COREOS_RELEASE_VERSION"; \
+fi'
+SSH_CMD_CONTAINER_LINUX_CHANNEL = 'for conf in /usr/share/coreos/update.conf /etc/coreos/update.conf; do \
+  [ -f "$conf" ] && source "$conf"; \
+done; \
+echo "$GROUP"'
 
 # ContainerLinux provides helpers to find OS-level properties for a cluster.
 module ContainerLinux


### PR DESCRIPTION
This change ensures that a Container Linux version will be reported even
if update-engine has not finished running and creating an
`aleph-version' file. If this is the case, we will simple read the
version from the canonical location, /usr/share/coreos/release.

cc @cpanato @enxebre