### PR TITLE
README: Fix broken links to openstack and vmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See [tests/README.md](tests/README.md).
 
 
 [openstack-tf]: https://github.com/coreos/tectonic-docs/blob/master/Documentation/install/openstack/openstack-terraform.md
-[platform-lifecycle]: Documentation/platform-lifecycle.md
+[platform-lifecycle]: https://coreos.com/tectonic/docs/latest/platform-lifecycle.html
 [release-notes]: https://coreos.com/tectonic/releases/
 [rhel-installation]: https://coreos.com/tectonic/docs/latest/install/rhel/installing-workers.html
 [vmware-tf]: https://github.com/coreos/tectonic-docs/blob/master/Documentation/install/vmware/vmware-terraform.md

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ See the official Tectonic documentation:
 
 These instructions can be used for the official stable platforms listed above, and for the following alpha/beta platforms:
 
-- [OpenStack via Terraform](Documentation/install/openstack/openstack-terraform.md) [[**alpha**][platform-lifecycle]]
-- [VMware via Terraform](Documentation/install/vmware/vmware-terraform.md) [[**alpha**][platform-lifecycle]]
+- [OpenStack via Terraform][openstack-tf] [[**alpha**][platform-lifecycle]]
+- [VMware via Terraform][vmware-tf] [[**alpha**][platform-lifecycle]]
 
 **Go and Source**
 
@@ -64,8 +64,8 @@ The [Yarn](https://yarnpkg.com) JavaScript package manager is required for build
 
 First, set the `PLATFORM=` environment variable. This example will use `PLATFORM=azure`.
 
-- `PLATFORM=openstack` [OpenStack via Terraform](Documentation/install/openstack/openstack-terraform.md) [[**alpha**][platform-lifecycle]]
-- `PLATFORM=vmware` [VMware via Terraform](Documentation/install/vmware/vmware-terraform.md) [[**alpha**][platform-lifecycle]]
+- `PLATFORM=openstack` [OpenStack via Terraform][openstack-tf] [[**alpha**][platform-lifecycle]]
+- `PLATFORM=vmware` [VMware via Terraform][vmware-tf] [[**alpha**][platform-lifecycle]]
 
 **Initiate the Cluster Configuration**
 
@@ -102,6 +102,8 @@ PLATFORM=azure CLUSTER=my-cluster make destroy
 See [tests/README.md](tests/README.md).
 
 
+[openstack-tf]: https://github.com/coreos/tectonic-docs/blob/master/Documentation/install/openstack/openstack-terraform.md
 [platform-lifecycle]: Documentation/platform-lifecycle.md
 [release-notes]: https://coreos.com/tectonic/releases/
 [rhel-installation]: https://coreos.com/tectonic/docs/latest/install/rhel/installing-workers.html
+[vmware-tf]: https://github.com/coreos/tectonic-docs/blob/master/Documentation/install/vmware/vmware-terraform.md


### PR DESCRIPTION
Update links to openstack and vmware terraform install docs, and make them reference format, too.

Ref: https://coreos.slack.com/archives/C2ZA5QGMV/p1509456941000394