### PR TITLE
platform/gcp: add iam support with service accounts and scopes

### DIFF
--- a/modules/gcp/etcd/etcd.tf
+++ b/modules/gcp/etcd/etcd.tf
@@ -43,8 +43,4 @@ resource "google_compute_instance" "etcd-node" {
     user-data = "${data.ignition_config.etcd.*.rendered[count.index]}"
     sshKeys   = "core:${file(var.public_ssh_key)}"
   }
-
-  service_account {
-    scopes = ["cloud-platform"]
-  }
 }

--- a/modules/gcp/master-igm/iam.tf
+++ b/modules/gcp/master-igm/iam.tf
@@ -1,0 +1,19 @@
+resource "google_service_account" "master-node-sa" {
+  account_id   = "${var.cluster_name}-master-node"
+  display_name = "Master node"
+}
+
+resource "google_project_iam_member" "master-compute-admin" {
+  role   = "roles/compute.instanceAdmin"
+  member = "serviceAccount:${google_service_account.master-node-sa.email}"
+}
+
+resource "google_project_iam_member" "master-network-admin" {
+  role   = "roles/compute.networkAdmin"
+  member = "serviceAccount:${google_service_account.master-node-sa.email}"
+}
+
+resource "google_project_iam_member" "master-storage-admin" {
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.master-node-sa.email}"
+}

--- a/modules/gcp/master-igm/master.tf
+++ b/modules/gcp/master-igm/master.tf
@@ -43,6 +43,7 @@ resource "google_compute_instance_template" "master-it" {
   }
 
   service_account {
+    email  = "${google_service_account.master-node-sa.email}"
     scopes = ["cloud-platform"]
   }
 }

--- a/modules/gcp/worker-igm/iam.tf
+++ b/modules/gcp/worker-igm/iam.tf
@@ -1,0 +1,14 @@
+resource "google_service_account" "worker-node-sa" {
+  account_id   = "${var.cluster_name}-worker-node"
+  display_name = "Worker node"
+}
+
+resource "google_project_iam_member" "worker-compute-viewer" {
+  role   = "roles/compute.viewer"
+  member = "serviceAccount:${google_service_account.worker-node-sa.email}"
+}
+
+resource "google_project_iam_member" "worker-storage-admin" {
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.worker-node-sa.email}"
+}

--- a/modules/gcp/worker-igm/worker.tf
+++ b/modules/gcp/worker-igm/worker.tf
@@ -43,6 +43,7 @@ resource "google_compute_instance_template" "worker-it" {
   }
 
   service_account {
+    email  = "${google_service_account.worker-node-sa.email}"
     scopes = ["cloud-platform"]
   }
 }


### PR DESCRIPTION
Started by using ```resource_google_project_iam_policy``` https://github.com/terraform-providers/terraform-provider-google/pull/691
But ```google_project_iam_member``` gives more granular control and no race problems