### PR TITLE
test: doing some crazy naming :smile:

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -403,7 +403,7 @@ def forcefullyCleanWorkspace() {
     args: '-u root'
   ) {
     ansiColor('xterm') {
-      sh """#!/bin/bash -ex
+      sh """#!/bin/bash -e
         if [ -d "\$WORKSPACE" ]
         then
           rm -rfv \$WORKSPACE/*

--- a/tests/rspec/lib/name_generator.rb
+++ b/tests/rspec/lib/name_generator.rb
@@ -20,7 +20,8 @@ module NameGenerator
   def self.jenkins_env_name(prefix)
     build_id = ENV['BUILD_ID']
     branch_name = ENV['BRANCH_NAME'].to_s.delete('.')
-    name = "#{prefix}-#{branch_name}-#{build_id}"
+    short_prefix = prefix.split('-').map { |x| x[0...3] }.join.gsub(/^(.{10,}?).*$/m, '\1')
+    name = "#{short_prefix}-#{branch_name}-#{build_id}"
     name = name[0..(MAX_NAME_LENGTH - RANDOM_HASH_LENGTH - 1)]
     name += SecureRandom.hex[0...RANDOM_HASH_LENGTH]
     name

--- a/tests/rspec/spec/meta-tests/name_generator_spec.rb
+++ b/tests/rspec/spec/meta-tests/name_generator_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'name_generator'
+
+describe NameGenerator do
+  before(:all) do
+    @curent_env = ENV.clone
+  end
+
+  after(:all) do
+    ENV.clear
+    ENV = @curent_env.clone
+  end
+
+  it 'prefix should not contain more than 10 chars' do
+    ENV['BUILD_ID'] = '1'
+    ENV['BRANCH_NAME'] = 'master'
+    prefix = 'my-long-string-with-prefix'
+
+    expect(NameGenerator.jenkins_env_name(prefix).split('-')[0]).to eq('mylonstrwi')
+  end
+end


### PR DESCRIPTION
Doing that because in some tests (in azure e.g.) the test name is big and we don't have the PR-number in the cluster name, then we don't know which resource group belongs to which PR