### PR TITLE
Fix variable naming for vmware networks, remove unused variable vm_network_label left over from PR #2282

### DIFF
--- a/Documentation/variables/vmware.md
+++ b/Documentation/variables/vmware.md
@@ -14,7 +14,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_etcd_hostnames | Terraform map of etcd node(s) Hostnames, Example:   tectonic_vmware_etcd_hostnames = {   "0" = "mycluster-etcd-0"   "1" = "mycluster-etcd-1"   "2" = "mycluster-etcd-2" } | map | - |
 | tectonic_vmware_etcd_ip | Terraform map of etcd node(s) IP Addresses, Example:   tectonic_vmware_etcd_ip = {   "0" = "192.168.246.10/24"   "1" = "192.168.246.11/24"   "2" = "192.168.246.12/24" } | map | - |
 | tectonic_vmware_etcd_memory | etcd node(s) VM Memory Size in MB | string | `4096` |
-| tectonic_vmware_etcd_networks | Terraform map of etcd node(s) vSphere network portgroups, Example:   tectonic_vmware_etcd_ip = {   "0" = "mynet-0"   "1" = "mynet-1"   "2" = "mynet-2" } | map | - |
+| tectonic_vmware_etcd_networks | Terraform map of etcd node(s) vSphere network portgroups, Example:   tectonic_vmware_etcd_networks = {   "0" = "mynet-0"   "1" = "mynet-1"   "2" = "mynet-2" } | map | - |
 | tectonic_vmware_etcd_resource_pool | Terraform map of etcd node(s) vSphere Resource Pools, Example:   tectonic_vmware_etcd_resource_pool = {   "0" = "myresourcepool-0"   "1" = "myresourcepool-1"   "2" = "myresourcepool-2" } | map | - |
 | tectonic_vmware_etcd_vcpu | etcd node(s) VM vCPU count | string | `1` |
 | tectonic_vmware_folder | vSphere Folder to create and add the Tectonic nodes | string | - |
@@ -26,7 +26,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_master_hostnames | Terraform map of Master node(s) Hostnames, Example:   tectonic_vmware_master_hostnames = {   "0" = "mycluster-master-0"   "1" = "mycluster-master-1" } | map | - |
 | tectonic_vmware_master_ip | Terraform map of Master node(s) IP Addresses, Example:   tectonic_vmware_master_ip = {   "0" = "192.168.246.20/24"   "1" = "192.168.246.21/24" } | map | - |
 | tectonic_vmware_master_memory | Master node(s) Memory Size in MB | string | `4096` |
-| tectonic_vmware_master_networks | Terraform map of master node(s) vSphere network portgroups, Example:   tectonic_vmware_master_ip = {   "0" = "mynet-0"   "1" = "mynet-1" } | map | - |
+| tectonic_vmware_master_networks | Terraform map of master node(s) vSphere network portgroups, Example:   tectonic_vmware_master_networks = {   "0" = "mynet-0"   "1" = "mynet-1" } | map | - |
 | tectonic_vmware_master_resource_pool | Terraform map of master node(s) vSphere Resource pools, Example:   tectonic_vmware_master_resource_pool = {   "0" = "myresourcepool-0"   "1" = "myresourcepool-1" } | map | - |
 | tectonic_vmware_master_vcpu | Master node(s) vCPU count | string | `1` |
 | tectonic_vmware_node_dns | DNS Server to be used by Virtual Machine(s). Multiple DNS servers can be separated by whitespace. Example: `"192.168.1.1 192.168.2.1"` | string | - |
@@ -44,7 +44,7 @@ This document gives an overview of variables used in the VMware platform of the 
 | tectonic_vmware_worker_hostnames | Terraform map of Worker node(s) Hostnames, Example:   tectonic_vmware_worker_hostnames = {   "0" = "mycluster-worker-0"   "1" = "mycluster-worker-1" } | map | - |
 | tectonic_vmware_worker_ip | Terraform map of Worker node(s) IP Addresses, Example:   tectonic_vmware_worker_ip = {   "0" = "192.168.246.30/24"   "1" = "192.168.246.31/24" } | map | - |
 | tectonic_vmware_worker_memory | Worker node(s) Memory Size in MB | string | `4096` |
