### PR TITLE
Terraform providers: bump versions to latests releases

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "archive" {
-  version = "0.1.0"
+  version = "1.0.0"
 }
 
 provider "external" {
@@ -15,23 +15,23 @@ provider "ignition" {
 }
 
 provider "local" {
-  version = "0.1.0"
+  version = "1.0.0"
 }
 
 provider "null" {
-  version = "0.1.0"
+  version = "1.0.0"
 }
 
 provider "random" {
-  version = "0.1.0"
+  version = "1.0.0"
 }
 
 provider "template" {
-  version = "0.1.1"
+  version = "1.0.0"
 }
 
 provider "tls" {
-  version = "0.1.0"
+  version = "1.0.0"
 }
 
 variable "tectonic_config_version" {

--- a/modules/dns/ddns/main.tf
+++ b/modules/dns/ddns/main.tf
@@ -1,4 +1,6 @@
 provider "dns" {
+  version = "1.0.0"
+
   update {
     server        = "${var.dns_server}"
     key_name      = "${var.dns_key_name}"

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
-  version = "0.1.4"
+  version = "1.1.0"
 }
 
 data "aws_availability_zones" "azs" {}

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version       = "0.1.7"
+  version       = "0.3.1"
   environment   = "${var.tectonic_azure_cloud_environment}"
   client_secret = "${var.tectonic_azure_client_secret}"
 }

--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -1,5 +1,5 @@
 provider "vsphere" {
-  version              = "0.2.2"
+  version              = "0.4.2"
   vsphere_server       = "${var.tectonic_vmware_server}"
   allow_unverified_ssl = "${var.tectonic_vmware_sslselfsigned}"
 }

--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -159,6 +159,12 @@ class Cluster
       sleep 10
     end
 
+    # Here we're already into timeout condition so
+    # we'll print the journal of the service before raising
+    ips.each do |master_ip|
+      print_service_logs(master_ip, service)
+    end
+
     raise "timeout waiting for #{service} service to bootstrap on any of: #{ips}"
   end
 
@@ -180,5 +186,18 @@ class Cluster
     end
 
     false
+  end
+
+  def print_service_logs(ip, service)
+    command = "journalctl --no-pager -u '#{service}'"
+    begin
+      stdout, stderr, exitcode = ssh_exec(ip, command)
+      puts "Journal of #{service} service on #{ip} (exitcode #{exitcode})"
+      puts "Standard output: \n#{stdout}"
+      puts "Standard error: \n#{stderr}"
+      puts "End of journal of #{service} service on #{ip}"
+    rescue => e
+      puts "Cannot retrieve logs of service #{service} - failed to ssh exec on ip #{ip} with: #{e}"
+    end
   end
 end


### PR DESCRIPTION
We were lagging quite a few versions behind on some of the providers.
This means we're not incorporating potentially critical fixes from upstream. 
This is especially relevant in the light of the recently occurring Azure DNS API errors.

/cc: @sym3tri 