### PR TITLE
platforms/vmware: Add ability to span VMware clusters

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -6,9 +6,9 @@ This document gives an overview of variables used in the VMware platform of the 
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
-| tectonic_vmware_cluster | vCenter Cluster used to create VMs under | string | - |
 | tectonic_vmware_controller_domain | The domain name which resolves to controller node(s) | string | - |
 | tectonic_vmware_datacenter | Virtual DataCenter to deploy VMs | string | - |
+| tectonic_vmware_etcd_clusters | Terraform map of etcd node(s) vSphere Clusters, Example:   tectonic_vmware_etcd_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1"   "2" = "myvmwarecluster-2" } | map | - |
 | tectonic_vmware_etcd_datastore | The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
 | tectonic_vmware_etcd_gateway | Default Gateway IP address for etcd nodes(s) | string | - |
 | tectonic_vmware_etcd_hostnames | Terraform map of etcd node(s) Hostnames, Example:   tectonic_vmware_etcd_hostnames = {   "0" = "mycluster-etcd-0"   "1" = "mycluster-etcd-1"   "2" = "mycluster-etcd-2" } | map | - |
@@ -17,6 +17,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_etcd_vcpu | etcd node(s) VM vCPU count | string | `1` |
 | tectonic_vmware_folder | vSphere Folder to create and add the Tectonic nodes | string | - |
 | tectonic_vmware_ingress_domain | The domain name which resolves to Tectonic Ingress (i.e. worker node(s)) | string | - |
+| tectonic_vmware_master_clusters | Terraform map of master node(s) vSphere Clusters, Example:   tectonic_vmware_master_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
 | tectonic_vmware_master_datastore | The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
 | tectonic_vmware_master_gateway | Default Gateway IP address for Master nodes(s) | string | - |
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:   tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
@@ -31,6 +32,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_sslselfsigned | Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"` | string | - |
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |
+| tectonic_vmware_worker_clusters | Terraform map of worker node(s) vSphere Clusters, Example:   tectonic_vmware_worker_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
 | tectonic_vmware_worker_datastore | The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
 | tectonic_vmware_worker_gateway | Default Gateway IP address for Master nodes(s) | string | - |
 | tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:   tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -165,6 +165,14 @@ tectonic_vmware_controller_domain = ""
 // Virtual DataCenter to deploy VMs
 tectonic_vmware_datacenter = ""
 
+// Terraform map of etcd node(s) vSphere Clusters, Example:
+//   tectonic_vmware_etcd_clusters = {
+//   "0" = "myvmwarecluster-0"
+//   "1" = "myvmwarecluster-1"
+//   "2" = "myvmwarecluster-2"
+// }
+tectonic_vmware_etcd_clusters = ""
+
 // The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_etcd_datastore = ""
 
@@ -178,14 +186,6 @@ tectonic_vmware_etcd_gateway = ""
 //   "2" = "mycluster-etcd-2"
 // }
 tectonic_vmware_etcd_hostnames = ""
-
-//  Terraform map of etcd node(s) vSphere Clusters, Example:
-//    tectonic_vmware_etcd_clusters = {
-//    "0" = "myvmwarecluster-0"
-//    "1" = "myvmwarecluster-1"
-//    "2" = "myvmwarecluster-2"
-// }
-tectonic_vmware_etcd_clusters = ""
 
 // Terraform map of etcd node(s) IP Addresses, Example:
 //   tectonic_vmware_etcd_ip = {
@@ -207,6 +207,13 @@ tectonic_vmware_folder = ""
 // The domain name which resolves to Tectonic Ingress (i.e. worker node(s))
 tectonic_vmware_ingress_domain = ""
 
+// Terraform map of master node(s) vSphere Clusters, Example:
+//   tectonic_vmware_master_clusters = {
+//   "0" = "myvmwarecluster-0"
+//   "1" = "myvmwarecluster-1"
+// }
+tectonic_vmware_master_clusters = ""
+
 // The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_master_datastore = ""
 
@@ -219,13 +226,6 @@ tectonic_vmware_master_gateway = ""
 //   "1" = "mycluster-master-1"
 // }
 tectonic_vmware_master_hostnames = ""
-
-//  Terraform map of master node(s) vSphere Clusters, Example:
-//    tectonic_vmware_master_clusters = {
-//    "0" = "myvmwarecluster-0"
-//    "1" = "myvmwarecluster-1"
-// }
-tectonic_vmware_master_clusters = ""
 
 // Terraform map of Master node(s) IP Addresses, Example:
 //   tectonic_vmware_master_ip = {
