### PR TITLE
platforms/vmware: Add ability to assign unique gateways, and unique network labels

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -10,9 +10,10 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_etcd_clusters | Terraform map of etcd node(s) vSphere Clusters, Example:   tectonic_vmware_etcd_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1"   "2" = "myvmwarecluster-2" } | map | - |
 | tectonic_vmware_etcd_datacenters | terraform map of etcd node(s) Virtual DataCenters, example:   tectonic_vmware_etcd_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1"   "2" = "myvmwaredc-2" } | map | - |
 | tectonic_vmware_etcd_datastore | The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
-| tectonic_vmware_etcd_gateway | Default Gateway IP address for etcd nodes(s) | string | - |
+| tectonic_vmware_etcd_gateways | Terraform map of default Gateway IP addresses for etcd node(s), Example: tectonic_vmware_etcd_gateways = {   "0" = ""192.168.246.1   "1" = "192.168.246.2"   "2" = "192.168.246.3" } | map | - |
 | tectonic_vmware_etcd_hostnames | Terraform map of etcd node(s) Hostnames, Example:   tectonic_vmware_etcd_hostnames = {   "0" = "mycluster-etcd-0"   "1" = "mycluster-etcd-1"   "2" = "mycluster-etcd-2" } | map | - |
 | tectonic_vmware_etcd_ip | Terraform map of etcd node(s) IP Addresses, Example:   tectonic_vmware_etcd_ip = {   "0" = "192.168.246.10/24"   "1" = "192.168.246.11/24"   "2" = "192.168.246.12/24" } | map | - |
+| tectonic_vmware_etcd_networks | Terraform map of Portgroup to attach the etcd cluster node(s), Example:   tectonic_vmware_etcd_networks = {   "0" = "VM Network 1"   "1" = "VM Network 2"   "2" = "VM Network 3" } | map | - |
 | tectonic_vmware_etcd_memory | etcd node(s) VM Memory Size in MB | string | `4096` |
 | tectonic_vmware_etcd_vcpu | etcd node(s) VM vCPU count | string | `1` |
 | tectonic_vmware_folder | vSphere Folder to create and add the Tectonic nodes | string | - |
@@ -20,12 +21,12 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_master_clusters | Terraform map of master node(s) vSphere Clusters, Example:   tectonic_vmware_master_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
 | tectonic_vmware_master_datacenters | terraform map of master node(s) Virtual DataCenters, example:   tectonic_vmware_master_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1"   "2" = "myvmwaredc-2" } | map | - |
 | tectonic_vmware_master_datastore | The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
-| tectonic_vmware_master_gateway | Default Gateway IP address for Master nodes(s) | string | - |
+| tectonic_vmware_master_gateways | Terraform map of default Gateway IP addresses for master node(s), Example: tectonic_vmware_master_gateways = {   "0" = ""192.168.246.1   "1" = "192.168.246.2"   "2" = "192.168.246.3" } | map | - |
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:   tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
 | tectonic_vmware_master_ip | Terraform map of Master node(s) IP Addresses, Example:   tectonic_vmware_master_ip = {   "0" = "192.168.246.20/24"   "1" = "192.168.246.21/24" } | map | - |
+| tectonic_vmware_master_networks | Terraform map of Portgroup to attach the master cluster node(s), Example:   tectonic_vmware_master_networks = {   "0" = "VM Network 1"   "1" = "VM Network 2"   "2" = "VM Network 3" } | map | - |
 | tectonic_vmware_master_memory | Master node(s) Memory Size in MB | string | `4096` |
 | tectonic_vmware_master_vcpu | Master node(s) vCPU count | string | `1` |
-| tectonic_vmware_network | Portgroup to attach the cluster nodes | string | - |
 | tectonic_vmware_node_dns | DNS Server to be used by Virtual Machine(s). Multiple DNS servers can be separated by whitespace. Example: `"192.168.1.1 192.168.2.1"` | string | - |
 | tectonic_vmware_server | vCenter Server IP/FQDN | string | - |
 | tectonic_vmware_ssh_authorized_key | SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."` | string | - |
@@ -36,9 +37,10 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_worker_clusters | Terraform map of worker node(s) vSphere Clusters, Example:   tectonic_vmware_worker_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
 | tectonic_vmware_worker_datacenters | terraform map of worker node(s) Virtual DataCenters, example:   tectonic_vmware_worker_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1" } | map | - |
 | tectonic_vmware_worker_datastore | The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