-| tectonic_vmware_worker_networks | Terraform map of worker node(s) vSphere network portgroups, Example:   tectonic_vmware_worker_ip = {   "0" = "mynet-0"   "1" = "mynet-1" } | map | - |
+| tectonic_vmware_worker_networks | Terraform map of worker node(s) vSphere network portgroups, Example:   tectonic_vmware_worker_networks = {   "0" = "mynet-0"   "1" = "mynet-1" } | map | - |
 | tectonic_vmware_worker_resource_pool | Terraform map of worker node(s) vSphere Resource Pools, Example:   tectonic_vmware_worker_resource_pool = {   "0" = "myresourcepool-0"   "1" = "myresourcepool-1" } | map | - |
 | tectonic_vmware_worker_vcpu | Worker node(s) vCPU count | string | `1` |
 

--- a/examples/terraform.tfvars.vmware
+++ b/examples/terraform.tfvars.vmware
@@ -220,7 +220,7 @@ tectonic_vmware_etcd_ip = ""
 tectonic_vmware_etcd_memory = "4096"
 
 // Terraform map of etcd node(s) vSphere network portgroups, Example:
-//   tectonic_vmware_etcd_ip = {
+//   tectonic_vmware_etcd_networks = {
 //   "0" = "mynet-0"
 //   "1" = "mynet-1"
 //   "2" = "mynet-2"
@@ -287,7 +287,7 @@ tectonic_vmware_master_ip = ""
 tectonic_vmware_master_memory = "4096"
 
 // Terraform map of master node(s) vSphere network portgroups, Example:
-//   tectonic_vmware_master_ip = {
+//   tectonic_vmware_master_networks = {
 //   "0" = "mynet-0"
 //   "1" = "mynet-1"
 // }
@@ -369,7 +369,7 @@ tectonic_vmware_worker_ip = ""
 tectonic_vmware_worker_memory = "4096"
 
 // Terraform map of worker node(s) vSphere network portgroups, Example:
-//   tectonic_vmware_worker_ip = {
+//   tectonic_vmware_worker_networks = {
 //   "0" = "mynet-0"
 //   "1" = "mynet-1"
 // }

--- a/modules/vmware/node/variables.tf
+++ b/modules/vmware/node/variables.tf
@@ -88,11 +88,6 @@ variable "vm_memory" {
   description = "VMs Memory size in MB"
 }
 
-variable "vm_network_label" {
-  type        = "string"
-  description = "VMs PortGroup"
-}
-
 variable "vm_vcpu" {
   type        = "string"
   description = "VMs vCPU count"

--- a/platforms/vmware/variables.tf
+++ b/platforms/vmware/variables.tf
@@ -164,7 +164,7 @@ variable "tectonic_vmware_etcd_networks" {
 
   description = <<EOF
   Terraform map of etcd node(s) vSphere network portgroups, Example:
-  tectonic_vmware_etcd_ip = {
+  tectonic_vmware_etcd_networks = {
   "0" = "mynet-0"
   "1" = "mynet-1"
   "2" = "mynet-2"
@@ -270,7 +270,7 @@ variable "tectonic_vmware_master_networks" {
 
   description = <<EOF
   Terraform map of master node(s) vSphere network portgroups, Example:
-  tectonic_vmware_master_ip = {
+  tectonic_vmware_master_networks = {
   "0" = "mynet-0"
   "1" = "mynet-1"
 }
@@ -368,7 +368,7 @@ variable "tectonic_vmware_worker_networks" {
 
   description = <<EOF
   Terraform map of worker node(s) vSphere network portgroups, Example:
-  tectonic_vmware_worker_ip = {
+  tectonic_vmware_worker_networks = {
   "0" = "mynet-0"
   "1" = "mynet-1"
 }


### PR DESCRIPTION

Error getting plugins: module root:
    module masters: required variable "vm_network_label" not set
    module workers: required variable "vm_network_label" not set

Fix examples:

var.tectonic_vmware_etcd_networks
    Terraform map of etcd node(s) vSphere network portgroups, Example:
    tectonic_vmware_etcd_ip = {
    "0" = "mynet-0"
    "1" = "mynet-1"
    "2" = "mynet-2"
  }

