### PR TITLE
tests/frontend: Change Nightwatch tests to output tfvars files

### DIFF
--- a/installer/frontend/__tests__/examples/aws-vpc.json
+++ b/installer/frontend/__tests__/examples/aws-vpc.json
@@ -21,20 +21,20 @@
       "subnet-43ef260a",
       "subnet-1ad7e242"
     ],
-    "tectonic_aws_public_endpoints": true,
     "tectonic_aws_external_vpc_id": "someVPCID",
     "tectonic_aws_external_worker_subnet_ids": [
       "subnet-277ccb40",
       "subnet-19ef2650",
       "subnet-36d7e26e"
     ],
-    "tectonic_aws_region": "us-west-1",
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },
     "tectonic_aws_master_ec2_type": "t2.large",
     "tectonic_aws_master_root_volume_size": 33,
     "tectonic_aws_master_root_volume_type": "gp2",
+    "tectonic_aws_public_endpoints": true,
+    "tectonic_aws_region": "us-west-1",
     "tectonic_aws_ssh_key": "some-ssh-key",
     "tectonic_aws_worker_ec2_type": "t2.medium",
     "tectonic_aws_worker_root_volume_iops": 1000,

--- a/installer/frontend/__tests__/examples/aws.json
+++ b/installer/frontend/__tests__/examples/aws.json
@@ -1,14 +1,14 @@
 {
-  "dryRun": false,
-  "license": "<TECTONIC_LICENSE>",
-  "platform": "aws",
-  "pullSecret": "<TECTONIC_PULL_SECRET>",
-  "retry": false,
   "clusterKind": "tectonic-aws-tf",
   "credentials": {
     "AWSAccessKeyID": "awsAccessKeyId",
     "AWSSecretAccessKey": "awsSecretAccessKey"
   },
+  "dryRun": false,
+  "license": "<TECTONIC_LICENSE>",
+  "platform": "aws",
+  "pullSecret": "<TECTONIC_PULL_SECRET>",
+  "retry": false,
   "variables": {
     "tectonic_admin_email": "admin@example.com",
     "tectonic_admin_password": "password",
@@ -22,10 +22,11 @@
       "us-west-1a": "10.0.0.0/19",
       "us-west-1c": "10.0.32.0/19"
     },
-    "tectonic_aws_region": "us-west-1",
     "tectonic_aws_master_ec2_type": "t2.medium",
     "tectonic_aws_master_root_volume_size": 30,
     "tectonic_aws_master_root_volume_type": "gp2",
+    "tectonic_aws_private_endpoints": false,
+    "tectonic_aws_region": "us-west-1",
     "tectonic_aws_ssh_key": "tectonic-jenkins",
     "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
     "tectonic_aws_worker_custom_subnets": {
@@ -42,7 +43,6 @@
     "tectonic_etcd_count": 3,
     "tectonic_master_count": 3,
     "tectonic_service_cidr": "10.3.0.0/16",
-    "tectonic_worker_count": 3,
-    "tectonic_aws_private_endpoints": false
+    "tectonic_worker_count": 3
   }
 }

--- a/installer/frontend/__tests__/examples/metal.json
+++ b/installer/frontend/__tests__/examples/metal.json
@@ -11,8 +11,8 @@
     "tectonic_base_domain": "unused",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "my-cluster",
-    "tectonic_dns_name": "",
     "tectonic_container_linux_version": "1353.8.0",
