### PR TITLE
kube-dns.yaml, identity/services.yaml: Add targetPort parts.

### DIFF
--- a/modules/bootkube/resources/manifests/kube-dns.yaml
+++ b/modules/bootkube/resources/manifests/kube-dns.yaml
@@ -15,9 +15,11 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
+    targetPort: 53
   - name: dns-tcp
     port: 53
     protocol: TCP
+    targetPort: 53
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/modules/tectonic/resources/manifests/identity/services.yaml
+++ b/modules/tectonic/resources/manifests/identity/services.yaml
@@ -14,6 +14,7 @@ spec:
   - name: worker
     protocol: TCP
     port: 5556
+    targetPort: 5556
 ---
 apiVersion: v1
 kind: Service
@@ -28,3 +29,4 @@ spec:
   - name: api
     protocol: TCP
     port: 5557
+    targetPort: 5557


### PR DESCRIPTION
This fixes the patch merge conflict because the upstream patch
merge code can't handle targetPort well.