### PR TITLE
Add ability to map VMs to network gateways

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -10,7 +10,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_etcd_clusters | Terraform map of etcd node(s) vSphere Clusters, Example:   tectonic_vmware_etcd_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1"   "2" = "myvmwarecluster-2" } | map | - |
 | tectonic_vmware_etcd_datacenters | terraform map of etcd node(s) Virtual DataCenters, example:   tectonic_vmware_etcd_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1"   "2" = "myvmwaredc-2" } | map | - |
 | tectonic_vmware_etcd_datastore | The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
-| tectonic_vmware_etcd_gateway | Default Gateway IP address for etcd nodes(s) | string | - |
+| tectonic_vmware_etcd_gateways | Terraform map of etcd node(s) network gateway IP, Example:   tectonic_vmware_etcd_gateways = {   "0" = "192.168.246.99"   "1" = "192.168.246.99"   "2" = "192.168.246.99" } | map | - |
 | tectonic_vmware_etcd_hostnames | Terraform map of etcd node(s) Hostnames, Example:   tectonic_vmware_etcd_hostnames = {   "0" = "mycluster-etcd-0"   "1" = "mycluster-etcd-1"   "2" = "mycluster-etcd-2" } | map | - |
 | tectonic_vmware_etcd_ip | Terraform map of etcd node(s) IP Addresses, Example:   tectonic_vmware_etcd_ip = {   "0" = "192.168.246.10/24"   "1" = "192.168.246.11/24"   "2" = "192.168.246.12/24" } | map | - |
 | tectonic_vmware_etcd_memory | etcd node(s) VM Memory Size in MB | string | `4096` |
@@ -22,7 +22,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_master_clusters | Terraform map of master node(s) vSphere Clusters, Example:   tectonic_vmware_master_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
 | tectonic_vmware_master_datacenters | terraform map of master node(s) Virtual DataCenters, example:   tectonic_vmware_master_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1"   "2" = "myvmwaredc-2" } | map | - |
 | tectonic_vmware_master_datastore | The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
-| tectonic_vmware_master_gateway | Default Gateway IP address for Master nodes(s) | string | - |
+| tectonic_vmware_master_gateways | Terraform map of master node(s) network gateway IP, Example:   tectonic_vmware_master_gateways = {   "0" = "192.168.246.99"   "1" = "192.168.246.99" } | map | - |
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:   tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
 | tectonic_vmware_master_ip | Terraform map of Master node(s) IP Addresses, Example:   tectonic_vmware_master_ip = {   "0" = "192.168.246.20/24"   "1" = "192.168.246.21/24" } | map | - |
 | tectonic_vmware_master_memory | Master node(s) Memory Size in MB | string | `4096` |
@@ -39,7 +39,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_worker_clusters | Terraform map of worker node(s) vSphere Clusters, Example:   tectonic_vmware_worker_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |
 | tectonic_vmware_worker_datacenters | terraform map of worker node(s) Virtual DataCenters, example:   tectonic_vmware_worker_datacenters = {   "0" = "myvmwaredc-0"   "1" = "myvmwaredc-1" } | map | - |
 | tectonic_vmware_worker_datastore | The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore. | string | `` |
-| tectonic_vmware_worker_gateway | Default Gateway IP address for Master nodes(s) | string | - |
+| tectonic_vmware_worker_gateways | Terraform map of worker node(s) network gateway IP, Example:   tectonic_vmware_worker_gateways = {   "0" = "192.168.246.99"   "1" = "192.168.246.99" } | map | - |
 | tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:   tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |
 | tectonic_vmware_worker_ip | Terraform map of Worker node(s) IP Addresses, Example:   tectonic_vmware_worker_ip = {   "0" = "192.168.246.30/24"   "1" = "192.168.246.31/24" } | map | - |
 | tectonic_vmware_worker_memory | Worker node(s) Memory Size in MB | string | `4096` |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -192,8 +192,13 @@ tectonic_vmware_etcd_datacenters = ""
 // The storage LUN used by etcd nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_etcd_datastore = ""
 
