### PR TITLE
platform/gcp: bump nginx ingress controller version

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -71,7 +71,7 @@ variable "tectonic_container_images" {
     heapster                     = "gcr.io/google_containers/heapster:v1.4.1"
     hyperkube                    = "quay.io/coreos/hyperkube:v1.7.9_coreos.0"
     identity                     = "quay.io/coreos/dex:v2.7.1"
-    ingress_controller           = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15"
+    ingress_controller           = "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0-beta.16"
     kenc                         = "quay.io/coreos/kenc:0.0.2"
     kubedns                      = "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5"
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"


### PR DESCRIPTION
This fix the issue with livenessProbe failing when running k1.8 and hostNetwork true
See https://github.com/coreos/tectonic-installer/pull/1938#issuecomment-342500647