### PR TITLE
platforms/vmware: Add ability to assign VMs to resource pools

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -14,6 +14,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_etcd_hostnames | Terraform map of etcd node(s) Hostnames, Example:   tectonic_vmware_etcd_hostnames = {   "0" = "mycluster-etcd-0"   "1" = "mycluster-etcd-1"   "2" = "mycluster-etcd-2" } | map | - |
 | tectonic_vmware_etcd_ip | Terraform map of etcd node(s) IP Addresses, Example:   tectonic_vmware_etcd_ip = {   "0" = "192.168.246.10/24"   "1" = "192.168.246.11/24"   "2" = "192.168.246.12/24" } | map | - |
 | tectonic_vmware_etcd_memory | etcd node(s) VM Memory Size in MB | string | `4096` |
+| tectonic_vmware_etcd_resource_pool | Terraform map of etcd node(s) vSphere Resource Pools, Example:   tectonic_vmware_etcd_resource_pool = {   "0" = "myresourcepool-0"   "1" = "myresourcepool-1"   "2" = "myresourcepool-2" } | map | - |
 | tectonic_vmware_etcd_vcpu | etcd node(s) VM vCPU count | string | `1` |
 | tectonic_vmware_folder | vSphere Folder to create and add the Tectonic nodes | string | - |
 | tectonic_vmware_ingress_domain | The domain name which resolves to Tectonic Ingress (i.e. worker node(s)) | string | - |
@@ -24,6 +25,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:   tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
 | tectonic_vmware_master_ip | Terraform map of Master node(s) IP Addresses, Example:   tectonic_vmware_master_ip = {   "0" = "192.168.246.20/24"   "1" = "192.168.246.21/24" } | map | - |
 | tectonic_vmware_master_memory | Master node(s) Memory Size in MB | string | `4096` |
+| tectonic_vmware_master_resource_pool | Terraform map of master node(s) vSphere Resource pools, Example:   tectonic_vmware_master_resource_pool = {   "0" = "myresourcepool-0"   "1" = "myresourcepool-1" } | map | - |
 | tectonic_vmware_master_vcpu | Master node(s) vCPU count | string | `1` |
 | tectonic_vmware_network | Portgroup to attach the cluster nodes | string | - |
 | tectonic_vmware_node_dns | DNS Server to be used by Virtual Machine(s). Multiple DNS servers can be separated by whitespace. Example: `"192.168.1.1 192.168.2.1"` | string | - |
@@ -40,5 +42,6 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:   tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |
 | tectonic_vmware_worker_ip | Terraform map of Worker node(s) IP Addresses, Example:   tectonic_vmware_worker_ip = {   "0" = "192.168.246.30/24"   "1" = "192.168.246.31/24" } | map | - |
 | tectonic_vmware_worker_memory | Worker node(s) Memory Size in MB | string | `4096` |
+| tectonic_vmware_worker_resource_pool | Terraform map of worker node(s) vSphere Resource Pools, Example:   tectonic_vmware_worker_resource_pool = {   "0" = "myresourcepool-0"   "1" = "myresourcepool-1" } | map | - |
 | tectonic_vmware_worker_vcpu | Worker node(s) vCPU count | string | `1` |
 

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -214,6 +214,14 @@ tectonic_vmware_etcd_ip = ""
 // etcd node(s) VM Memory Size in MB
 tectonic_vmware_etcd_memory = "4096"
 
+// Terraform map of etcd node(s) vSphere Resource Pools, Example:
+//   tectonic_vmware_etcd_resource_pool = {
+//   "0" = "myresourcepool-0"
+//   "1" = "myresourcepool-1"
+//   "2" = "myresourcepool-2"
+// }
+tectonic_vmware_etcd_resource_pool = ""
+
 // etcd node(s) VM vCPU count
 tectonic_vmware_etcd_vcpu = "1"
 
@@ -260,6 +268,13 @@ tectonic_vmware_master_ip = ""
 
 // Master node(s) Memory Size in MB
 tectonic_vmware_master_memory = "4096"
+
+// Terraform map of master node(s) vSphere Resource pools, Example:
+//   tectonic_vmware_master_resource_pool = {
+//   "0" = "myresourcepool-0"
+//   "1" = "myresourcepool-1"
+// }
+tectonic_vmware_master_resource_pool = ""
 
 // Master node(s) vCPU count
 tectonic_vmware_master_vcpu = "1"
@@ -324,6 +339,13 @@ tectonic_vmware_worker_ip = ""
 
 // Worker node(s) Memory Size in MB
 tectonic_vmware_worker_memory = "4096"
+
+// Terraform map of worker node(s) vSphere Resource Pools, Example:
+//   tectonic_vmware_worker_resource_pool = {
+//   "0" = "myresourcepool-0"
+//   "1" = "myresourcepool-1"
+// }
+tectonic_vmware_worker_resource_pool = ""
 
 // Worker node(s) vCPU count
 tectonic_vmware_worker_vcpu = "1"

