### PR TITLE
platform/gcp: add kubenet and cloud-provider optional support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,6 +265,7 @@ pipeline {
           def gcp = [
             [file: 'basic_spec.rb', args: ''],
             [file: 'ha_spec.rb', args: ''],
+            [file: 'kubenet_ha_spec.rb', args: ''],
           ]
 
           if (params."PLATFORM/AWS") {

--- a/modules/bootkube/assets.tf
+++ b/modules/bootkube/assets.tf
@@ -66,6 +66,8 @@ resource "template_dir" "bootkube" {
 
     cloud_provider_profile = "${var.cloud_provider != "" ? "${var.cloud_provider}" : "metal"}"
     cloud_config_path      = "${var.cloud_config_path}"
+    cluster_name           = "${var.cluster_name}"
+    configure_cloud_routes = "${var.configure_cloud_routes}"
   }
 }
 
@@ -101,9 +103,11 @@ resource "template_dir" "bootkube_bootstrap" {
     cloud_provider_config      = "${var.cloud_provider_config}"
     cloud_provider_config_flag = "${var.cloud_provider_config != "" ? "- --cloud-config=/etc/kubernetes/cloud/config" : "# no cloud provider config given"}"
 
-    advertise_address = "${var.advertise_address}"
-    cluster_cidr      = "${var.cluster_cidr}"
-    service_cidr      = "${var.service_cidr}"
+    advertise_address      = "${var.advertise_address}"
+    cluster_cidr           = "${var.cluster_cidr}"
+    service_cidr           = "${var.service_cidr}"
+    cluster_name           = "${var.cluster_name}"
+    configure_cloud_routes = "${var.configure_cloud_routes}"
   }
 }
 

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -10,11 +10,12 @@ spec:
     command:
     - ./hyperkube
     - controller-manager
+    - --cluster-name=${cluster_name}
     - --allocate-node-cidrs=true
     - --cluster-cidr=${cluster_cidr}
     - --cloud-provider=${cloud_provider}
     ${cloud_provider_config_flag}
-    - --configure-cloud-routes=false
+    - --configure-cloud-routes=${configure_cloud_routes}
     - --leader-elect=true
     - --kubeconfig=/etc/kubernetes/kubeconfig
     - --root-ca-file=/etc/kubernetes/bootstrap-secrets/ca.crt

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -40,8 +40,9 @@ spec:
         command:
         - ./hyperkube
         - controller-manager
+        - --cluster-name=${cluster_name}
         - --allocate-node-cidrs=true
-        - --configure-cloud-routes=false
+        - --configure-cloud-routes=${configure_cloud_routes}
         - --cluster-cidr=${cluster_cidr}
         - --root-ca-file=/etc/kubernetes/secrets/ca.crt
         - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -173,3 +173,9 @@ variable "versions" {
   description = "Container versions to use"
   type        = "map"
 }
+
+variable "configure_cloud_routes" {
+  description = "Rely on the cloud provider to configure routes"
+  type        = "string"
+  default     = false
+}

--- a/modules/gcp/kubenet/outputs.tf
+++ b/modules/gcp/kubenet/outputs.tf
@@ -1,0 +1,24 @@
+data "template_file" "cloud_provider_config" {
+  template = <<EOF
+[global]
+multizone = true
+EOF
+
+  vars {}
+}
+
+output "cloud_provider" {
+  value = "${var.enabled ? "gce" : ""}"
+}
+
+output "cloud_provider_config" {
+  value = "${var.enabled ? "${data.template_file.cloud_provider_config.rendered}" : ""}"
+}
+
+output "network_plugin" {
+  value = "${var.enabled ? "kubenet" : "cni"}"
+}
+
+output "hostname_override_cmd" {
+  value = "${var.enabled ? "--hostname-override=$${NODENAME}" : ""}"
+}

--- a/modules/gcp/kubenet/variables.tf
+++ b/modules/gcp/kubenet/variables.tf
@@ -1,0 +1,3 @@
+variable "enabled" {
+  description = "If set true, kubenet networking will be deployed"
+}

