### PR TITLE
platforms/openstack/neutron: Bump openstack provider to 1.0.0

### DIFF
--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -1,5 +1,5 @@
 provider "openstack" {
-  version = "0.3.0"
+  version = "1.0.0"
 }
 
 data "template_file" "etcd_hostname_list" {


### PR DESCRIPTION
Fixes #2269 