### PR TITLE
modules/dns/designate: Fix buggy zone creation

### DIFF
--- a/modules/dns/designate/etcd.tf
+++ b/modules/dns/designate/etcd.tf
@@ -2,7 +2,7 @@ resource "openstack_dns_recordset_v2" "etcd_a_nodes" {
   count   = "${var.tectonic_experimental ? 0 : var.etcd_count}"
   type    = "A"
   ttl     = "60"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   name    = "${var.cluster_name}-etcd-${count.index}.${var.base_domain}."
   records = ["${var.etcd_ips[count.index]}"]
 }
@@ -11,7 +11,7 @@ resource "openstack_dns_recordset_v2" "etcd_srv_discover" {
   count   = "${var.tectonic_experimental ? 0 : 1}"
   name    = "${var.etcd_tls_enabled ? "_etcd-server-ssl._tcp" : "_etcd-server._tcp"}.${var.base_domain}."
   type    = "SRV"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   records = ["${formatlist("0 0 2380 %s", openstack_dns_recordset_v2.etcd_a_nodes.*.name)}"]
   ttl     = "300"
 }
@@ -20,7 +20,7 @@ resource "openstack_dns_recordset_v2" "etcd_srv_client" {
   count   = "${var.tectonic_experimental ? 0 : 1}"
   name    = "${var.etcd_tls_enabled ? "_etcd-client-ssl._tcp" : "_etcd-client._tcp"}.${var.base_domain}."
   type    = "SRV"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   records = ["${formatlist("0 0 2379 %s", openstack_dns_recordset_v2.etcd_a_nodes.*.name)}"]
   ttl     = "60"
 }

--- a/modules/dns/designate/master.tf
+++ b/modules/dns/designate/master.tf
@@ -1,6 +1,6 @@
 resource "openstack_dns_recordset_v2" "master_nodes" {
   count   = "${var.master_count}"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   name    = "${var.cluster_name}-master-${count.index}.${var.base_domain}."
   type    = "A"
   ttl     = "60"

--- a/modules/dns/designate/tectonic.tf
+++ b/modules/dns/designate/tectonic.tf
@@ -1,4 +1,4 @@
-data "openstack_dns_zone_v2" "tectonic" {
+resource "openstack_dns_zone_v2" "tectonic" {
   name  = "${var.base_domain}."
   email = "${var.admin_email}"
   ttl   = "60"
@@ -6,7 +6,7 @@ data "openstack_dns_zone_v2" "tectonic" {
 
 resource "openstack_dns_recordset_v2" "tectonic-api" {
   count   = "1"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   name    = "${var.cluster_name}-k8s.${var.base_domain}."
   type    = "A"
   ttl     = "60"
@@ -15,7 +15,7 @@ resource "openstack_dns_recordset_v2" "tectonic-api" {
 
 resource "openstack_dns_recordset_v2" "tectonic-console" {
   count   = "${var.tectonic_vanilla_k8s ? 0 : 1}"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   name    = "${var.cluster_name}.${var.base_domain}."
   type    = "A"
   ttl     = "60"

--- a/modules/dns/designate/worker.tf
+++ b/modules/dns/designate/worker.tf
@@ -1,6 +1,6 @@
 resource "openstack_dns_recordset_v2" "worker_nodes" {
   count   = "${var.worker_count}"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   name    = "${var.cluster_name}-worker-${count.index}.${var.base_domain}."
   type    = "A"
   ttl     = "60"
@@ -10,7 +10,7 @@ resource "openstack_dns_recordset_v2" "worker_nodes" {
 resource "openstack_dns_recordset_v2" "worker_nodes_public" {
   // hack: worker_public_ips_enabled is a workaround for https://github.com/hashicorp/terraform/issues/10857
   count   = "${var.worker_public_ips_enabled ? var.worker_count : 0}"
-  zone_id = "${data.openstack_dns_zone_v2.tectonic.id}"
+  zone_id = "${openstack_dns_zone_v2.tectonic.id}"
   name    = "${var.cluster_name}-worker-${count.index}-public.${var.base_domain}."
   type    = "A"
   ttl     = "60"


### PR DESCRIPTION
The DNS zone was incorrectly specified as data rather than a resource,
which prevented it from being created. Changed to resource and updated
related references.

See https://github.com/coreos/tectonic-forum/issues/197#issuecomment-338516712