### PR TITLE
platforms/vmware: Add ability to span virtual datacenters

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -7,8 +7,8 @@ This document gives an overview of variables used in the VMware platform of the 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
 | tectonic_vmware_controller_domain | The domain name which resolves to controller node(s) | string | - |
-| tectonic_vmware_datacenter | Virtual DataCenter to deploy VMs | string | - |
 | tectonic_vmware_etcd_clusters | Terraform map of etcd node(s) vSphere Clusters, Example:   tectonic_vmware_etcd_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1"   "2" = "myvmwarecluster-2" } | map | - |
+| tectonic_vmware_etcd_datacenters | terraform map of etcd node(s) Virtual DataCenters, example:   tectonic_vmware_etcd_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1"   "2" = "myvmwaredc-2" } | map | - |
 | tectonic_vmware_etcd_datastore | The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
 | tectonic_vmware_etcd_gateway | Default Gateway IP address for etcd nodes(s) | string | - |
 | tectonic_vmware_etcd_hostnames | Terraform map of etcd node(s) Hostnames, Example:   tectonic_vmware_etcd_hostnames = {   "0" = "mycluster-etcd-0"   "1" = "mycluster-etcd-1"   "2" = "mycluster-etcd-2" } | map | - |
@@ -18,6 +18,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_folder | vSphere Folder to create and add the Tectonic nodes | string | - |
 | tectonic_vmware_ingress_domain | The domain name which resolves to Tectonic Ingress (i.e. worker node(s)) | string | - |
 | tectonic_vmware_master_clusters | Terraform map of master node(s) vSphere Clusters, Example:   tectonic_vmware_master_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
+| tectonic_vmware_master_datacenters | terraform map of master node(s) Virtual DataCenters, example:   tectonic_vmware_master_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1"   "2" = "myvmwaredc-2" } | map | - |
 | tectonic_vmware_master_datastore | The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
 | tectonic_vmware_master_gateway | Default Gateway IP address for Master nodes(s) | string | - |
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:   tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
@@ -33,6 +34,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_worker_clusters | Terraform map of worker node(s) vSphere Clusters, Example:   tectonic_vmware_worker_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
+| tectonic_vmware_worker_datacenters | terraform map of worker node(s) Virtual DataCenters, example:   tectonic_vmware_worker_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1" } | map | - |
 | tectonic_vmware_worker_datastore | The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
 | tectonic_vmware_worker_gateway | Default Gateway IP address for Master nodes(s) | string | - |
 | tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:   tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -173,9 +173,6 @@ tectonic_vanilla_k8s = false
 // The domain name which resolves to controller node(s)
 tectonic_vmware_controller_domain = ""
 
-// Virtual DataCenter to deploy VMs
-tectonic_vmware_datacenter = ""
-
 // Terraform map of etcd node(s) vSphere Clusters, Example:
 //   tectonic_vmware_etcd_clusters = {
 //   "0" = "myvmwarecluster-0"
@@ -183,6 +180,14 @@ tectonic_vmware_datacenter = ""
 //   "2" = "myvmwarecluster-2"
 // }
 tectonic_vmware_etcd_clusters = ""
+
+// terraform map of etcd node(s) Virtual DataCenters, example:
+//   tectonic_vmware_etcd_datacenters = {
+//   "0" = "myvmwaredc-0"
+//   "1" = "myvmwaredc-1"
+//   "2" = "myvmwaredc-2"
+// }
+tectonic_vmware_etcd_datacenters = ""
 
 // The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_etcd_datastore = ""
@@ -224,6 +229,14 @@ tectonic_vmware_ingress_domain = ""
 //   "1" = "myvmwarecluster-1"
 // }
 tectonic_vmware_master_clusters = ""
+
+// terraform map of master node(s) Virtual DataCenters, example:
+//   tectonic_vmware_master_datacenters = {
+//   "0" = "myvmwaredc-0"
+//   "1" = "myvmwaredc-1"
+//   "2" = "myvmwaredc-2"
+// }
+tectonic_vmware_master_datacenters = ""
 
 // The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_master_datastore = ""
@@ -281,6 +294,13 @@ tectonic_vmware_vm_template_folder = ""
 //   "1" = "myvmwarecluster-1"
 // }
 tectonic_vmware_worker_clusters = ""
+
+// terraform map of worker node(s) Virtual DataCenters, example:
+//   tectonic_vmware_worker_datacenters = {
+//   "0" = "myvmwaredc-0"
+//   "1" = "myvmwaredc-1"
+// }
+tectonic_vmware_worker_datacenters = ""
 
 // The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_worker_datastore = ""