-// Default Gateway IP address for etcd nodes(s)
-tectonic_vmware_etcd_gateway = ""
+// Terraform map of etcd node(s) network gateway IP, Example:
+//   tectonic_vmware_etcd_gateways = {
+//   "0" = "192.168.246.99"
+//   "1" = "192.168.246.99"
+//   "2" = "192.168.246.99"
+// }
+tectonic_vmware_etcd_gateways = ""
 
 // Terraform map of etcd node(s) Hostnames, Example:
 //   tectonic_vmware_etcd_hostnames = {
@@ -257,8 +262,12 @@ tectonic_vmware_master_datacenters = ""
 // The storage LUN used by master nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_master_datastore = ""
 
-// Default Gateway IP address for Master nodes(s)
-tectonic_vmware_master_gateway = ""
+// Terraform map of master node(s) network gateway IP, Example:
+//   tectonic_vmware_master_gateways = {
+//   "0" = "192.168.246.99"
+//   "1" = "192.168.246.99"
+// }
+tectonic_vmware_master_gateways = ""
 
 // Terraform map of Master node(s) Hostnames, Example:
 //   tectonic_vmware_master_hostnames = {
@@ -332,8 +341,12 @@ tectonic_vmware_worker_datacenters = ""
 // The storage LUN used by worker nodes. In order to use vSphere Datastore Cluster use the syntax DatastoreClusterName/datastore.
 tectonic_vmware_worker_datastore = ""
 
-// Default Gateway IP address for Master nodes(s)
-tectonic_vmware_worker_gateway = ""
+// Terraform map of worker node(s) network gateway IP, Example:
+//   tectonic_vmware_worker_gateways = {
+//   "0" = "192.168.246.99"
+//   "1" = "192.168.246.99"
+// }
+tectonic_vmware_worker_gateways = ""
 
 // Terraform map of Worker node(s) Hostnames, Example:
 //   tectonic_vmware_worker_hostnames = {

