### PR TITLE
frontend: Improve bare metal Matchbox Address page spinner

### DIFF
--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -155,7 +155,6 @@ export const DEFAULT_CLUSTER_CONFIG = {
   ignore: {}, // to store validation errors
   inFly: {}, // to store inFly
   extra: {}, // extraneous, non-value data for this field
-  bootCfgInfly: false, // TODO (ggreer): total hack. clean up after release
   [DESELECTED_FIELDS]: {},
   [BM_MATCHBOX_HTTP]: '',
   [BM_OS_TO_USE]: '',

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
@@ -26,8 +27,6 @@ const stateToProps = ({eventErrors, clusterConfig}) => ({
   http: clusterConfig[BM_MATCHBOX_HTTP],
   osToUse: clusterConfig[BM_OS_TO_USE],
   versionError: eventErrors[COREOS_VERSIONS_ERROR_NAME],
-  // TODO: (ggreer) total hack
-  bootCfgInfly: clusterConfig.bootCfgInfly,
 });
 
 const dispatchToProps = dispatch => ({
@@ -39,14 +38,16 @@ const dispatchToProps = dispatch => ({
         error: null,
       },
     });
-    configActions.set({matchboxHTTP: value}, dispatch);
+    const payload = {
+      [BM_OS_TO_USE]: DEFAULT_CLUSTER_CONFIG[BM_OS_TO_USE],
+      matchboxHTTP: value,
+    };
+    configActions.set(payload, dispatch);
   },
   getOsToUse: matchboxHTTP => {
     if (validate.hostPort(matchboxHTTP)) {
       return;
     }
-
-    configActions.set({bootCfgInfly: true}, dispatch);
 
     const endpointURL = `http://${matchboxHTTP}/assets/coreos`;
     return fetch(`/containerlinux/images/matchbox?endpoint=${encodeURIComponent(endpointURL)}`)
@@ -76,9 +77,7 @@ const dispatchToProps = dispatch => ({
             error: err,
           },
         });
-        configActions.set({[BM_OS_TO_USE]: DEFAULT_CLUSTER_CONFIG[BM_OS_TO_USE]}, dispatch);
-      })
-      .then(() => configActions.set({bootCfgInfly: false}, dispatch));
+      });
   },
 });
 
@@ -103,10 +102,11 @@ export const BM_Matchbox = connect(stateToProps, dispatchToProps)(
     }
 
     render () {
-      const {http, osToUse, versionError, bootCfgInfly} = this.props;
+      const {http, osToUse, versionError} = this.props;
       const osError = osToUse ? false : versionError;
+      const httpError = validate.hostPort(http);
       const iClassNames = classNames('fa', 'fa-refresh', {
-        'fa-spin': bootCfgInfly,
+        'fa-spin': !httpError && _.isEmpty(osToUse) && _.isEmpty(versionError),
       });
 
       return <div className="row form-group">
@@ -131,10 +131,10 @@ export const BM_Matchbox = connect(stateToProps, dispatchToProps)(
                   prefix={<span className="input__prefix--protocol">http://</span>}
                   placeholder="matchbox.example.com:8080"
                   forceDirty={!!osError}
-                  invalid={osError || validate.hostPort(http)}
+                  invalid={osError || httpError}
                   value={http}
                   onValue={v => this.onBootCfg(v)}>
-                  <button className="btn btn-default" disabled={!!validate.hostPort(http)} onClick={() => this.onBootCfg(http, 0)}>
+                  <button className="btn btn-default" disabled={!!httpError} onClick={() => this.onBootCfg(http, 0)}>
                     <i className={iClassNames}></i>
                   </button>
                 </Input>


### PR DESCRIPTION
Removes `bootCfgInfly` hack.

Clears `osToUse` (`BM_OS_TO_USE`) and `matchboxHTTP` at the same time, which I think is better to ensure they are consistent.

This causes the spinner to start when you being typing rather than when the API call actually starts, which I think is better since otherwise the call can be so fast that the spinner doesn't visibly animate, giving no visual feedback.