+    "tectonic_dns_name": "",
     "tectonic_metal_controller_domain": "cluster.example.com",
     "tectonic_metal_controller_domains": [
       "node1.example.com"

--- a/installer/frontend/ui-tests/output/aws.tfvars
+++ b/installer/frontend/ui-tests/output/aws.tfvars
@@ -1,0 +1,41 @@
+{
+  "tectonic_admin_email": "admin@example.com",
+  "tectonic_admin_password": "password",
+  "tectonic_aws_etcd_ec2_type": "t2.medium",
+  "tectonic_aws_etcd_root_volume_size": 30,
+  "tectonic_aws_etcd_root_volume_type": "gp2",
+  "tectonic_aws_extra_tags": {
+    "test_tag": "testing"
+  },
+  "tectonic_aws_master_custom_subnets": {
+    "us-west-1a": "10.0.0.0/19",
+    "us-west-1c": "10.0.32.0/19"
+  },
+  "tectonic_aws_master_ec2_type": "t2.medium",
+  "tectonic_aws_master_root_volume_size": 30,
+  "tectonic_aws_master_root_volume_type": "gp2",
+  "tectonic_aws_private_endpoints": false,
+  "tectonic_aws_region": "us-west-1",
+  "tectonic_aws_ssh_key": "tectonic-jenkins",
+  "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
+  "tectonic_aws_worker_custom_subnets": {
+    "us-west-1a": "10.0.64.0/19",
+    "us-west-1c": "10.0.96.0/19"
+  },
+  "tectonic_aws_worker_ec2_type": "t2.medium",
+  "tectonic_aws_worker_root_volume_size": 30,
+  "tectonic_aws_worker_root_volume_type": "gp2",
+  "tectonic_base_domain": "tectonic.dev.coreos.systems",
+  "tectonic_cluster_cidr": "10.2.0.0/16",
+  "tectonic_cluster_name": "test",
+  "tectonic_dns_name": "test",
+  "tectonic_etcd_count": 3,
+  "tectonic_kube_apiserver_service_ip": "10.3.0.1",
+  "tectonic_kube_dns_service_ip": "10.3.0.10",
+  "tectonic_kube_etcd_service_ip": "10.3.0.15",
+  "tectonic_license_path": "./license.txt",
+  "tectonic_master_count": 3,
+  "tectonic_pull_secret_path": "./pull_secret.json",
+  "tectonic_service_cidr": "10.3.0.0/16",
+  "tectonic_worker_count": 3
+}

--- a/installer/frontend/ui-tests/output/metal.tfvars
+++ b/installer/frontend/ui-tests/output/metal.tfvars
@@ -1,0 +1,44 @@
+{
+  "tectonic_admin_email": "admin@example.com",
+  "tectonic_admin_password": "password",
+  "tectonic_base_domain": "unused",
+  "tectonic_cluster_cidr": "10.2.0.0/16",
+  "tectonic_cluster_name": "my-cluster",
+  "tectonic_container_linux_version": "1353.8.0",
+  "tectonic_dns_name": "",
+  "tectonic_kube_apiserver_service_ip": "10.3.0.1",
+  "tectonic_kube_dns_service_ip": "10.3.0.10",
+  "tectonic_kube_etcd_service_ip": "10.3.0.15",
+  "tectonic_license_path": "./license.txt",
+  "tectonic_metal_controller_domain": "cluster.example.com",
+  "tectonic_metal_controller_domains": [
+    "node1.example.com"
+  ],
+  "tectonic_metal_controller_macs": [
+    "52:54:00:a1:9c:ae"
+  ],
+  "tectonic_metal_controller_names": [
+    "node1"
+  ],
+  "tectonic_metal_ingress_domain": "tectonic.example.com",
+  "tectonic_metal_matchbox_ca": "-----BEGIN CERTIFICATE-----\nMIIFDTCCAvWgAwIBAgIJAIuXq10k2OFlMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV\nBAMMB2Zha2UtY2EwHhcNMTcwMjAxMjIxMzI0WhcNMjcwMTMwMjIxMzI0WjASMRAw\nDgYDVQQDDAdmYWtlLWNhMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA\nzzHsB56F6oZjsVBKzfpicsG+mVHQ/QzA4jqRCbQ8Zr12NtUZKnPUVwDoFf4WTfmy\nZ0u8Uv+6/B/8un3LGsIaJEugPfRboc2oZKJcqfMJSFfLb/wkmT0D/1HJR60ml/M5\nwpHeh4vQ7BhktNsK90EjdlLvr1GDfevXArnye5ksEInOSX9nXVsGPrm0AGSffhmY\nuUAjY8f9IspJa1j4vL6NI89GWO4jqME+SUnuI4SYIkuQJoSElofAIX2b5Tk3dFya\nVKmAq2L89teCMYsciPbFa/Z2HvDNZ7pC17Ow7zr1f+V5BU18h3cLk610YNPcEBw0\nf94+mePsmMSMjUM0f+NMFyDERF+pys60/3qqVWrJe/FkJM6NDCyWXXXAfTxIwLq0\nCVrlWALdTc+RMAPI2sxAdUp4BqAuek4SjIg3FuoJrBs3EAUPfybclJ7g3HJwyXM2\n3WIe10BnSk+rGzd4KMVbYw5/nM8Nc/Y20R2an/vVZn6xTxs9o6hhEHF7d5iws6Bi\n7/jv+jdZhLG8b3sG6Tj7a7YdvKWqH/mSPFlc/sevYOjR7NKYRMwGnl0d9qf+Xe5V\nxyH1llIXPs6+y1B4tRyL/tulyeVqi25+I4QVAYypxWU8CPyw7tsSdOsSTbeGTmXj\nehelY/BCjAqAcexL7oRV7dy7VZ1Ezg6zQRwMt0Tar90CAwEAAaNmMGQwHQYDVR0O\nBBYEFNGPoXTjJnHjG2zMpjSg/9vNO/trMB8GA1UdIwQYMBaAFNGPoXTjJnHjG2zM\npjSg/9vNO/trMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQDAgGGMA0G\nCSqGSIb3DQEBCwUAA4ICAQC9V/0iiEZYHz7xbezHpeGHwmecH5oylEvAeCcN10gx\nHFvUN+XMyBaPqN7iRtx/rSqyp2iN2AK1Cdn1viOSRc09lwPiuj9V4diSDyPwJWxd\n60gqd5E9F9gQXlenWoIdm7kW8Lo8HLfx8ItYKGpE51JUctTmGY5WURRmBlVKr1LA\nhbVsAWBaGQfPyW1CrFcxxc5mCABxWOxjRjLw8A8c5IXD0Q5C5pRd0BckBHKTdl40\nowm893oPEQcu/1C432T4vIddVh1Ktq1pd7O/9BPYOaPryzf7076xSwZ0bSuBUGRq\nVd3STfu5QRqpMv4dIrhqRofmIUzjOHLRX8Lx2pzgYcMgMQ8O+jM+ETrYD6rsDoLQ\nuiVSWZK0YFndKzNTA04u57arRumWKqqfS0kkDFayumyv6KaDS6YZdsqSRmaiLAOG\nF6jchpUtkDhDY0v/Y7jESUneT0hRnqNMPAKJMNhE4hS+1qkcP/ikQQgZl/OWma1z\nHUyBGT4OGP2T3JIfq12Z4vC5FGVD4aD/frTvPMlifV3i8lKlYZs271JPXUo6ASIA\nZSBpV5QilOlE25Q5Lcw0yWmN4KwxqBL9bJ5W9D1I0qhWxaMF78m+8vLIFv+dAylE\nOd27a+1We/P5ey7WRlwCfuEcFV7nYS/qMykYdQ9fxHSPgTPlrGrSwKstaaIIqOkE\nkA==\n-----END CERTIFICATE-----\n",
+  "tectonic_metal_matchbox_client_cert": "-----BEGIN CERTIFICATE-----\nMIIEYDCCAkigAwIBAgICEAEwDQYJKoZIhvcNAQELBQAwEjEQMA4GA1UEAwwHZmFr\nZS1jYTAeFw0xNzAyMDEyMjEzMjVaFw0xODAyMDEyMjEzMjVaMBYxFDASBgNVBAMM\nC2Zha2UtY2xpZW50MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr8S7\nx/tAS6W+aRW3X833OvNfxXjUJAiRkUV85Raln7tqVcTG/9iyRhWgNpUn/WU1/3qV\nobto4ZCURIwoQh0kWk8io1lafZJ+S6Znm3+0TKo7u6QMavolJyetsOQkT/bIoZ73\n09fhk4Vu9GILjtZtxV7GDb4WqR9R7z77nYTdHMio/BQVk+Xg6rkOsMRyoR+B9JHG\nn9mvXLZSi8Q+3ABtsN6flPt7mTkhFFFvTgWxtzgVbeORT/uFxIV/IMjtGseUIzvF\nGUQP6KCyCJb3Kp4rxSxIbi35mFqEWXjB7BVT/0pjx1mc5tSvGuFl7G4N/MmGe3Zq\nZCF4FalpiPGAInKrWQIDAQABo4G7MIG4MAkGA1UdEwQCMAAwEQYJYIZIAYb4QgEB\nBAQDAgeAMDMGCWCGSAGG+EIBDQQmFiRPcGVuU1NMIEdlbmVyYXRlZCBDbGllbnQg\nQ2VydGlmaWNhdGUwHQYDVR0OBBYEFNZOj+0OOvhOFEtGGriZrPVCSzc3MB8GA1Ud\nIwQYMBaAFNGPoXTjJnHjG2zMpjSg/9vNO/trMA4GA1UdDwEB/wQEAwIF4DATBgNV\nHSUEDDAKBggrBgEFBQcDAjANBgkqhkiG9w0BAQsFAAOCAgEAiiGHlmPI6RlJQq7/\nz/1i0vFArDbnc2mwBf3pqrDPyqx1EBx7V3Tsm38TNMZyHaz0IyPUDvRPn10UYXui\n2ZGseauwU/PmvFNofxVbG0Dc55lOoxl31520K0h9cWxVHcYzUxPndQ1pltYkXiMm\n/596LHkJ+unMJszDVhAIOmc0PgECtGH1VG6EoTTFlMu7VJekKInkYNow4Q6cAVcr\n11F4meOs0DMZgzfeUjSnsKG7KsLHfr5bLw6FEEzobgtI2sXVMOJi+ypd3zTY+ACq\noRt6wkRFCUoEgap7SG6B2TwHPGe15VIFZJtcnOZqHdrnfJLVROPnA4dYhJVJj1v1\n9JFH/T6EIi6nIqnrlX+10zaatpzq2+AFX8LiWpr7C7S99LgH3cnFdssfmlqoG82t\n3BshYpDrIw1f72zy8+RCkK52OdjNpDoVwubwz6i8jldzoENqmsioyetyaVfe9GGH\nUdEPrUZ4BHLeGPjHclOPVEhjVBZuofQ/GgM2gmCUdn5tcVLjnIeLAv/sQXwkMxIe\n4m9QcPrxVAKOlDr9LhB0mVPr2kfc4yI/wYWEe+CniwcuvxJiOmjsyrENxfaFY30r\nQspTSDVt8hVfVISzpuEchtLVjuRO/ESpmeOF1rRTc1qL/CjetmidkedDm64EZjyK\njyXQv9IZPMTwOndF6AVLH7l1F0E=\n-----END CERTIFICATE-----\n",
+  "tectonic_metal_matchbox_client_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpQIBAAKCAQEAr8S7x/tAS6W+aRW3X833OvNfxXjUJAiRkUV85Raln7tqVcTG\n/9iyRhWgNpUn/WU1/3qVobto4ZCURIwoQh0kWk8io1lafZJ+S6Znm3+0TKo7u6QM\navolJyetsOQkT/bIoZ7309fhk4Vu9GILjtZtxV7GDb4WqR9R7z77nYTdHMio/BQV\nk+Xg6rkOsMRyoR+B9JHGn9mvXLZSi8Q+3ABtsN6flPt7mTkhFFFvTgWxtzgVbeOR\nT/uFxIV/IMjtGseUIzvFGUQP6KCyCJb3Kp4rxSxIbi35mFqEWXjB7BVT/0pjx1mc\n5tSvGuFl7G4N/MmGe3ZqZCF4FalpiPGAInKrWQIDAQABAoIBAQCR/OQ+0JdxfWNu\nYqQhBbA/nV7BZH9GwnstXrrCiBHeXsqOHFdwruo7PcEJNM+3LnYwEP/xCfityOjt\nGkBh0VSdUbciV5fKTn9pk/ff9qypNIdSbYoG3Gc5Y0JndsYWSJIRczjCEj+AyMYE\nYt7Yr48S7ImxZl3p8GKcRQK1rWH9geg4cyCPisbaDSfjJbYh5yLk/2wsxGBRM3gg\nCyJEbkJ/v107a1iThTGBgEgnFPP+FqZ2jlnfhBPVzuYggYyiMJuNtgDl7Vi7NLBe\n2ueqq1UAT9LCpZNLJ8eYiDuyNHZtA7a2r3O/jTR4cvQy1xEjD3h4Es7olkAf/Lzu\n6wuggbllAoGBANcqZyJtVxkGwHV9CWTWniTT7BNQ2ehYErkNKggMXl2AzOqEKzqn\nIDRoBhiJKeAphdw/ccvqUEm9bUJD2QLpTJuMmUBkOwqMhATBXFrFCBX4PzGHYnC8\n6hEXjoUE6XhKdJEOgXTqrt31HDgj13GwAp/2DnsscFkC9co5+IW68sUjAoGBANEg\nQvZYdI4Me6JxLXotyirpo57xjocvlo+uffws/YwBH8nK/op6am69zzMMOgUYA5Li\n00WzfEXoyO+BdcbH28xYdBZT0CTkGlPM8IHuH+d/AwnEurxUElWZRRXSz6g17siM\nKjBodqI8h+jQiQJuJ/zBJbOm3bUbpIt1Z+ROjstTAoGAWdAdVMWHQa8Lzv7uWOUt\nBfpf5IAvNUjuJ8hS7yEakrUc1BdvZAA29Skmwj8e967dbV4eRhv8f4tOfAaOIyT3\nEUbTAYnVC0Y0JTgBMPJluaXx2t7EPILewVuv5d5zBf8uQQ5pA0Ci1YtmyBhN6eqq\nbdLroIagLseJiWxBTLEIfTkCgYEAjikXPC2fdhzoQuIbHy5Xe1p+PwNId3+TIzNk\nM3RGG9F70YqsBGj5RzTC0JnkKyhK7aRCKOS9eyymw6HG9Y1RTpVmvPLW0O07NHJh\noIHGsHD4GMDijDm+iO/7Nb2sKlYXb79Qwr2Qv/LUFSEFsmA90KVgQsMRfhc/gQob\nyOjaSz8CgYEAwr3aYp1CkKBXeUTNioLbyymhA4RqGPH/69F1NQ7froLXb152SzOV\njWcrt4ogRacgHb8thuTedrjUiJJLoWhQ3KqzSA2pI3tTLIxrJePiMMpt1Xb2z9l6\nPikk0rvNVB/vrPeVjAdGY9TJC/vpz3om92DRDmUifu8rCFxIHE0GrQ0=\n-----END RSA PRIVATE KEY-----\n",
+  "tectonic_metal_matchbox_http_url": "http://matchbox.example.com:8080",
+  "tectonic_metal_matchbox_rpc_endpoint": "matchbox.example.com:8081",
+  "tectonic_metal_worker_domains": [
+    "node2.example.com",
+    "node3.example.com"
+  ],
+  "tectonic_metal_worker_macs": [
+    "52:54:00:b2:2f:86",
+    "52:54:00:c3:61:77"
+  ],
+  "tectonic_metal_worker_names": [
+    "node2",
+    "node3"
+  ],
+  "tectonic_pull_secret_path": "./pull_secret.json",
+  "tectonic_service_cidr": "10.3.0.0/16",
+  "tectonic_ssh_authorized_key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCt3BebCHqnSsgpLjo4kVvyfY/z2BS8t27r/7du+O2pb4xYkr7n+KFpbOz523vMTpQ+o1jY4u4TgexglyT9nqasWgLOvo1qjD1agHme8LlTPQSk07rXqOB85Uq5p7ig2zoOejF6qXhcc3n1c7+HkxHrgpBENjLVHOBpzPBIAHkAGaZcl07OCqbsG5yxqEmSGiAlh/IiUVOZgdDMaGjCRFy0wk0mQaGD66DmnFc1H5CzcPjsxr0qO65e7lTGsE930KkO1Vc+RHCVwvhdXs+c2NhJ2/3740Kpes9n1/YullaWZUzlCPDXtRuy6JRbFbvy39JUgHWGWzB3d+3f8oJ/N4qZ cardno:000603633110"
+}

--- a/installer/frontend/ui-tests/tests/awsInstaller.js
+++ b/installer/frontend/ui-tests/tests/awsInstaller.js
@@ -5,9 +5,6 @@ const tfvarsUtil = require('../utils/terraformTfvars');
 // Test input .progress file
 const input = tfvarsUtil.loadJson('tectonic-aws.progress').clusterConfig;
 
-// Expected Terraform tfvars file variables
-const expected = tfvarsUtil.loadJson('aws.json').variables;
-
 const testPage = (page, nextInitiallyDisabled) => wizard.testPage(page, 'aws', input, nextInitiallyDisabled);
 
 const REQUIRED_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'TF_VAR_tectonic_license_path', 'TF_VAR_tectonic_pull_secret_path'];
