### PR TITLE
Allow specifying of AWS profile

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -27,6 +27,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_master_root_volume_size | The size of the volume in gigabytes for the root block device of master nodes. | string | `30` |
 | tectonic_aws_master_root_volume_type | The type of volume for the root block device of master nodes. | string | `gp2` |
 | tectonic_aws_private_endpoints | (optional) If set to true, create private-facing ingress resources (ELB, A-records). If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone. | string | `true` |
+| tectonic_aws_profile | (optional) This declares the AWS credentials profile to use. | string | `default` |
 | tectonic_aws_public_endpoints | (optional) If set to true, create public-facing ingress resources (ELB, A-records). If set to false, no public-facing ingress resources will be created. | string | `true` |
 | tectonic_aws_region | The target AWS region for the cluster. | string | `eu-west-1` |
 | tectonic_aws_ssh_key | Name of an SSH key located within the AWS region. Example: coreos-user. | string | - |

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -92,6 +92,9 @@ tectonic_aws_master_root_volume_type = "gp2"
 // If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
 // tectonic_aws_private_endpoints = true
 
+// (optional) This declares the AWS credentials profile to use.
+// tectonic_aws_profile = "default"
+
 // (optional) If set to true, create public-facing ingress resources (ELB, A-records).
 // If set to false, no public-facing ingress resources will be created.
 // tectonic_aws_public_endpoints = true

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
+  profile = "${var.tectonic_aws_profile}"
   version = "1.1.0"
 }
 

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -7,6 +7,15 @@ EOF
   default = "1.0"
 }
 
+variable "tectonic_aws_profile" {
+  description = <<EOF
+(optional) This declares the AWS credentials profile to use.
+EOF
+
+  type    = "string"
+  default = "default"
+}
+
 variable "tectonic_aws_ssh_key" {
   type        = "string"
   description = "Name of an SSH key located within the AWS region. Example: coreos-user."


### PR DESCRIPTION
Allow specifying the AWS credentials profile to use with the AWS platform. As far as I can tell this should work fine, it's useful to me as I juggle different AWS profiles.