### PR TITLE
frontend: Fix Cluster Info page's next button after Start Over

### DIFF
--- a/installer/frontend/components/cluster-info.jsx
+++ b/installer/frontend/components/cluster-info.jsx
@@ -50,9 +50,7 @@ const pullSecretField = new Field(PULL_SECRET, {
   },
 });
 
-const form = new Form(LICENSING, [fields[CLUSTER_NAME], licenseField, pullSecretField], {
-  validator: (data, cc) => !licenseField.validator(cc[TECTONIC_LICENSE]) && !pullSecretField.validator(cc[PULL_SECRET]),
-});
+new Form(LICENSING, [fields[CLUSTER_NAME], licenseField, pullSecretField]);
 
 const FileInput = ({id, onValue}) => {
   const upload = e => {
@@ -139,4 +137,6 @@ export const ClusterInfo = () => <div>
   </div>
 </div>;
 
-ClusterInfo.canNavigateForward = form.canNavigateForward;
+ClusterInfo.canNavigateForward = ({clusterConfig: cc}) => !fields[CLUSTER_NAME].validator(cc[CLUSTER_NAME], cc) &&
+  !licenseField.validator(cc[TECTONIC_LICENSE]) &&
+  !pullSecretField.validator(cc[PULL_SECRET]);


### PR DESCRIPTION
Fixes the Cluster Info page's next button enabled / disabled state.

The problem only occurred if you completed the install, then clicked Start Over and went through the wizard again. In that case, the Next Step button would stay disabled even after filling in the name field. You needed to upload the license and pull secret again to enable the button.