### PR TITLE
tests: Remove unused param reference

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,7 +196,6 @@ pipeline {
         TECTONIC_INSTALLER_ROLE = 'tectonic-installer'
         GRAFITI_DELETER_ROLE = 'grafiti-deleter'
         TF_VAR_tectonic_container_images = "${params.hyperkube_image}"
-        TF_VAR_tectonic_container_linux_version = "${params.container_linux_version}"
         GOOGLE_PROJECT = "tectonic-installer"
       }
       steps {


### PR DESCRIPTION
The container linux version parameter was removed recently. This
reference has to be removed as well. Otherwise, the wanted container
linux version will be an empty string which results in:
```
module.workers.data.aws_ami.coreos_ami: data.aws_ami.coreos_ami: Your
query returned no results. Please change your search criteria and try
again.
```