--- a/modules/gcp/master-igm/ignition.tf
+++ b/modules/gcp/master-igm/ignition.tf
@@ -3,6 +3,7 @@ data "ignition_config" "main" {
     "${data.ignition_file.kubeconfig.id}",
     "${var.ign_max_user_watches_id}",
     "${var.ign_installer_kubelet_env_id}",
+    "${data.ignition_file.cloud_provider_config.id}",
   ]
 
   systemd = ["${compact(list(
@@ -13,7 +14,8 @@ data "ignition_config" "main" {
     var.ign_bootkube_service_id,
     var.ign_tectonic_service_id,
     var.ign_bootkube_path_unit_id,
-    var.ign_tectonic_path_unit_id
+    var.ign_tectonic_path_unit_id,
+    data.ignition_systemd_unit.node_name.id,
    ))}"]
 }
 
@@ -25,4 +27,24 @@ data "ignition_file" "kubeconfig" {
   content {
     content = "${var.kubeconfig_content}"
   }
+}
+
+data "ignition_file" "cloud_provider_config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+
+  content {
+    content = "${var.cloud_provider_config}"
+  }
+}
+
+data "template_file" "node_name" {
+  template = "${file("${path.module}/resources/services/node-name.service")}"
+}
+
+data "ignition_systemd_unit" "node_name" {
+  name    = "node-name.service"
+  enable  = "${var.cloud_provider_config != "" ? true : false}"
+  content = "${data.template_file.node_name.rendered}"
 }