@@ -42,17 +39,5 @@ module.exports = {
   'AWS: Networking': ({page}) => testPage(page.networkingPage()),
   'AWS: Console Login': ({page}) => testPage(page.consoleLoginPage()),
 
-  'AWS: Submit': client => {
-    const submitPage = client.page.submitPage();
-    submitPage.click('@manuallyBoot');
-    submitPage.expect.element('a[href="/terraform/assets"]').to.be.visible.before(120000);
-    client.getCookie('tectonic-installer', result => {
-      tfvarsUtil.returnTerraformTfvars(client.launch_url, result.value, (err, actualJson) => {
-        if (err) {
-          return client.assert.fail(err);
-        }
-        tfvarsUtil.assertDeepEqual(client, actualJson, expected);
-      });
-    });
-  },
+  'AWS: Manual Boot': client => tfvarsUtil.testManualBoot(client, 'aws.tfvars'),
 };

--- a/installer/frontend/ui-tests/tests/bareMetalInstaller.js
+++ b/installer/frontend/ui-tests/tests/bareMetalInstaller.js
@@ -5,9 +5,6 @@ const tfvarsUtil = require('../utils/terraformTfvars');
 // Test input .progress file
 const input = tfvarsUtil.loadJson('tectonic-baremetal.progress').clusterConfig;
 
