### PR TITLE
Send credentials when checking release version

### DIFF
--- a/installer/frontend/components/header.jsx
+++ b/installer/frontend/components/header.jsx
@@ -3,8 +3,11 @@ import semver from 'semver';
 import { Dropdown } from './ui';
 
 const fetchLatestRelease = () => {
-  return fetch('/releases/latest',
-    { method: 'GET' }).then((response) => {
+  const opts = {
+    credentials: 'same-origin',
+    method: 'GET',
+  };
+  return fetch('/releases/latest', opts).then((response) => {
     if (response.ok) {
       return response.text();
     }


### PR DESCRIPTION
[Pod-proxy](https://github.com/coreos-inc/pod-proxy/) assigns a Pod per user session with a cookie. 

Sending cookies with the modified request to prevents an unnecessary Pods from being spawned with Pod Proxy.