### PR TITLE
tests: Request all repository labels on PR trigger

### DIFF
--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -59,7 +59,7 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   steps {
     shell """#!/bin/bash -ex
-      curl "https://api.github.com/repos/coreos/tectonic-installer/labels" > repoLabels
+      curl "https://api.github.com/repos/coreos/tectonic-installer/labels?per_page=100" > repoLabels
       repoLabels=\$(jq ".[] | .name" repoLabels)
       repoLabels=\$(echo \$repoLabels | tr -d "\\"" | tr [a-z] [A-Z] | tr - _)
       for label in \$repoLabels


### PR DESCRIPTION
GitHub by default does not return all repository labels, but uses
pagination. This patch bumps the limit to 100 which we will hopefully
never reach.

Thanks @cpanato for uncovering this.