### PR TITLE
platforms/openstack: Set apiserver advertise address to master LB FIP

### DIFF
--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -63,7 +63,7 @@ module "bootkube" {
   service_cidr = "${var.tectonic_service_cidr}"
   cluster_cidr = "${var.tectonic_cluster_cidr}"
 
-  advertise_address = "0.0.0.0"
+  advertise_address = "${openstack_networking_floatingip_v2.loadbalancer.address}"
   anonymous_auth    = "false"
 
   oidc_username_claim = "email"


### PR DESCRIPTION
Every OpenStack cluster gets a master load balancer, so use that IP address to advertise the apiservers.