### PR TITLE
config.tf: Bump tectonic version to 1.8.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -117,7 +117,7 @@ variable "tectonic_versions" {
     etcd          = "3.1.8"
     kubernetes    = "1.7.5+tectonic.1"
     monitoring    = "1.7.0"
-    tectonic      = "1.7.5-tectonic.1"
+    tectonic      = "1.8.2-tectonic.1"
     tectonic-etcd = "0.0.1"
     cluo          = "0.2.3"
   }


### PR DESCRIPTION
This is a placeholder so that the [release automation job](https://jenkins-tectonic-installer.prod.coreos.systems/job/tectonic-release-automation/) can generate
a new payload, which will be used by [nightly upgrade test job](https://jenkins-tectonic-installer.prod.coreos.systems/job/upgrade-test/).

Ideally this could be done automatically when we cut a release branch.