-| tectonic_vmware_worker_gateway | Default Gateway IP address for Master nodes(s) | string | - |
+| tectonic_vmware_worker_gateways | Terraform map of default Gateway IP addresses for worker node(s), Example: tectonic_vmware_worker_gateways = {   "0" = ""192.168.246.1   "1" = "192.168.246.2"   "2" = "192.168.246.3" } | map | - |
 | tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:   tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |
 | tectonic_vmware_worker_ip | Terraform map of Worker node(s) IP Addresses, Example:   tectonic_vmware_worker_ip = {   "0" = "192.168.246.30/24"   "1" = "192.168.246.31/24" } | map | - |
+| tectonic_vmware_worker_networks | Terraform map of Portgroup to attach the worker cluster node(s), Example:   tectonic_vmware_worker_networks = {   "0" = "VM Network 1"   "1" = "VM Network 2"   "2" = "VM Network 3" } | map | - |
 | tectonic_vmware_worker_memory | Worker node(s) Memory Size in MB | string | `4096` |
 | tectonic_vmware_worker_vcpu | Worker node(s) vCPU count | string | `1` |
 

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -192,8 +192,13 @@ tectonic_vmware_etcd_datacenters = ""
 // The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_etcd_datastore = ""
 
-// Default Gateway IP address for etcd nodes(s)
-tectonic_vmware_etcd_gateway = ""
+// Terraform map of default Gateway IP address for etcd node(s), Example:
+//   tectonic_vmware_etcd_gateways = {
+//   "0" = "192.168.246.1"
+//   "1" = "192.168.247.1"
+//   "2" = "192.168.248.1"
+// }
+tectonic_vmware_etcd_gateways = ""
 
 // Terraform map of etcd node(s) Hostnames, Example:
 //   tectonic_vmware_etcd_hostnames = {
@@ -210,6 +215,14 @@ tectonic_vmware_etcd_hostnames = ""
 //   "2" = "192.168.246.12/24"
 // }
 tectonic_vmware_etcd_ip = ""
+
+// Terraform map of Portgroup to attach the etcd cluster node(s), Example: */
+//   tectonic_vmware_etcd_networks" {
+//   "0" = "VM Network 1"
+//   "1" = "VM Network 2"
+//   "2" = "VM Network 3"
+// }
+tectonic_vmware_etcd_networks = ""
 
 // etcd node(s) VM Memory Size in MB
 tectonic_vmware_etcd_memory = "4096"
@@ -258,14 +271,19 @@ tectonic_vmware_master_hostnames = ""
 // }
 tectonic_vmware_master_ip = ""
 
+// Terraform map of Portgroup to attach the master cluster node(s), Example: */
+//   tectonic_vmware_master_networks" {
+//   "0" = "VM Network 1"
+//   "1" = "VM Network 2"
+//   "2" = "VM Network 3"
+// }
+tectonic_vmware_master_networks = ""
+
 // Master node(s) Memory Size in MB
 tectonic_vmware_master_memory = "4096"
 
 // Master node(s) vCPU count
 tectonic_vmware_master_vcpu = "1"
-
-// Portgroup to attach the cluster nodes
-tectonic_vmware_network = ""
 
 // DNS Server to be used by Virtual Machine(s). Multiple DNS servers can be separated by whitespace. Example: `"192.168.1.1 192.168.2.1"`
 tectonic_vmware_node_dns = ""
@@ -294,6 +312,14 @@ tectonic_vmware_vm_template_folder = ""
 //   "1" = "myvmwarecluster-1"
 // }
 tectonic_vmware_worker_clusters = ""
+
+// Terraform map of Portgroup to attach the worker cluster node(s), Example: */
+//   tectonic_vmware_worker_networks" {
+//   "0" = "VM Network 1"
+//   "1" = "VM Network 2"
+//   "2" = "VM Network 3"
+// }
+tectonic_vmware_worker_networks = ""
 
 // terraform map of worker node(s) Virtual DataCenters, example:
 //   tectonic_vmware_worker_datacenters = {