--- a/modules/vmware/etcd/ignition.tf
+++ b/modules/vmware/etcd/ignition.tf
@@ -160,7 +160,7 @@ data "ignition_networkd_unit" "vmnetwork" {
   [Network]
   DNS=${var.dns_server}
   Address=${var.ip_address["${count.index}"]}
-  Gateway=${var.gateway}
+  Gateway=${var.gateways["${count.index}"]}
   UseDomains=yes
   Domains=${var.base_domain}
 EOF

--- a/modules/vmware/etcd/variables.tf
+++ b/modules/vmware/etcd/variables.tf
@@ -85,9 +85,9 @@ variable ip_address {
   description = "IP Address of the node"
 }
 
-variable gateway {
-  type        = "string"
-  description = "Gateway of the node"
+variable gateways {
+  type        = "map"
+  description = "Network gateway IP for the node"
 }
 
 variable hostname {

--- a/modules/vmware/node/ignition.tf
+++ b/modules/vmware/node/ignition.tf
@@ -42,7 +42,7 @@ data "ignition_networkd_unit" "vmnetwork" {
   [Network]
   DNS=${var.dns_server}
   Address=${var.ip_address["${count.index}"]}
-  Gateway=${var.gateway}
+  Gateway=${var.gateways["${count.index}"]}
   UseDomains=yes
   Domains=${var.base_domain}
 EOF

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -43,9 +43,9 @@ variable "dns_server" {
   description = "DNS Server of the nodes"
 }
 
-variable "gateway" {
-  type        = "string"
-  description = "Gateway of the node"
+variable "gateways" {
+  type        = "map"
+  description = "Network gateway IP for the node"
 }
 
 variable "hostname" {

--- a/platforms/vmware/main.tf
+++ b/platforms/vmware/main.tf
@@ -19,7 +19,7 @@ module "etcd" {
   hostname   = "${var.tectonic_vmware_etcd_hostnames}"
   dns_server = "${var.tectonic_vmware_node_dns}"
   ip_address = "${var.tectonic_vmware_etcd_ip}"
-  gateway    = "${var.tectonic_vmware_etcd_gateway}"
+  gateways   = "${var.tectonic_vmware_etcd_gateways}"
 
   vmware_datacenters      = "${var.tectonic_vmware_etcd_datacenters}"
   vmware_clusters         = "${var.tectonic_vmware_etcd_clusters}"
@@ -64,7 +64,7 @@ module "masters" {
   hostname         = "${var.tectonic_vmware_master_hostnames}"
   dns_server       = "${var.tectonic_vmware_node_dns}"
   ip_address       = "${var.tectonic_vmware_master_ip}"
-  gateway          = "${var.tectonic_vmware_master_gateway}"
+  gateways         = "${var.tectonic_vmware_master_gateways}"
 
   container_images = "${var.tectonic_container_images}"
 
@@ -115,7 +115,7 @@ module "workers" {
   hostname         = "${var.tectonic_vmware_worker_hostnames}"
   dns_server       = "${var.tectonic_vmware_node_dns}"
   ip_address       = "${var.tectonic_vmware_worker_ip}"
-  gateway          = "${var.tectonic_vmware_worker_gateway}"
+  gateways         = "${var.tectonic_vmware_worker_gateways}"
 
   container_images = "${var.tectonic_container_images}"
 

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -121,6 +121,19 @@ variable "tectonic_vmware_etcd_resource_pool" {
 EOF
 }
 
+variable "tectonic_vmware_etcd_gateways" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of etcd node(s) network gateway IP, Example:
+  tectonic_vmware_etcd_gateways = {
+  "0" = "192.168.246.99"
+  "1" = "192.168.246.99"
+  "2" = "192.168.246.99"
+}
+EOF
+}
+
 variable "tectonic_vmware_etcd_ip" {
   type = "map"
 
@@ -132,11 +145,6 @@ variable "tectonic_vmware_etcd_ip" {
   "2" = "192.168.246.12/24"
 }
 EOF
-}
-
-variable "tectonic_vmware_etcd_gateway" {
-  type        = "string"
-  description = "Default Gateway IP address for etcd nodes(s)"
 }
 
 variable "tectonic_vmware_etcd_datastore" {
@@ -221,6 +229,18 @@ variable "tectonic_vmware_master_resource_pool" {
 EOF
 }
 
+variable "tectonic_vmware_master_gateways" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of master node(s) network gateway IP, Example:
+  tectonic_vmware_master_gateways = {
+  "0" = "192.168.246.99"
+  "1" = "192.168.246.99"
+}
+EOF
+}
+
 variable "tectonic_vmware_master_ip" {
   type = "map"
 
@@ -231,11 +251,6 @@ variable "tectonic_vmware_master_ip" {
   "1" = "192.168.246.21/24"
 }
 EOF
-}
-
-variable "tectonic_vmware_master_gateway" {
-  type        = "string"
-  description = "Default Gateway IP address for Master nodes(s)"
 }
 
 variable "tectonic_vmware_master_datastore" {
@@ -318,6 +333,18 @@ variable "tectonic_vmware_worker_resource_pool" {
 EOF
 }
 
+variable "tectonic_vmware_worker_gateways" {
+  type = "map"
+
+  description = <<EOF
+  Terraform map of worker node(s) network gateway IP, Example:
+  tectonic_vmware_worker_gateways = {
+  "0" = "192.168.246.99"
+  "1" = "192.168.246.99"
+}
+EOF
+}
+
 variable "tectonic_vmware_worker_ip" {
   type = "map"
 
@@ -328,11 +355,6 @@ variable "tectonic_vmware_worker_ip" {
   "1" = "192.168.246.31/24"
 }
 EOF
-}
-
-variable "tectonic_vmware_worker_gateway" {
-  type        = "string"
-  description = "Default Gateway IP address for Master nodes(s)"
 }
 
 variable "tectonic_vmware_worker_networks" {


### PR DESCRIPTION
Currently, all nodes of a given role (etcd, master, worker) need to
share a common network gateway.  This change will allow network gateways
to be assigned to nodes individually to support nodes being spread
across subnets with different gateways in a multi-az kind of approach.

Jira issue: https://jira.prod.coreos.systems/projects/FR/issues/FR-369