### PR TITLE
bootkube/pod-checkpointer: remove -v=4

### DIFF
--- a/modules/bootkube/resources/manifests/pod-checkpointer.yaml
+++ b/modules/bootkube/resources/manifests/pod-checkpointer.yaml
@@ -24,7 +24,6 @@ spec:
         image: ${pod_checkpointer_image}
         command:
         - /checkpoint
-        - --v=4
         - --lock-file=/var/run/lock/pod-checkpointer.lock
         env:
         - name: NODE_NAME


### PR DESCRIPTION
Removes -v=4 because it is very noisy and will fill logs unnecessarily.