### PR TITLE
frontend: Remove 3 unused "validator" attributes

### DIFF
--- a/installer/frontend/components/users.jsx
+++ b/installer/frontend/components/users.jsx
@@ -26,7 +26,7 @@ export const Users = () => <div>
       <label htmlFor={ADMIN_EMAIL}>Email Address</label>
     </div>
     <div className="col-sm-8">
-      <Connect field={ADMIN_EMAIL} validator={validate.email}>
+      <Connect field={ADMIN_EMAIL}>
         <Input type="email" placeholder="admin@example.com" />
       </Connect>
     </div>
@@ -36,7 +36,7 @@ export const Users = () => <div>
       <label htmlFor={ADMIN_PASSWORD}>Password</label>
     </div>
     <div className="col-sm-8">
-      <Connect field={ADMIN_PASSWORD} validator={validate.nonEmpty}>
+      <Connect field={ADMIN_PASSWORD}>
         <Password />
       </Connect>
     </div>
@@ -46,7 +46,7 @@ export const Users = () => <div>
       <label htmlFor={ADMIN_PASSWORD2}>Confirm Password</label>
     </div>
     <div className="col-sm-8">
-      <Connect field={ADMIN_PASSWORD2} validator={validate.nonEmpty}>
+      <Connect field={ADMIN_PASSWORD2}>
         <Password />
       </Connect>
     </div>


### PR DESCRIPTION
With the `Connect` component, `validator` is specified when creating the `Field`, not passed as an attribute to `Connect`.