### PR TITLE
tests: Remove redundant container removal step

### DIFF
--- a/installer/scripts/maintenance/clean-aws.sh
+++ b/installer/scripts/maintenance/clean-aws.sh
@@ -156,7 +156,7 @@ if [ ! $force ]; then
   fi
 fi
 
-trap 'docker stop grafiti-deleter && docker rm grafiti-deleter; exit' EXIT
+trap 'docker stop grafiti-deleter; exit' EXIT
 
 docker run -t --rm --name grafiti-deleter \
 	-v "$tmp_dir":/tmp/config:z \

--- a/installer/scripts/maintenance/tag-aws.sh
+++ b/installer/scripts/maintenance/tag-aws.sh
@@ -179,7 +179,7 @@ if [ ! $force ]; then
   fi
 fi
 
-trap 'docker stop grafiti-tagger && docker rm grafiti-tagger; exit' EXIT
+trap 'docker stop grafiti-tagger; exit' EXIT
 
 docker run -t --rm --name grafiti-tagger \
 	-v "$tmp_dir":/tmp/config:z \


### PR DESCRIPTION
The grafiti container is started with the `--rm` flag. Thereby the
following `docker rm` step is not needed and fails as there is no
container to delete. This patch removes the second step.