--- a/modules/vmware/etcd/nodes.tf
+++ b/modules/vmware/etcd/nodes.tf
@@ -1,7 +1,7 @@
 resource "vsphere_virtual_machine" "etcd_node" {
   count      = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
   name       = "${var.hostname["${count.index}"]}"
-  datacenter = "${var.vmware_datacenter}"
+  datacenter = "${var.vmware_datacenters["${count.index}"]}"
   cluster    = "${var.vmware_clusters["${count.index}"]}"
   vcpu       = "${var.vm_vcpu}"
   memory     = "${var.vm_memory}"

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -30,8 +30,8 @@ variable core_public_keys {
   description = "Public Key for Core User"
 }
 
-variable vmware_datacenter {
-  type        = "string"
+variable vmware_datacenters {
+  type        = "map"
   description = "vSphere Datacenter to create VMs in"
 }
 

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -1,7 +1,7 @@
 resource "vsphere_virtual_machine" "node" {
   count      = "${var.instance_count}"
   name       = "${var.hostname["${count.index}"]}"
-  datacenter = "${var.vmware_datacenter}"
+  datacenter = "${var.vmware_datacenters["${count.index}"]}"
   cluster    = "${var.vmware_clusters["${count.index}"]}"
   vcpu       = "${var.vm_vcpu}"
   memory     = "${var.vm_memory}"

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -93,8 +93,8 @@ variable "vmware_clusters" {
   description = "vSphere Cluster to create VMs in"
 }
 
-variable "vmware_datacenter" {
-  type        = "string"
+variable "vmware_datacenters" {
+  type        = "map"
   description = "vSphere Datacenter to create VMs in"
 }
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -21,7 +21,7 @@ module "etcd" {
   ip_address = "${var.tectonic_vmware_etcd_ip}"
   gateway    = "${var.tectonic_vmware_etcd_gateway}"
 
-  vmware_datacenter       = "${var.tectonic_vmware_datacenter}"
+  vmware_datacenters      = "${var.tectonic_vmware_etcd_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_etcd_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_etcd_vcpu}"
   vm_memory               = "${var.tectonic_vmware_etcd_memory}"
@@ -67,7 +67,7 @@ module "masters" {
 
   container_images = "${var.tectonic_container_images}"
 
-  vmware_datacenter       = "${var.tectonic_vmware_datacenter}"
+  vmware_datacenters      = "${var.tectonic_vmware_master_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_master_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_master_vcpu}"
   vm_memory               = "${var.tectonic_vmware_master_memory}"
@@ -117,7 +117,7 @@ module "workers" {
 
   container_images = "${var.tectonic_container_images}"
 
-  vmware_datacenter       = "${var.tectonic_vmware_datacenter}"
+  vmware_datacenters      = "${var.tectonic_vmware_worker_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_worker_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_worker_vcpu}"
   vm_memory               = "${var.tectonic_vmware_worker_memory}"

--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -6,5 +6,5 @@ provider "vsphere" {
 
 resource "vsphere_folder" "tectonic_vsphere_folder" {
   path       = "${var.tectonic_vmware_folder}"
-  datacenter = "${var.tectonic_vmware_datacenter}"
+  datacenter = "${var.tectonic_vmware_worker_datacenters[0]}"
 }

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -30,11 +30,6 @@ variable "tectonic_vmware_network" {
   description = "Portgroup to attach the cluster nodes"
 }
 
-variable "tectonic_vmware_datacenter" {
-  type        = "string"
-  description = "Virtual DataCenter to deploy VMs"
-}
-
 // # Global
 
 variable "tectonic_vmware_ssh_authorized_key" {
@@ -105,6 +100,19 @@ variable "tectonic_vmware_etcd_clusters" {
 EOF
 }
 
+variable "tectonic_vmware_etcd_datacenters" {
+  type = "map"
+
+  description = <<EOF
+  terraform map of etcd node(s) Virtual DataCenters, example:
+  tectonic_vmware_etcd_datacenters = {
+  "0" = "myvmwaredc-0"
+  "1" = "myvmwaredc-1"
+  "2" = "myvmwaredc-2"
+}
+EOF
+}
+
 variable "tectonic_vmware_etcd_ip" {
   type = "map"
 
@@ -167,6 +175,19 @@ variable "tectonic_vmware_master_clusters" {
 EOF
 }
 
+variable "tectonic_vmware_master_datacenters" {
+  type = "map"
+
+  description = <<EOF
+  terraform map of master node(s) Virtual DataCenters, example:
+  tectonic_vmware_master_datacenters = {
+  "0" = "myvmwaredc-0"
+  "1" = "myvmwaredc-1"
+  "2" = "myvmwaredc-2"
+}
+EOF
+}
+
 variable "tectonic_vmware_master_ip" {
   type = "map"
 
@@ -224,6 +245,18 @@ variable "tectonic_vmware_worker_clusters" {
   tectonic_vmware_worker_clusters = {
   "0" = "myvmwarecluster-0"
   "1" = "myvmwarecluster-1"
+}
+EOF
+}
+
+variable "tectonic_vmware_worker_datacenters" {
+  type = "map"
+
+  description = <<EOF
+  terraform map of worker node(s) Virtual DataCenters, example:
+  tectonic_vmware_worker_datacenters = {
+  "0" = "myvmwaredc-0"
+  "1" = "myvmwaredc-1"
 }
 EOF
 }


### PR DESCRIPTION
Currently, Tectonic clusters must reside entirely within a virtual
datacenter.  This change will allow the virtual machines to be mapped to
the virtual datacenters.

Jira issue: https://jira.prod.coreos.systems/browse/FR-361