--- a/modules/vmware/etcd/nodes.tf
+++ b/modules/vmware/etcd/nodes.tf
@@ -1,12 +1,13 @@
 resource "vsphere_virtual_machine" "etcd_node" {
-  count      = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
-  name       = "${var.hostname["${count.index}"]}"
-  datacenter = "${var.vmware_datacenters["${count.index}"]}"
-  cluster    = "${var.vmware_clusters["${count.index}"]}"
-  vcpu       = "${var.vm_vcpu}"
-  memory     = "${var.vm_memory}"
-  folder     = "${var.vmware_folder}"
-  domain     = "${var.base_domain}"
+  count         = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
+  name          = "${var.hostname["${count.index}"]}"
+  datacenter    = "${var.vmware_datacenters["${count.index}"]}"
+  cluster       = "${var.vmware_clusters["${count.index}"]}"
+  resource_pool = "${var.vmware_resource_pool["${count.index}"]}"
+  vcpu          = "${var.vm_vcpu}"
+  memory        = "${var.vm_memory}"
+  folder        = "${var.vmware_folder}"
+  domain        = "${var.base_domain}"
 
   network_interface {
     label = "${var.vm_network_label}"

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -40,6 +40,11 @@ variable vmware_clusters {
   description = "vSphere Cluster to create VMs in"
 }
 
+variable "vmware_resource_pool" {
+  type        = "map"
+  description = "vSphere resource pool to create VMs in"
+}
+
 variable vm_vcpu {
   type        = "string"
   description = "ETCD VMs vCPU count"

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -1,12 +1,13 @@
 resource "vsphere_virtual_machine" "node" {
-  count      = "${var.instance_count}"
-  name       = "${var.hostname["${count.index}"]}"
-  datacenter = "${var.vmware_datacenters["${count.index}"]}"
-  cluster    = "${var.vmware_clusters["${count.index}"]}"
-  vcpu       = "${var.vm_vcpu}"
-  memory     = "${var.vm_memory}"
-  folder     = "${var.vmware_folder}"
-  domain     = "${var.base_domain}"
+  count         = "${var.instance_count}"
+  name          = "${var.hostname["${count.index}"]}"
+  datacenter    = "${var.vmware_datacenters["${count.index}"]}"
+  cluster       = "${var.vmware_clusters["${count.index}"]}"
+  resource_pool = "${var.vmware_resource_pool["${count.index}"]}"
+  vcpu          = "${var.vm_vcpu}"
+  memory        = "${var.vm_memory}"
+  folder        = "${var.vmware_folder}"
+  domain        = "${var.base_domain}"
 
   network_interface {
     label = "${var.vm_network_label}"

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -58,6 +58,11 @@ variable "ip_address" {
   description = "IP Address of the node"
 }
 
+variable "vmware_resource_pool" {
+  type        = "map"
+  description = "vSphere resource pool to create VMs in"
+}
+
 variable "vm_disk_datastore" {
   type        = "string"
   description = "Datastore to create VM(s) in "

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -23,6 +23,7 @@ module "etcd" {
 
   vmware_datacenters      = "${var.tectonic_vmware_etcd_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_etcd_clusters}"
+  vmware_resource_pool    = "${var.tectonic_vmware_etcd_resource_pool}"
   vm_vcpu                 = "${var.tectonic_vmware_etcd_vcpu}"
   vm_memory               = "${var.tectonic_vmware_etcd_memory}"
   vm_network_label        = "${var.tectonic_vmware_network}"
@@ -69,6 +70,7 @@ module "masters" {
 
   vmware_datacenters      = "${var.tectonic_vmware_master_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_master_clusters}"
+  vmware_resource_pool    = "${var.tectonic_vmware_master_resource_pool}"
   vm_vcpu                 = "${var.tectonic_vmware_master_vcpu}"
   vm_memory               = "${var.tectonic_vmware_master_memory}"
   vm_network_label        = "${var.tectonic_vmware_network}"
@@ -119,6 +121,7 @@ module "workers" {
 
   vmware_datacenters      = "${var.tectonic_vmware_worker_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_worker_clusters}"
+  vmware_resource_pool    = "${var.tectonic_vmware_worker_resource_pool}"
   vm_vcpu                 = "${var.tectonic_vmware_worker_vcpu}"
   vm_memory               = "${var.tectonic_vmware_worker_memory}"
   vm_network_label        = "${var.tectonic_vmware_network}"

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -113,6 +113,19 @@ variable "tectonic_vmware_etcd_datacenters" {
 EOF
 }
 
+variable "tectonic_vmware_etcd_resource_pool" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of etcd node(s) vSphere Resource Pools, Example:
+  tectonic_vmware_etcd_resource_pool = {
+  "0" = "myresourcepool-0"
+  "1" = "myresourcepool-1"
+  "2" = "myresourcepool-2"
+}
+EOF
+}
+
 variable "tectonic_vmware_etcd_ip" {
   type = "map"
 
@@ -188,6 +201,18 @@ variable "tectonic_vmware_master_datacenters" {
 EOF
 }
 
+variable "tectonic_vmware_master_resource_pool" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of master node(s) vSphere Resource pools, Example:
+  tectonic_vmware_master_resource_pool = {
+  "0" = "myresourcepool-0"
+  "1" = "myresourcepool-1"
+}
+EOF
+}
+
 variable "tectonic_vmware_master_ip" {
   type = "map"
 
@@ -257,6 +282,18 @@ variable "tectonic_vmware_worker_datacenters" {
   tectonic_vmware_worker_datacenters = {
   "0" = "myvmwaredc-0"
   "1" = "myvmwaredc-1"
+}
+EOF
+}
+
+variable "tectonic_vmware_worker_resource_pool" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of worker node(s) vSphere Resource Pools, Example:
+  tectonic_vmware_worker_resource_pool = {
+  "0" = "myresourcepool-0"
+  "1" = "myresourcepool-1"
 }
 EOF
 }


### PR DESCRIPTION
Currently, all VMs in a cluster must be assigned to a single VMware
resource pool.  This change allows VMs to be assigned to different
resource pools so that, for example, master nodes won't run into a
resource contention with worker nodes.

Jira issue: https://jira.prod.coreos.systems/projects/FR/issues/FR-364