-// Expected Terraform tfvars file variables
-const expected = tfvarsUtil.loadJson('metal.json').variables;
-
 const testPage = (page, nextInitiallyDisabled) => wizard.testPage(page, 'metal', input, nextInitiallyDisabled);
 
 const REQUIRED_ENV_VARS = ['TF_VAR_tectonic_license_path', 'TF_VAR_tectonic_pull_secret_path'];
@@ -46,17 +43,5 @@ module.exports = {
   'BM: SSH Key': ({page}) => testPage(page.sshKeysPage()),
   'BM: Console Login': ({page}) => testPage(page.consoleLoginPage()),
 
-  'BM: Submit': client => {
-    const submitPage = client.page.submitPage();
-    submitPage.click('@manuallyBoot');
-    submitPage.expect.element('a[href="/terraform/assets"]').to.be.visible.before(120000);
-    client.getCookie('tectonic-installer', result => {
-      tfvarsUtil.returnTerraformTfvars(client.launch_url, result.value, (err, actualJson) => {
-        if (err) {
-          return client.assert.fail(err);
-        }
-        tfvarsUtil.assertDeepEqual(client, actualJson, expected);
-      });
-    });
-  },
+  'BM: Manual Boot': client => tfvarsUtil.testManualBoot(client, 'metal.tfvars'),
 };