@@ -264,6 +264,13 @@ tectonic_vmware_vm_template = ""
 // Folder for VM template of CoreOS Container Linux.
 tectonic_vmware_vm_template_folder = ""
 
+// Terraform map of worker node(s) vSphere Clusters, Example:
+//   tectonic_vmware_worker_clusters = {
+//   "0" = "myvmwarecluster-0"
+//   "1" = "myvmwarecluster-1"
+// }
+tectonic_vmware_worker_clusters = ""
+
 // The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_worker_datastore = ""
 
@@ -276,13 +283,6 @@ tectonic_vmware_worker_gateway = ""
 //   "1" = "mycluster-worker-1"
 // }
 tectonic_vmware_worker_hostnames = ""
-
-//  Terraform map of worker node(s) vSphere Clusters, Example:
-//    tectonic_vmware_worker_clusters = {
-//    "0" = "myvmwarecluster-0"
-//    "1" = "myvmwarecluster-1"
-// }
-tectonic_vmware_worker_clusters = ""
 
 // Terraform map of Worker node(s) IP Addresses, Example:
 //   tectonic_vmware_worker_ip = {

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -159,9 +159,6 @@ tectonic_pull_secret_path = ""
 // If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
 tectonic_vanilla_k8s = false
 
-// vCenter Cluster used to create VMs under
-tectonic_vmware_cluster = ""
-
 // The domain name which resolves to controller node(s)
 tectonic_vmware_controller_domain = ""
 
@@ -181,6 +178,14 @@ tectonic_vmware_etcd_gateway = ""
 //   "2" = "mycluster-etcd-2"
 // }
 tectonic_vmware_etcd_hostnames = ""
+
+//  Terraform map of etcd node(s) vSphere Clusters, Example:
+//    tectonic_vmware_etcd_clusters = {
+//    "0" = "myvmwarecluster-0"
+//    "1" = "myvmwarecluster-1"
+//    "2" = "myvmwarecluster-2"
+// }
+tectonic_vmware_etcd_clusters = ""
 
 // Terraform map of etcd node(s) IP Addresses, Example:
 //   tectonic_vmware_etcd_ip = {
@@ -214,6 +219,13 @@ tectonic_vmware_master_gateway = ""
 //   "1" = "mycluster-master-1"
 // }
 tectonic_vmware_master_hostnames = ""
+
+//  Terraform map of master node(s) vSphere Clusters, Example:
+//    tectonic_vmware_master_clusters = {
+//    "0" = "myvmwarecluster-0"
+//    "1" = "myvmwarecluster-1"
+// }
+tectonic_vmware_master_clusters = ""
 
 // Terraform map of Master node(s) IP Addresses, Example:
 //   tectonic_vmware_master_ip = {
@@ -264,6 +276,13 @@ tectonic_vmware_worker_gateway = ""
 //   "1" = "mycluster-worker-1"
 // }
 tectonic_vmware_worker_hostnames = ""
+
+//  Terraform map of worker node(s) vSphere Clusters, Example:
+//    tectonic_vmware_worker_clusters = {
+//    "0" = "myvmwarecluster-0"
+//    "1" = "myvmwarecluster-1"
+// }
+tectonic_vmware_worker_clusters = ""
 
 // Terraform map of Worker node(s) IP Addresses, Example:
 //   tectonic_vmware_worker_ip = {