--- a/modules/vmware/etcd/ignition.tf
+++ b/modules/vmware/etcd/ignition.tf
@@ -18,7 +18,7 @@ data "ignition_config" "etcd" {
 
   systemd = [
     "${data.ignition_systemd_unit.locksmithd.*.id[count.index]}",
-    "${var.ign_etcd_dropin_id_list[count.index]}",
+    "${data.ignition_systemd_unit.etcd3.*.id[count.index]}",
   ]
 
   networkd = [
@@ -128,12 +128,55 @@ data "ignition_systemd_unit" "locksmithd" {
       name    = "40-etcd-lock.conf"
 
       content = <<EOF
-[Service]
-Environment=REBOOT_STRATEGY=etcd-lock
+[Service] 
+Environment=REBOOT_STRATEGY=etcd-lock 
 Environment=LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/ca.crt
 Environment=LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/client.key
 Environment=LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/client.crt
 Environment=LOCKSMITHD_ENDPOINT=https://${var.hostname["${count.index}"]}.${var.base_domain}:2379
+EOF
+    },
+  ]
+}
+
+data "template_file" "etcd-cluster" {
+  template = "${file("${path.module}/resources/etcd-cluster")}"
+  count    = "${var.instance_count}"
+
+  vars = {
+    etcd-name    = "${var.hostname["${count.index}"]}"
+    etcd-address = "${var.hostname["${count.index}"]}.${var.base_domain}"
+  }
+}
+
+data "ignition_systemd_unit" "etcd3" {
+  count  = "${length(var.external_endpoints) == 0 ? var.instance_count : 0}"
+  name   = "etcd-member.service"
+  enable = true
+
+  dropin = [
+    {
+      name = "40-etcd-cluster.conf"
+
+      content = <<EOF
+[Service]
+Environment="ETCD_IMAGE=${var.container_image}"
+Environment="RKT_RUN_ARGS=--volume etcd-ssl,kind=host,source=/etc/ssl/etcd \
+  --mount volume=etcd-ssl,target=/etc/ssl/etcd"
+ExecStart=
+ExecStart=/usr/lib/coreos/etcd-wrapper \
+--name=${var.hostname["${count.index}"]} \
+--initial-cluster="${join("," , data.template_file.etcd-cluster.*.rendered)}" \
+--advertise-client-urls=https://${var.hostname["${count.index}"]}.${var.base_domain}:2379 \
+--cert-file=/etc/ssl/etcd/server.crt \
+--key-file=/etc/ssl/etcd/server.key \
+--peer-cert-file=/etc/ssl/etcd/peer.crt \
+--peer-key-file=/etc/ssl/etcd/peer.key \
+--peer-trusted-ca-file=/etc/ssl/etcd/ca.crt \
+--peer-client-cert-auth=true \
+--initial-advertise-peer-urls=https://${var.hostname["${count.index}"]}.${var.base_domain}:2380 \
+--listen-client-urls=https://0.0.0.0:2379 \
+--listen-peer-urls=https://0.0.0.0:2380 
 EOF
     },
   ]
@@ -160,7 +203,7 @@ data "ignition_networkd_unit" "vmnetwork" {
   [Network]
   DNS=${var.dns_server}
   Address=${var.ip_address["${count.index}"]}
-  Gateway=${var.gateway}
+  Gateway=${var.gateway["${count.index}"]}
   UseDomains=yes
   Domains=${var.base_domain}
 EOF

--- a/modules/vmware/etcd/nodes.tf
+++ b/modules/vmware/etcd/nodes.tf
@@ -9,7 +9,7 @@ resource "vsphere_virtual_machine" "etcd_node" {
   domain     = "${var.base_domain}"
 
   network_interface {
-    label = "${var.vm_network_label}"
+    label = "${var.vm_network_labels["${count.index}"]}"
   }
 
   disk {

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -50,8 +50,8 @@ variable vm_memory {
   description = "ETCD VMs Memory size in MB"
 }
 
-variable vm_network_label {
-  type        = "string"
+variable vm_network_labels {
+  type        = "map"
   description = "ETCD VMs PortGroup"
 }
 
@@ -81,7 +81,7 @@ variable ip_address {
 }
 
 variable gateway {
-  type        = "string"
+  type        = "map"
   description = "Gateway of the node"
 }
 

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -42,7 +42,7 @@ data "ignition_networkd_unit" "vmnetwork" {
   [Network]
   DNS=${var.dns_server}
   Address=${var.ip_address["${count.index}"]}
-  Gateway=${var.gateway}
+  Gateway=${var.gateway["${count.index}"]}
   UseDomains=yes
   Domains=${var.base_domain}
 EOF

--- a/modules/vmware/node/nodes.tf
+++ b/modules/vmware/node/nodes.tf
@@ -9,7 +9,7 @@ resource "vsphere_virtual_machine" "node" {
   domain     = "${var.base_domain}"
 
   network_interface {
-    label = "${var.vm_network_label}"
+    label = "${var.vm_network_labels["${count.index}"]}"
   }
 
   disk {

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -44,7 +44,7 @@ variable "dns_server" {
 }
 
 variable "gateway" {
-  type        = "string"
+  type        = "map"
   description = "Gateway of the node"
 }
 
@@ -78,8 +78,8 @@ variable "vm_memory" {
   description = "VMs Memory size in MB"
 }
 
-variable "vm_network_label" {
-  type        = "string"
+variable "vm_network_labels" {
+  type        = "map"
   description = "VMs PortGroup"
 }
 

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -19,13 +19,13 @@ module "etcd" {
   hostname   = "${var.tectonic_vmware_etcd_hostnames}"
   dns_server = "${var.tectonic_vmware_node_dns}"
   ip_address = "${var.tectonic_vmware_etcd_ip}"
-  gateway    = "${var.tectonic_vmware_etcd_gateway}"
+  gateway    = "${var.tectonic_vmware_etcd_gateways}"
 
   vmware_datacenters      = "${var.tectonic_vmware_etcd_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_etcd_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_etcd_vcpu}"
   vm_memory               = "${var.tectonic_vmware_etcd_memory}"
-  vm_network_label        = "${var.tectonic_vmware_network}"
+  vm_network_labels       = "${var.tectonic_vmware_etcd_networks}"
   vm_disk_datastore       = "${var.tectonic_vmware_etcd_datastore}"
   vm_disk_template        = "${var.tectonic_vmware_vm_template}"
   vm_disk_template_folder = "${var.tectonic_vmware_vm_template_folder}"
@@ -63,7 +63,7 @@ module "masters" {
   hostname         = "${var.tectonic_vmware_master_hostnames}"
   dns_server       = "${var.tectonic_vmware_node_dns}"
   ip_address       = "${var.tectonic_vmware_master_ip}"
-  gateway          = "${var.tectonic_vmware_master_gateway}"
+  gateway          = "${var.tectonic_vmware_master_gateways}"
 
   container_images = "${var.tectonic_container_images}"
 
@@ -71,7 +71,7 @@ module "masters" {
   vmware_clusters         = "${var.tectonic_vmware_master_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_master_vcpu}"
   vm_memory               = "${var.tectonic_vmware_master_memory}"
-  vm_network_label        = "${var.tectonic_vmware_network}"
+  vm_network_labels       = "${var.tectonic_vmware_master_networks}"
   vm_disk_datastore       = "${var.tectonic_vmware_master_datastore}"
   vm_disk_template        = "${var.tectonic_vmware_vm_template}"
   vm_disk_template_folder = "${var.tectonic_vmware_vm_template_folder}"
@@ -113,7 +113,7 @@ module "workers" {
   hostname         = "${var.tectonic_vmware_worker_hostnames}"
   dns_server       = "${var.tectonic_vmware_node_dns}"
   ip_address       = "${var.tectonic_vmware_worker_ip}"
-  gateway          = "${var.tectonic_vmware_worker_gateway}"
+  gateway          = "${var.tectonic_vmware_worker_gateways}"
 
   container_images = "${var.tectonic_container_images}"
 
@@ -121,7 +121,7 @@ module "workers" {
   vmware_clusters         = "${var.tectonic_vmware_worker_clusters}"
   vm_vcpu                 = "${var.tectonic_vmware_worker_vcpu}"
   vm_memory               = "${var.tectonic_vmware_worker_memory}"
-  vm_network_label        = "${var.tectonic_vmware_network}"
+  vm_network_labels       = "${var.tectonic_vmware_worker_networks}"
   vm_disk_datastore       = "${var.tectonic_vmware_worker_datastore}"
   vm_disk_template        = "${var.tectonic_vmware_vm_template}"
   vm_disk_template_folder = "${var.tectonic_vmware_vm_template_folder}"

--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -5,6 +5,7 @@ provider "vsphere" {
 }
 
 resource "vsphere_folder" "tectonic_vsphere_folder" {
-  path       = "${var.tectonic_vmware_folder}"
-  datacenter = "${var.tectonic_vmware_worker_datacenters[0]}"
+  path          = "${var.tectonic_vmware_folder}"
+  type          = "${var.tectonic_vmware_type}"
+  datacenter_id = "${var.tectonic_vmware_worker_datacenters[0]}"
 }

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -25,9 +25,10 @@ variable "tectonic_vmware_folder" {
   description = "vSphere Folder to create and add the Tectonic nodes"
 }
 
-variable "tectonic_vmware_network" {
+variable "tectonic_vmware_type" {
   type        = "string"
-  description = "Portgroup to attach the cluster nodes"
+  description = "The type of folder to create. Allowed options: datacenter,host,vm, datastore, and network."
+  default     = "vm"
 }
 
 // # Global
@@ -113,6 +114,19 @@ variable "tectonic_vmware_etcd_datacenters" {
 EOF
 }
 
+variable "tectonic_vmware_etcd_networks" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of Portgroup to attach the etcd cluster node(s), Example:
+  tectonic_vmware_etcd_networks = {
+  "0" = "VM Network 1"
+  "1" = "VM Network 2"
+  "2" = "VM Network 3"
+}
+EOF
+}
+
 variable "tectonic_vmware_etcd_ip" {
   type = "map"
 
@@ -126,9 +140,17 @@ variable "tectonic_vmware_etcd_ip" {
 EOF
 }
 
-variable "tectonic_vmware_etcd_gateway" {
-  type        = "string"
-  description = "Default Gateway IP address for etcd nodes(s)"
+variable "tectonic_vmware_etcd_gateways" {
+  type = "map"
+
+  description = <<EOF
+  "Default Gateway IP addresses for etcd nodes(s)"
+  tectonic_vmware_etcd_gateways = {
+  "0" = "192.168.246.1/24"
+  "1" = "192.168.246.2/24"
+  "2" = "192.168.246.3/24"
+}
+EOF
 }
 
 variable "tectonic_vmware_etcd_datastore" {
@@ -200,9 +222,30 @@ variable "tectonic_vmware_master_ip" {
 EOF
 }
 
-variable "tectonic_vmware_master_gateway" {
-  type        = "string"
-  description = "Default Gateway IP address for Master nodes(s)"
+variable "tectonic_vmware_master_networks" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of Portgroup to attach the master cluster node(s), Example:
+  tectonic_vmware_master_networks = {
+  "0" = "VM Network 1"
+  "1" = "VM Network 2"
+  "2" = "VM Network 3"
+}
+EOF
+}
+
+variable "tectonic_vmware_master_gateways" {
+  type = "map"
+
+  description = <<EOF
+  "Default Gateway IP addresses for Master nodes(s)"
+  tectonic_vmware_master_gateways = {
+  "0" = "192.168.246.1"
+  "1" = "192.168.246.2"
+  "2" = "192.168.246.3"
+}
+EOF
 }
 
 variable "tectonic_vmware_master_datastore" {
@@ -273,9 +316,30 @@ variable "tectonic_vmware_worker_ip" {
 EOF
 }
 
-variable "tectonic_vmware_worker_gateway" {
-  type        = "string"
-  description = "Default Gateway IP address for Master nodes(s)"
+variable "tectonic_vmware_worker_networks" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of Portgroup to attach the worker cluster node(s), Example:
+  tectonic_vmware_worker_networks = {
+  "0" = "VM Network 1"
+  "1" = "VM Network 2"
+  "2" = "VM Network 3"
+}
+EOF
+}
+
+variable "tectonic_vmware_worker_gateways" {
+  type = "map"
+
+  description = <<EOF
+  "Default Gateway IP addresses for worker nodes(s)"
+  tectonic_vmware_worker_gateways = {
+  "0" = "192.168.246.1/24"
+  "1" = "192.168.246.2/24"
+  "2" = "192.168.246.3/24"
+}
+EOF
 }
 
 variable "tectonic_vmware_worker_datastore" {


### PR DESCRIPTION
We needed the ability to assign specific network labels to each group of our nodes in our cluster due to networking requirements.  This patch has been tested in VCenter 6.0 and is being used to build clusters.  

Also updated vsphere_folder to reflect changes made to vmware provider in 0.4.2.  See https://github.com/terraform-providers/terraform-provider-vsphere/blob/master/CHANGELOG.md for details on changes made.  Without changing 

modules/vmware/etcd/ignition.tf was changed to include what is in the official 1.7.5 installer. 

Error refreshing state: 1 error(s) occurred:

* module.etcd.data.ignition_config.etcd: 3 error(s) occurred:

* module.etcd.data.ignition_config.etcd[0]: At column 30, line 1: list "var.ign_etcd_dropin_id_list" does not have any elements so cannot determine type. in:

${var.ign_etcd_dropin_id_list[count.index]}
* module.etcd.data.ignition_config.etcd[2]: At column 30, line 1: list "var.ign_etcd_dropin_id_list" does not have any elements so cannot determine type. in:

${var.ign_etcd_dropin_id_list[count.index]}
* module.etcd.data.ignition_config.etcd[1]: At column 30, line 1: list "var.ign_etcd_dropin_id_list" does not have any elements so cannot determine type. in:

${var.ign_etcd_dropin_id_list[count.index]}