### PR TITLE
Remove unused variable tectonic_dns_name

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -39,5 +39,4 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_worker_root_volume_iops | The amount of provisioned IOPS for the root block device of worker nodes. Ignored if the volume type is not io1. | string | `100` |
 | tectonic_aws_worker_root_volume_size | The size of the volume in gigabytes for the root block device of worker nodes. | string | `30` |
 | tectonic_aws_worker_root_volume_type | The type of volume for the root block device of worker nodes. | string | `gp2` |
-| tectonic_dns_name | (optional) DNS prefix used to construct the console and API server endpoints. | string | `` |
 

--- a/examples/terraform.tfvars.aws
+++ b/examples/terraform.tfvars.aws
@@ -224,9 +224,6 @@ tectonic_container_linux_version = "latest"
 // Specifies the RFC2136 Dynamic DNS server IP/host to register IP addresses to.
 // tectonic_ddns_server = ""
 
-// (optional) DNS prefix used to construct the console and API server endpoints.
-// tectonic_dns_name = ""
-
 // (optional) The size in MB of the PersistentVolume used for handling etcd backups.
 // tectonic_etcd_backup_size = "512"
 

--- a/installer/frontend/__tests__/examples/aws-vpc.json
+++ b/installer/frontend/__tests__/examples/aws-vpc.json
@@ -43,7 +43,6 @@
     "tectonic_base_domain": "example.com",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "test",
-    "tectonic_dns_name": "test",
     "tectonic_etcd_count": 3,
     "tectonic_master_count": 1,
     "tectonic_service_cidr": "10.3.0.0/16",

--- a/installer/frontend/__tests__/examples/aws.json
+++ b/installer/frontend/__tests__/examples/aws.json
@@ -39,7 +39,6 @@
     "tectonic_base_domain": "tectonic.dev.coreos.systems",
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "test",
-    "tectonic_dns_name": "test",
     "tectonic_etcd_count": 3,
     "tectonic_master_count": 3,
     "tectonic_service_cidr": "10.3.0.0/16",

--- a/installer/frontend/__tests__/examples/metal.json
+++ b/installer/frontend/__tests__/examples/metal.json
@@ -12,7 +12,6 @@
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "my-cluster",
     "tectonic_container_linux_version": "1353.8.0",
-    "tectonic_dns_name": "",
     "tectonic_metal_controller_domain": "cluster.example.com",
     "tectonic_metal_controller_domains": [
       "node1.example.com"

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -218,7 +218,6 @@ export const toAWS_TF = (cc, FORMS) => {
       tectonic_service_cidr: cc[SERVICE_CIDR],
       tectonic_worker_count: workers[NUMBER_OF_INSTANCES],
       // TODO: shouldn't hostedZoneID be specified somewhere?
-      tectonic_dns_name: cc[CLUSTER_SUBDOMAIN],
     },
   };
 
@@ -297,7 +296,6 @@ export const toBaremetal_TF = (cc, FORMS) => {
       tectonic_ssh_authorized_key: sshKey[SSH_AUTHORIZED_KEY],
       tectonic_cluster_cidr: cc[POD_CIDR],
       tectonic_service_cidr: cc[SERVICE_CIDR],
-      tectonic_dns_name: cc[CLUSTER_SUBDOMAIN],
       tectonic_base_domain: 'unused',
     },
   };

--- a/installer/frontend/ui-tests/output/aws.tfvars
+++ b/installer/frontend/ui-tests/output/aws.tfvars
@@ -28,7 +28,6 @@
   "tectonic_base_domain": "tectonic.dev.coreos.systems",
   "tectonic_cluster_cidr": "10.2.0.0/16",
   "tectonic_cluster_name": "test",
-  "tectonic_dns_name": "test",
   "tectonic_etcd_count": 3,
   "tectonic_kube_apiserver_service_ip": "10.3.0.1",
   "tectonic_kube_dns_service_ip": "10.3.0.10",

--- a/installer/frontend/ui-tests/output/metal.tfvars
+++ b/installer/frontend/ui-tests/output/metal.tfvars
@@ -5,7 +5,6 @@
   "tectonic_cluster_cidr": "10.2.0.0/16",
   "tectonic_cluster_name": "my-cluster",
   "tectonic_container_linux_version": "1353.8.0",
-  "tectonic_dns_name": "",
   "tectonic_kube_apiserver_service_ip": "10.3.0.1",
   "tectonic_kube_dns_service_ip": "10.3.0.10",
   "tectonic_kube_etcd_service_ip": "10.3.0.15",

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -175,12 +175,6 @@ Example: `[ { key = "foo", value = "bar", propagate_at_launch = true } ]`
 EOF
 }
 
-variable "tectonic_dns_name" {
-  type        = "string"
-  default     = ""
-  description = "(optional) DNS prefix used to construct the console and API server endpoints."
-}
-
 variable "tectonic_aws_etcd_root_volume_type" {
   type        = "string"
   default     = "gp2"


### PR DESCRIPTION
I'm removing the unused AWS variable `tectonic_dns_name`, as I can't see it being used anywhere. Also, if it's an AWS variable shouldn't it be named `tectonic_aws_dns_name` instead?