--- a/modules/vmware/etcd/nodes.tf
+++ b/modules/vmware/etcd/nodes.tf
@@ -2,7 +2,7 @@ resource "vsphere_virtual_machine" "etcd_node" {
   count      = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
   name       = "${var.hostname["${count.index}"]}"
   datacenter = "${var.vmware_datacenter}"
-  cluster    = "${var.vmware_cluster}"
+  cluster    = "${var.vmware_clusters["${count.index}"]}"
   vcpu       = "${var.vm_vcpu}"
   memory     = "${var.vm_memory}"
   folder     = "${var.vmware_folder}"

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -35,8 +35,8 @@ variable vmware_datacenter {
   description = "vSphere Datacenter to create VMs in"
 }
 
-variable vmware_cluster {
-  type        = "string"
+variable vmware_clusters {
+  type        = "map"
   description = "vSphere Cluster to create VMs in"
 }
 

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -2,7 +2,7 @@ resource "vsphere_virtual_machine" "node" {
   count      = "${var.instance_count}"
   name       = "${var.hostname["${count.index}"]}"
   datacenter = "${var.vmware_datacenter}"
-  cluster    = "${var.vmware_cluster}"
+  cluster    = "${var.vmware_clusters["${count.index}"]}"
   vcpu       = "${var.vm_vcpu}"
   memory     = "${var.vm_memory}"
   folder     = "${var.vmware_folder}"

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -88,8 +88,8 @@ variable "vm_vcpu" {
   description = "VMs vCPU count"
 }
 
-variable "vmware_cluster" {
-  type        = "string"
+variable "vmware_clusters" {
+  type        = "map"
   description = "vSphere Cluster to create VMs in"
 }
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -22,7 +22,7 @@ module "etcd" {
   gateway    = "${var.tectonic_vmware_etcd_gateway}"
 
   vmware_datacenter       = "${var.tectonic_vmware_datacenter}"
-  vmware_cluster          = "${var.tectonic_vmware_cluster}"
+  vmware_clusters         = "${var.tectonic_vmware_etcd_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_etcd_vcpu}"
   vm_memory               = "${var.tectonic_vmware_etcd_memory}"
   vm_network_label        = "${var.tectonic_vmware_network}"
@@ -68,7 +68,7 @@ module "masters" {
   container_images = "${var.tectonic_container_images}"
 
   vmware_datacenter       = "${var.tectonic_vmware_datacenter}"
-  vmware_cluster          = "${var.tectonic_vmware_cluster}"
+  vmware_clusters         = "${var.tectonic_vmware_master_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_master_vcpu}"
   vm_memory               = "${var.tectonic_vmware_master_memory}"
   vm_network_label        = "${var.tectonic_vmware_network}"
@@ -118,7 +118,7 @@ module "workers" {
   container_images = "${var.tectonic_container_images}"
 
   vmware_datacenter       = "${var.tectonic_vmware_datacenter}"
-  vmware_cluster          = "${var.tectonic_vmware_cluster}"
+  vmware_clusters         = "${var.tectonic_vmware_worker_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_worker_vcpu}"
   vm_memory               = "${var.tectonic_vmware_worker_memory}"
   vm_network_label        = "${var.tectonic_vmware_network}"

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -35,11 +35,6 @@ variable "tectonic_vmware_datacenter" {
   description = "Virtual DataCenter to deploy VMs"
 }
 
-variable "tectonic_vmware_cluster" {
-  type        = "string"
-  description = "vCenter Cluster used to create VMs under"
-}
-
 // # Global
 
 variable "tectonic_vmware_ssh_authorized_key" {
@@ -97,6 +92,19 @@ variable "tectonic_vmware_etcd_hostnames" {
 EOF
 }
 
+variable "tectonic_vmware_etcd_clusters" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of etcd node(s) vSphere Clusters, Example:
+  tectonic_vmware_etcd_clusters = {
+  "0" = "myvmwarecluster-0"
+  "1" = "myvmwarecluster-1"
+  "2" = "myvmwarecluster-2"
+}
+EOF
+}
+
 variable "tectonic_vmware_etcd_ip" {
   type = "map"
 
@@ -147,6 +155,18 @@ variable "tectonic_vmware_master_hostnames" {
 EOF
 }
 
+variable "tectonic_vmware_master_clusters" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of master node(s) vSphere Clusters, Example:
+  tectonic_vmware_master_clusters = {
+  "0" = "myvmwarecluster-0"
+  "1" = "myvmwarecluster-1"
+}
+EOF
+}
+
 variable "tectonic_vmware_master_ip" {
   type = "map"
 
@@ -192,6 +212,18 @@ variable "tectonic_vmware_worker_hostnames" {
   tectonic_vmware_worker_hostnames = {
   "0" = "mycluster-worker-0"
   "1" = "mycluster-worker-1"
+}
+EOF
+}
+
+variable "tectonic_vmware_worker_clusters" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of worker node(s) vSphere Clusters, Example:
+  tectonic_vmware_worker_clusters = {
+  "0" = "myvmwarecluster-0"
+  "1" = "myvmwarecluster-1"
 }
 EOF
 }


### PR DESCRIPTION
Currently, Tectonic clusters are restricted to using a single VMWare
cluster.  VMware clusters allow HA behavior at the VM level.  This change
will allow virtual machines to be mapped to VMware clusters.

Jira issue: https://jira.prod.coreos.systems/browse/FR-363