### PR TITLE
frontend: Fix etcd address field to not ask for a port number

### DIFF
--- a/installer/frontend/components/etcd.jsx
+++ b/installer/frontend/components/etcd.jsx
@@ -28,7 +28,7 @@ const fields = [
   }),
   new Field(EXTERNAL_ETCD_CLIENT, {
     default: '',
-    validator: validate.hostPort,
+    validator: validate.host,
     dependencies: [ETCD_OPTION],
     ignoreWhen: cc => cc[ETCD_OPTION] !== ETCD_OPTIONS.EXTERNAL,
   }),
@@ -96,9 +96,9 @@ export const Etcd = connect(({clusterConfig}) => ({
                 autoFocus
                 className="wiz-inline-field wiz-inline-field--protocol"
                 prefix={<span className="input__prefix--protocol">http://</span>}
-                placeholder="etcd.example.com:2379" />
+                placeholder="etcd.example.com" />
             </Connect>
-            <p className="text-muted">Hostname and port of etcd client endpoint</p>
+            <p className="text-muted">Hostname or IP address of etcd client endpoint</p>
           </div>
         </div>
       </div>

--- a/installer/frontend/ui-tests/pages/etcdConnectionPage.js
+++ b/installer/frontend/ui-tests/pages/etcdConnectionPage.js
@@ -5,9 +5,9 @@ const pageCommands = {
 
     this
       .selectOption('@optionExternal')
-      .setField('@address', 'abc')
-      .expectValidationErrorContains('Invalid format')
       .setField('@address', 'example.com:1234')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@address', 'example.com')
       .expectNoValidationError();
 
     this.selectOption('@optionProvisioned');


### PR DESCRIPTION
`tectonic_etcd_servers` shouldn't include a port number, so the UI shouldn't be asking for it.

![screenshot-1](https://user-images.githubusercontent.com/460802/32151147-cc06eb7e-bd5d-11e7-9a88-5cbc0cbcb29b.png)

---

![screenshot-3](https://user-images.githubusercontent.com/460802/32151148-ced30c16-bd5d-11e7-8ae0-b05923b21dd1.png)
