### PR TITLE
platforms/vmware: Revert vsphere provider version

### DIFF
--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -1,5 +1,5 @@
 provider "vsphere" {
-  version              = "0.4.2"
+  version              = "0.2.2"
   vsphere_server       = "${var.tectonic_vmware_server}"
   allow_unverified_ssl = "${var.tectonic_vmware_sslselfsigned}"
 }


### PR DESCRIPTION
The necessary changes for the vsphere provider upgrade have not been
completed so reverting to old provider version for 1.7.9 release.