### PR TITLE
frontend: Clean up "dirty" / "clean" actions

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -27,6 +27,10 @@ export const dirtyActionTypes = {
   ADD: 'DIRTY_ADD',
   CLEAN: 'DIRTY_CLEAN',
 };
+export const dirtyActions = {
+  add: field => ({type: dirtyActionTypes.ADD, payload: field}),
+  clean: field => ({type: dirtyActionTypes.CLEAN, payload: field}),
+};
 
 export const eventErrorsActionTypes = {
   ERROR: 'EVENT_ERRORS_ERROR',

--- a/installer/frontend/components/bm-nodeforms.jsx
+++ b/installer/frontend/components/bm-nodeforms.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { connect } from 'react-redux';
 
-import { configActions } from '../actions';
+import { configActions, dirtyActions } from '../actions';
 import { Alert } from './alert';
 import { validate } from '../validate';
 import { readFile } from '../readfile';
@@ -16,18 +16,14 @@ import {
   BM_WORKERS,
 } from '../cluster-config';
 
-import {
-  Input,
-  Connect,
-  markIDDirty,
-} from './ui';
+import { Input, Connect } from './ui';
 
 const BulkUpload = connect(null, dispatch => ({
   updateNodes: (fieldID, payload) => {
     dispatch(configActions.updateField(fieldID, payload));
     _.each(payload, (row, i) => {
       _.each(row, (ignore, key) => {
-        markIDDirty(dispatch, [fieldID, i, key].join('.'));
+        dispatch(dirtyActions.add(`${fieldID}.${i}.${key}`));
       });
     });
     dispatch(configActions.updateField(fieldID, payload));
@@ -101,7 +97,7 @@ const BulkUpload = connect(null, dispatch => ({
       if (!csv) {
         body = <div>
           <div>
-          Select a CSV file to populate the node addresses
+            Select a CSV file to populate the node addresses
           </div>
           <div className="wiz-minimodal__body">
             <input type="file" onChange={e => this.handleUpload(e)} />
@@ -112,7 +108,7 @@ const BulkUpload = connect(null, dispatch => ({
         </div>;
       } else if (csv.errors.length) {
         body = <Alert severity="error">
-        Error parsing CSV:
+          Error parsing CSV:
           <ul>
             {csv.errors.map((e, i) => <li key={i}>{e.message} on line {e.row}.</li>)}
           </ul>
@@ -178,7 +174,8 @@ const BulkUpload = connect(null, dispatch => ({
         </div>
       );
     }
-  });
+  }
+);
 
 const generateField = (id, name, maxNodes) => new FieldList(id, {
   fields: {

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -315,7 +315,6 @@ const stateToProps = ({clusterConfig, dirty}, {field}) => ({
 const dispatchToProps = (dispatch, {field}) => ({
   updateField: (path, value, invalid) => dispatch(configActions.updateField(path, value, invalid)),
   makeDirty: () => dispatch(dirtyActions.add(field)),
-  makeClean: () => dispatch(dirtyActions.clean(field)),
   refreshExtraData: () => dispatch(configActions.refreshExtraData(field)),
   removeField: (i) => dispatch(configActions.removeField(field, i)),
   appendField: () => dispatch(configActions.appendField(field)),
@@ -341,7 +340,7 @@ class Connect_ extends React.Component {
   }
 
   render () {
-    const { field, value, invalid, children, isDirty, makeDirty, makeClean,
+    const { field, value, invalid, children, isDirty, makeDirty,
       extraData, refreshExtraData, inFly, removeField, appendField,
     } = this.props;
 
@@ -354,7 +353,6 @@ class Connect_ extends React.Component {
       inFly,
       invalid,
       isDirty,
-      makeClean,
       makeDirty,
       refreshExtraData,
       removeField,


### PR DESCRIPTION
Remove unused `autoClean` `Field` attribute.

Add `dirtyActions` and use to simplify marking fields as dirty:
- Remove `markIDDirty()` helper.
- Rename `markDirty()` and `markDirtyUpload()` to `makeDirty()` to since they are all identical.

Remove now unused `makeClean()`. If in the future a component needs to mark a field as "clean", it can define its own `makeClean()` action.