### PR TITLE
config.tf: update node-agent.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -78,7 +78,7 @@ variable "tectonic_container_images" {
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
     kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.9-kvo.3"
-    node_agent                   = "quay.io/coreos/node-agent:v1.7.5-kvo.3"
+    node_agent                   = "quay.io/coreos/node-agent:cd69b4a0f65b0d3a3b30edfce3bb184fd2a22c26"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:3517908b1a1837e78cfd041a0e51e61c7835d85f"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"


### PR DESCRIPTION
Updates node-agent to cd69b4a0f65b0d3a3b30edfce3bb184fd2a22c26. This
is to add support for tectonic-torcx updating the docker image at the
same time as the kubelet.