### PR TITLE
tests: Make sure `create_resource` raises error on failure

### DIFF
--- a/tests/rspec/lib/azure_vpn.rb
+++ b/tests/rspec/lib/azure_vpn.rb
@@ -56,14 +56,14 @@ class AzureVpn
   end
 
   def create_resources
+    commands = ['terraform init', 'terraform apply']
+
     Dir.chdir(@build_dir) do
-      MAX_RETRIES.times do |count|
-        raise 'Private vnet: init failed too many times' unless MAX_RETRIES > count
-        break if system(env_config, 'terraform init')
-      end
-      MAX_RETRIES.times do |count|
-        raise 'Private vnet: apply failed too many times' unless MAX_RETRIES > count
-        break if system(env_config, 'terraform apply')
+      commands.each do |command|
+        MAX_RETRIES.times do |count|
+          break if system(env_config, command)
+          raise "Private vnet: #{command} failed #{MAX_RETRIES} times" if MAX_RETRIES == count + 1
+        end
       end
     end
   end


### PR DESCRIPTION
The index in rubys `each` iterator is zero indexed. Previously
`create_resource` would never raise an error if the last retry fails,
because `MAX_RETRIES > count` was always true. This patch makes sure
`create_resource` properly raises an error in case the last iteration
fails.