### PR TITLE
Addresses FR-425

### DIFF
--- a/modules/ignition/resources/services/init-assets.service
+++ b/modules/ignition/resources/services/init-assets.service
@@ -2,6 +2,8 @@
 Description=Download Tectonic Assets
 ConditionPathExists=!/opt/init_assets.done
 Before=bootkube.service kubelet-env.service
+Wants=network-online.target network.target
+After=network-online.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This change makes init_assets.service dependant on
network-online.target.

This will ensure that the service waits until resolv.conf on the node is
present before trying to fetch assets.