### PR TITLE
1.7.9: restore tectonic-namespace.yaml.

### DIFF
--- a/modules/bootkube/resources/manifests/01-tectonic-namespace.yaml
+++ b/modules/bootkube/resources/manifests/01-tectonic-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tectonic-system # Create the namespace first.


### PR DESCRIPTION
I erroneously assumed that there was still another one in the tectonic
module, and merged it because the smoke tests passed.