### PR TITLE
update vsphere arguments to reflect changes in 0.4.2 provider

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -34,6 +34,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_ssh_authorized_key | SSH public key to use as an authorized key. Example: `"ssh-rsa AAAB3N..."` | string | - |
 | tectonic_vmware_ssh_private_key_path | SSH private key file in .pem format corresponding to tectonic_vmware_ssh_authorized_key. If not provided, SSH agent will be used. | string | `` |
 | tectonic_vmware_sslselfsigned | Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"` | string | - |
+| tectonic_vmware_type | The type of folder to create. Allowed options: datacenter, host, vm, datastore, and network. | string | `vm` |
 | tectonic_vmware_vm_template | Virtual Machine template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_vm_template_folder | Folder for VM template of CoreOS Container Linux. | string | - |
 | tectonic_vmware_worker_clusters | Terraform map of worker node(s) vSphere Clusters, Example:   tectonic_vmware_worker_clusters = {   "0" = "myvmwarecluster-0"   "1" = "myvmwarecluster-1" } | map | - |

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -318,6 +318,9 @@ tectonic_vmware_ssh_private_key_path = ""
 // Is the vCenter certificate Self-Signed? Example: `tectonic_vmware_sslselfsigned = "true"`
 tectonic_vmware_sslselfsigned = ""
 
+// The type of folder to create. Allowed options: datacenter, host, vm, datastore, and network.
+tectonic_vmware_type = "vm"
+
 // Virtual Machine template of CoreOS Container Linux.
 tectonic_vmware_vm_template = ""
 

--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -5,6 +5,7 @@ provider "vsphere" {
 }
 
 resource "vsphere_folder" "tectonic_vsphere_folder" {
-  path       = "${var.tectonic_vmware_folder}"
-  datacenter = "${var.tectonic_vmware_worker_datacenters[0]}"
+  path          = "${var.tectonic_vmware_folder}"
+  type          = "${var.tectonic_vmware_type}"
+  datacenter_id = "${var.tectonic_vmware_worker_datacenters[0]}"
 }

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -25,6 +25,12 @@ variable "tectonic_vmware_folder" {
   description = "vSphere Folder to create and add the Tectonic nodes"
 }
 
+variable "tectonic_vmware_type" {
+  type        = "string"
+  description = "The type of folder to create. Allowed options: datacenter, host, vm, datastore, and network."
+  default     = "vm"
+}
+
 // # Global
 
 variable "tectonic_vmware_ssh_authorized_key" {


### PR DESCRIPTION
Change datacenter to datacenter_id. Updated provider.tf and variables.tf to reflect changes.

Default variable to be "vm" since this will primarily be used to create VMs.

See https://github.com/terraform-providers/terraform-provider-vsphere/blob/master/CHANGELOG.md

Breaking changes presented in 0.4.0 to vsphere_folder that require updating.