--- a/modules/gcp/master-igm/master.tf
+++ b/modules/gcp/master-igm/master.tf
@@ -18,7 +18,7 @@ resource "google_compute_instance_template" "master-it" {
   name           = "${var.cluster_name}-master-it"
   region         = "${var.region}"
   machine_type   = "${var.machine_type}"
-  can_ip_forward = false
+  can_ip_forward = true
 
   disk {
     source_image = "coreos-${var.cl_channel}"

--- a/modules/gcp/master-igm/resources/services/node-name.service
+++ b/modules/gcp/master-igm/resources/services/node-name.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Set NODENAME for kubelet as expected by GCE cloud Provider
+ConditionPathExists=/etc/kubernetes/kubelet.env
+Requires=systemd-hostnamed.service systemd-networkd.service systemd-networkd-wait-online.service
+Before=kubelet.service
+After=systemd-hostnamed.service systemd-networkd.service systemd-networkd-wait-online.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "/bin/echo NODENAME=$(hostname -s) >> /etc/kubernetes/kubelet.env"
+
+[Install]
+WantedBy=kubelet.service

--- a/modules/gcp/master-igm/variables.tf
+++ b/modules/gcp/master-igm/variables.tf
@@ -70,20 +70,14 @@ variable "ign_tectonic_path_unit_id" {
   type = "string"
 }
 
-variable "container_images" {
-  description = "Container images to use"
-  type        = "map"
-}
-
-variable "image_re" {
-  description = "(internal) Regular expression used to extract repo and tag components from image strings"
-  type        = "string"
-}
-
 variable "public_ssh_key" {
   default = ""
 }
 
 variable "kubeconfig_content" {
+  type = "string"
+}
+
+variable "cloud_provider_config" {
   type = "string"
 }

--- a/modules/gcp/network/firewall-master.tf
+++ b/modules/gcp/network/firewall-master.tf
@@ -93,3 +93,23 @@ resource "google_compute_firewall" "master-ingress-services" {
   source_tags = ["tectonic-masters"]
   target_tags = ["tectonic-masters"]
 }
+
+resource "google_compute_firewall" "ingress-pods" {
+  name    = "${var.cluster_name}-ingress-pods"
+  network = "${google_compute_network.network.name}"
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = ["10.0.0.0/8", "10.2.0.0/16"]
+  target_tags   = ["tectonic-masters", "tectonic-workers"]
+}

--- a/modules/gcp/worker-igm/ignition.tf
+++ b/modules/gcp/worker-igm/ignition.tf
@@ -3,6 +3,7 @@ data "ignition_config" "main" {
     "${data.ignition_file.kubeconfig.id}",
     "${var.ign_max_user_watches_id}",
     "${var.ign_installer_kubelet_env_id}",
+    "${data.ignition_file.cloud-provider-config.id}",
   ]
 
   systemd = [
@@ -10,6 +11,7 @@ data "ignition_config" "main" {
     "${var.ign_k8s_node_bootstrap_service_id}",
     "${var.ign_locksmithd_service_id}",
     "${var.ign_kubelet_service_id}",
+    "${data.ignition_systemd_unit.node_name.id}",
   ]
 }
 
@@ -21,4 +23,24 @@ data "ignition_file" "kubeconfig" {
   content {
     content = "${var.kubeconfig_content}"
   }
+}
+
+data "ignition_file" "cloud-provider-config" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/cloud/config"
+  mode       = 0600
+
+  content {
+    content = "${var.cloud_provider_config}"
+  }
+}
+
+data "template_file" "node_name" {
+  template = "${file("${path.module}/resources/services/node-name.service")}"
+}
+
+data "ignition_systemd_unit" "node_name" {
+  name    = "node-name.service"
+  enable  = "${var.cloud_provider_config != "" ? true : false}"
+  content = "${data.template_file.node_name.rendered}"
 }

--- a/modules/gcp/worker-igm/resources/services/node-name.service
+++ b/modules/gcp/worker-igm/resources/services/node-name.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Set NODENAME for kubelet as expected by GCE cloud Provider
+ConditionPathExists=/etc/kubernetes/kubelet.env
+Requires=systemd-hostnamed.service systemd-networkd.service systemd-networkd-wait-online.service
+Before=kubelet.service
+After=systemd-hostnamed.service systemd-networkd.service systemd-networkd-wait-online.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "/bin/echo NODENAME=$(hostname -s) >> /etc/kubernetes/kubelet.env"
+
+[Install]
+WantedBy=kubelet.service

--- a/modules/gcp/worker-igm/variables.tf
+++ b/modules/gcp/worker-igm/variables.tf
@@ -59,3 +59,7 @@ variable "public_ssh_key" {
 variable "kubeconfig_content" {
   type = "string"
 }
+
+variable "cloud_provider_config" {
+  type = "string"
+}

--- a/modules/gcp/worker-igm/worker.tf
+++ b/modules/gcp/worker-igm/worker.tf
@@ -18,7 +18,7 @@ resource "google_compute_instance_template" "worker-it" {
   name           = "${var.cluster_name}-worker-it"
   region         = "${var.region}"
   machine_type   = "${var.machine_type}"
-  can_ip_forward = false
+  can_ip_forward = true
 
   disk {
     source_image = "coreos-${var.cl_channel}"

--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -39,6 +39,8 @@ data "template_file" "kubelet" {
     kubeconfig_fetch_cmd  = "${var.kubeconfig_fetch_cmd != "" ? "ExecStartPre=${var.kubeconfig_fetch_cmd}" : ""}"
     node_label            = "${var.kubelet_node_label}"
     node_taints_param     = "${var.kubelet_node_taints != "" ? "--register-with-taints=${var.kubelet_node_taints}" : ""}"
+    network_plugin        = "${var.network_plugin}"
+    hostname_override_cmd = "${var.hostname_override_cmd}"
   }
 }
 

--- a/modules/ignition/resources/services/kubelet.service
+++ b/modules/ignition/resources/services/kubelet.service
@@ -24,7 +24,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --kubeconfig=/etc/kubernetes/kubeconfig \
   --require-kubeconfig \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
-  --network-plugin=cni \
+  --network-plugin=${network_plugin} \
   --lock-file=/var/run/lock/kubelet.lock \
   --exit-on-lock-contention \
   --pod-manifest-path=/etc/kubernetes/manifests \
@@ -38,7 +38,8 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --client-ca-file=/etc/kubernetes/ca.crt \
   --cloud-provider=${cloud_provider} \
   ${cloud_provider_config} \
-  --anonymous-auth=false
+  --anonymous-auth=false \
+  ${hostname_override_cmd} \
 
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
 

--- a/modules/ignition/variables.tf
+++ b/modules/ignition/variables.tf
@@ -111,3 +111,11 @@ variable "metadata_provider" {
 variable "use_metadata" {
   default = true
 }
+
+variable "network_plugin" {
+  default = "cni"
+}
+
+variable "hostname_override_cmd" {
+  default = ""
+}

--- a/platforms/gcp/bootstrap.tf
+++ b/platforms/gcp/bootstrap.tf
@@ -7,9 +7,6 @@ module "bootstrapper" {
     "${module.etcd_certs.id}",
     "${module.bootkube.id}",
     "${module.tectonic.id}",
-    "${module.flannel_vxlan.id}",
-    "${module.calico.id}",
-    "${module.canal.id}",
   ]
 
   bootstrapping_host = "${module.network.ssh_master_ip}"

--- a/platforms/gcp/main.tf
+++ b/platforms/gcp/main.tf
@@ -75,12 +75,13 @@ module "etcd" {
 module "masters" {
   source = "../../modules/gcp/master-igm"
 
-  region             = "${var.tectonic_gcp_region}"
-  instance_count     = "${var.tectonic_master_count}"
-  machine_type       = "${var.tectonic_gcp_master_gce_type}"
-  cluster_name       = "${var.tectonic_cluster_name}"
-  public_ssh_key     = "${var.tectonic_gcp_ssh_key}"
-  kubeconfig_content = "${module.bootkube.kubeconfig}"
+  cloud_provider_config = "${module.kubenet.cloud_provider_config}"
+  region                = "${var.tectonic_gcp_region}"
+  instance_count        = "${var.tectonic_master_count}"
+  machine_type          = "${var.tectonic_gcp_master_gce_type}"
+  cluster_name          = "${var.tectonic_cluster_name}"
+  public_ssh_key        = "${var.tectonic_gcp_ssh_key}"
+  kubeconfig_content    = "${module.bootkube.kubeconfig}"
 
   master_subnetwork_name      = "${module.network.master_subnetwork_name}"
   master_targetpool_self_link = "${module.network.master_targetpool_self_link}"
@@ -100,19 +101,18 @@ module "masters" {
   ign_installer_kubelet_env_id      = "${module.ignition_masters.installer_kubelet_env_id}"
   ign_tectonic_path_unit_id         = "${var.tectonic_vanilla_k8s ? "" : module.tectonic.systemd_path_unit_id}"
   ign_tectonic_service_id           = "${module.tectonic.systemd_service_id}"
-  image_re                          = "${var.tectonic_image_re}"
-  container_images                  = "${var.tectonic_container_images}"
 }
 
 module "workers" {
   source = "../../modules/gcp/worker-igm"
 
-  region             = "${var.tectonic_gcp_region}"
-  instance_count     = "${var.tectonic_worker_count}"
-  machine_type       = "${var.tectonic_gcp_worker_gce_type}"
-  cluster_name       = "${var.tectonic_cluster_name}"
-  public_ssh_key     = "${var.tectonic_gcp_ssh_key}"
-  kubeconfig_content = "${module.bootkube.kubeconfig}"
+  cloud_provider_config = "${module.kubenet.cloud_provider_config}"
+  region                = "${var.tectonic_gcp_region}"
+  instance_count        = "${var.tectonic_worker_count}"
+  machine_type          = "${var.tectonic_gcp_worker_gce_type}"
+  cluster_name          = "${var.tectonic_cluster_name}"
+  public_ssh_key        = "${var.tectonic_gcp_ssh_key}"
+  kubeconfig_content    = "${module.bootkube.kubeconfig}"
 
   worker_subnetwork_name      = "${module.network.worker_subnetwork_name}"
   worker_targetpool_self_link = "${module.network.worker_targetpool_self_link}"
@@ -134,12 +134,14 @@ module "workers" {
 module "ignition_masters" {
   source = "../../modules/ignition"
 
-  cluster_name         = "${var.tectonic_cluster_name}"
-  bootstrap_upgrade_cl = "${var.tectonic_bootstrap_upgrade_cl}"
-  tectonic_vanilla_k8s = "${var.tectonic_vanilla_k8s}"
-  container_images     = "${var.tectonic_container_images}"
-  image_re             = "${var.tectonic_image_re}"
-  kube_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
+  cloud_provider        = "${module.kubenet.cloud_provider}"
+  cloud_provider_config = "${module.kubenet.cloud_provider_config}"
+  cluster_name          = "${var.tectonic_cluster_name}"
+  bootstrap_upgrade_cl  = "${var.tectonic_bootstrap_upgrade_cl}"
+  tectonic_vanilla_k8s  = "${var.tectonic_vanilla_k8s}"
+  container_images      = "${var.tectonic_container_images}"
+  image_re              = "${var.tectonic_image_re}"
+  kube_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
 
   kubelet_cni_bin_dir = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
   kubelet_node_label  = "node-role.kubernetes.io/master"
@@ -149,21 +151,27 @@ module "ignition_masters" {
   etcd_count                = "${length(data.template_file.etcd_hostname_list.*.id)}"
   etcd_initial_cluster_list = "${data.template_file.etcd_hostname_list.*.rendered}"
   etcd_tls_enabled          = "${var.tectonic_etcd_tls_enabled}"
+  network_plugin            = "${module.kubenet.network_plugin}"
+  hostname_override_cmd     = "${module.kubenet.hostname_override_cmd}"
 }
 
 module "ignition_workers" {
   source = "../../modules/ignition"
 
-  cluster_name         = "${var.tectonic_cluster_name}"
-  bootstrap_upgrade_cl = "${var.tectonic_bootstrap_upgrade_cl}"
-  tectonic_vanilla_k8s = "${var.tectonic_vanilla_k8s}"
-  container_images     = "${var.tectonic_container_images}"
-  image_re             = "${var.tectonic_image_re}"
-  kube_dns_service_ip  = "${module.bootkube.kube_dns_service_ip}"
+  cloud_provider        = "${module.kubenet.cloud_provider}"
+  cloud_provider_config = "${module.kubenet.cloud_provider_config}"
+  cluster_name          = "${var.tectonic_cluster_name}"
+  bootstrap_upgrade_cl  = "${var.tectonic_bootstrap_upgrade_cl}"
+  tectonic_vanilla_k8s  = "${var.tectonic_vanilla_k8s}"
+  container_images      = "${var.tectonic_container_images}"
+  image_re              = "${var.tectonic_image_re}"
+  kube_dns_service_ip   = "${module.bootkube.kube_dns_service_ip}"
 
-  kubelet_cni_bin_dir = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
-  kubelet_node_label  = "node-role.kubernetes.io/node"
-  kubelet_node_taints = ""
+  kubelet_cni_bin_dir   = "${var.tectonic_networking == "calico" || var.tectonic_networking == "canal" ? "/var/lib/cni/bin" : "" }"
+  kubelet_node_label    = "node-role.kubernetes.io/node"
+  kubelet_node_taints   = ""
+  network_plugin        = "${module.kubenet.network_plugin}"
+  hostname_override_cmd = "${module.kubenet.hostname_override_cmd}"
 }
 
 module "dns" {

--- a/platforms/gcp/tectonic.tf
+++ b/platforms/gcp/tectonic.tf
@@ -57,9 +57,10 @@ module "identity_certs" {
 }
 
 module "bootkube" {
-  source         = "../../modules/bootkube"
-  cloud_provider = ""
-  cluster_name   = "${var.tectonic_cluster_name}"
+  source                = "../../modules/bootkube"
+  cloud_provider        = "${module.kubenet.cloud_provider}"
+  cloud_provider_config = "${module.kubenet.cloud_provider_config}"
+  cluster_name          = "${var.tectonic_cluster_name}"
 
   kube_apiserver_url = "https://${module.dns.kube_apiserver_fqdn}:443"
   oidc_issuer_url    = "https://${module.dns.kube_ingress_fqdn}/identity"
@@ -98,6 +99,9 @@ module "bootkube" {
   etcd_endpoints            = "${data.template_file.etcd_hostname_list.*.rendered}"
   master_count              = "${var.tectonic_master_count}"
   self_hosted_etcd          = "${var.tectonic_self_hosted_etcd}"
+
+  cloud_config_path      = "/etc/kubernetes/cloud"
+  configure_cloud_routes = "${var.tectonic_networking == "kubenet" ? true : false}"
 }
 
 module "tectonic" {
@@ -171,6 +175,11 @@ module "canal" {
   enabled          = "${var.tectonic_networking == "canal"}"
 }
 
+module "kubenet" {
+  source  = "../../modules/gcp/kubenet"
+  enabled = "${var.tectonic_networking == "kubenet"}"
+}
+
 data "archive_file" "assets" {
   type       = "zip"
   source_dir = "${path.cwd}/generated/"
@@ -185,5 +194,5 @@ data "archive_file" "assets" {
   # Additionally, data sources do not support managing any lifecycle whatsoever,
   # and therefore, the archive is never deleted. To avoid cluttering the module
   # folder, we write it in the TerraForm managed hidden folder `.terraform`.
-  output_path = "./.terraform/generated_${sha1("${module.etcd_certs.id} ${module.tectonic.id} ${module.bootkube.id} ${module.flannel_vxlan.id} ${module.calico.id} ${module.canal.id}")}.zip"
+  output_path = "./.terraform/generated_${sha1("${module.etcd_certs.id} ${module.tectonic.id} ${module.bootkube.id} ${module.flannel_vxlan.id} ${module.calico.id} ${module.canal.id} ${module.kubenet.cloud_provider}")}}.zip"
 }

--- a/tests/rspec/spec/gcp/kubenet_ha_spec.rb
+++ b/tests/rspec/spec/gcp/kubenet_ha_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'shared_examples/k8s'
+
+RSpec.describe 'gcp-ha' do
+  include_examples('withRunningCluster', '../smoke/gcp/vars/gcp.kubenet.ha.tfvars.json')
+end

--- a/tests/smoke/gcp/vars/gcp.kubenet.ha.tfvars.json
+++ b/tests/smoke/gcp/vars/gcp.kubenet.ha.tfvars.json
@@ -1,0 +1,18 @@
+{
+  "tectonic_networking": "kubenet",
+  "tectonic_bootstrap_upgrade_cl": "false",
+  "tectonic_container_linux_version": "latest",
+  "tectonic_gcp_region": "us-central1",
+  "tectonic_gcp_ext_google_managedzone_name": "testing",
+  "tectonic_gcp_ssh_key": "~/.ssh/id_rsa.pub",
+  "tectonic_base_domain": "tectonic.gcp.dev.coreos.systems",
+  "tectonic_gcp_credentials": "",
+  "tectonic_master_count": "3",
+  "tectonic_worker_count": "3",
+  "tectonic_etcd_count": "3",
+  "tectonic_gcp_master_gce_type": "n1-standard-2",
+  "tectonic_gcp_worker_gce_type": "n1-standard-2",
+  "tectonic_gcp_etcd_gce_type": "n1-standard-1",
+  "tectonic_gcp_etcd_disktype": "pd-standard",
+  "tectonic_etcd_servers": []
+}


### PR DESCRIPTION
This adds support and test coverage for running the platform on GCP using ```kubenet``` and ```--cloud-provider=gce```

When kubenet is enabled:
- Set ```--cloud-provider=gce```
- Set ```--cloud-config```
- Set ```--hostname-override``` to the nodename expected by gce provider i.e machine name
- Set ```--network-plugin=kubenet```
- Set ```--configure-cloud-routes=true```

Why this flags are needed:
- At the moment because of https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_network.go#L85
The following scenario happens when running the Kubelet with ```--cloud-provider=gce```:
The node always set NetworkUnavailable property to true.
This flag is only cleared by the cloud-provider route controller which is run when the flag ```--configure-cloud-routes=true``` is set in the controller manager (default).
- A mismatch between the (kubelet) nodeName which is the hostname by default (for CL the fqdn) and the gcp machine name. See https://github.com/kubernetes/kubernetes/pull/54504

This also adds ```--cluster-name``` to the controller manager
Adding do-not-merge label as there's a non solved problem in this PR yet:
When using  ```--configure-cloud-routes=true``` the route controller will generate network routes not known by terraform. Hence when running ```terraform destroy``` it can’t destroy the network because it has dependencies with the routes on the google API.