--- a/installer/frontend/ui-tests/utils/terraformTfvars.js
+++ b/installer/frontend/ui-tests/utils/terraformTfvars.js
@@ -4,83 +4,52 @@ const JSZip = require('jszip');
 const path = require('path');
 const request = require('request');
 
-const getAssets = (launchUrl, cookie, callback) => {
-  const options = {
-    url: launchUrl + '/terraform/assets',
-    method: 'GET',
-    encoding: null,
-    headers: {
-      'Cookie': 'tectonic-installer=' + cookie,
-    },
-  };
-  request(options, (err, res, body) => {
-    if (err) {
-      return callback(err, res);
-    }
-    if (res.statusCode !== 200 || res.headers['content-type'] !== 'application/zip') {
-      return callback({
-        statusCode: res.statusCode,
-        contentType: res.headers['content-type'],
-      }, res);
-    }
-    return callback(null, res, body);
-  });
-};
+const diffTfvars = (client, assetsZip, expected) => {
+  JSZip.loadAsync(assetsZip).then(zip => {
+    zip.file(/tfvars$/)[0].async('string').then(tfvars => {
+      const actual = JSON.parse(tfvars);
 
-const getTerraformTfvars = (response, callback) => {
-  let fileName;
-  JSZip.loadAsync(response).then(zip => {
-    Object.keys(zip.files).forEach(key => {
-      if (/tfvars$/.test(key)) {
-        fileName = key;
+      // The password hash will be different every time, so can't diff
+      delete actual.tectonic_admin_password_hash;
+      delete expected.tectonic_admin_password_hash;
+
+      const diff = deep(actual, expected);
+      if (diff !== undefined) {
+        client.assert.fail(
+          'The following terraform.tfvars attributes differ from their expected value: ' +
+          diff.map(({attr, lhs, rhs}) => `${attr} (expected: ${rhs}, got: ${lhs})`).join(', ')
+        );
       }
     });
-    zip.file(fileName).async('string').then(callback);
   });
 };
 
-const returnRequiredTerraformTfvars = (terraformTfvars) => {
-  const json = JSON.parse(terraformTfvars);
-  const extraTfvars = [
-    'tectonic_license_path',
-    'tectonic_pull_secret_path',
-    'tectonic_kube_apiserver_service_ip',
-    'tectonic_kube_dns_service_ip',
-    'tectonic_kube_etcd_service_ip',
-  ];
-  extraTfvars.forEach(key => {
-    delete json[key];
-  });
-  return json;
-};
+const testManualBoot = (client, expectedFilename) => {
+  client.page.submitPage()
+    .click('@manuallyBoot')
+    .expect.element('a[href="/terraform/assets"]').to.be.visible.before(120000);
 
-const returnTerraformTfvars = (launchUrl, cookie, callback) => {
-  getAssets(launchUrl, cookie, (err, res, terraformAssestsResponse) => {
-    if (err) {
-      return callback(err);
-    }
-    if (res.statusCode !== 200 || res.headers['content-type'] !== 'application/zip' ) {
-      return callback('Terraform get assets api call failed', res);
-    }
-    getTerraformTfvars(terraformAssestsResponse, (terraformTfvars) => {
-      const actualJson = returnRequiredTerraformTfvars(terraformTfvars);
-      callback(null, actualJson);
+  client.getCookie('tectonic-installer', ({value}) => {
+    const options = {
+      url: `${client.launch_url}/terraform/assets`,
+      method: 'GET',
+      encoding: null,
+      headers: {'Cookie': `tectonic-installer=${value}`},
+    };
+    request(options, (err, res, assetsZip) => {
+      if (err) {
+        return client.assert.fail(err);
+      }
+      if (res.statusCode !== 200 || res.headers['content-type'] !== 'application/zip') {
+        return client.assert.fail('Terraform get assets API call failed');
+      }
+
+      // eslint-disable-next-line no-sync
+      const expected = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'output', expectedFilename), 'utf8'));
+
+      diffTfvars(client, assetsZip, expected);
     });
   });
-};
-
-const assertDeepEqual = (client, actual, expected) => {
-  // The password hash will be different every time, so can't diff
-  delete actual.tectonic_admin_password_hash;
-  delete expected.tectonic_admin_password_hash;
-
-  const diff = deep(actual, expected);
-  if (diff !== undefined) {
-    client.assert.fail(
-      'The following terraform.tfvars attributes differ from their expected value: ' +
-      diff.map(({attr, lhs, rhs}) => `${attr} (expected: ${rhs}, got: ${lhs})`).join(', ')
-    );
-  }
 };
 
 const jsonDir = path.join(__dirname, '..', '..', '__tests__', 'examples');
@@ -88,7 +57,6 @@ const jsonDir = path.join(__dirname, '..', '..', '__tests__', 'examples');
 const loadJson = filename => JSON.parse(fs.readFileSync(path.join(jsonDir, filename), 'utf8'));
 
 module.exports = {
-  returnTerraformTfvars,
-  assertDeepEqual,
   loadJson,
+  testManualBoot,
 };


### PR DESCRIPTION
Instead of comparing against the unit test example JSON files, diff the generated tfvars files against what we expect them to be. This means we can diff against several additional vars and also allows us to simplify the test code a bit.