### PR TITLE
tests: Choose right commit sha

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -373,7 +373,7 @@ pipeline {
         }
       }
     }
-    
+
     stage('Send logfile to S3') {
       environment {
         LOGSTASH_BUCKET = 'log-analyzer-tectonic-installer'

--- a/tests/jenkins-jobs/scripts/report-status-to-github.sh
+++ b/tests/jenkins-jobs/scripts/report-status-to-github.sh
@@ -2,7 +2,7 @@
 
 STATUS="$1"
 CONTEXT=${2/spec/smoke-tests}
-COMMIT=$(git log -n 1 --no-merges --pretty=format:'%H')
+COMMIT=$(git rev-parse origin/"${BRANCH_NAME}")
 
 curl -f \
      -H 'Content-Type: application/json' \


### PR DESCRIPTION
Using the second last commit sha is not proficient, as master might be
ahead of the PR, thereby reporting a status of a commit on master and
not the HEAD of the PR.