### PR TITLE
frontend: AWS Credentials page validation fixes

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -9,6 +9,7 @@ import { Alert } from './alert';
 import { getRegions } from '../aws-actions';
 import { Field, Form } from '../form';
 import { TectonicGA } from '../tectonic-ga';
+import { toExtraDataError } from '../utils';
 
 import {
   AWS_ACCESS_KEY_ID,
@@ -81,6 +82,10 @@ const selectRegionForm = new Form(AWS_REGION_FORM, [
     validator: validate.nonEmpty,
     dependencies: [AWS_CREDS],
     getExtraStuff: dispatch => dispatch(getRegions()),
+    asyncValidator: (dispatch, getState) => {
+      const error = _.get(getState().clusterConfig, toExtraDataError('awsRegion'));
+      return _.isEmpty(error) ? Promise.resolve() : Promise.reject(error);
+    },
   }),
 ]);
 

--- a/installer/frontend/components/make-node-form.jsx
+++ b/installer/frontend/components/make-node-form.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 
 import { getIamRoles } from '../aws-actions';
 import {
-  AWS_CREDS,
+  AWS_REGION_FORM,
   IAM_ROLE,
   IAM_ROLE_CREATE_OPTION,
   INSTANCE_TYPE,
@@ -23,7 +23,7 @@ new Form('DUMMY_NODE_FORM', [
   new Field(IAM_ROLE, {
     default: 'DUMMY_VALUE',
     name: IAM_ROLE,
-    dependencies: [AWS_CREDS],
+    dependencies: [AWS_REGION_FORM],
     getExtraStuff: (dispatch, isNow) => dispatch(getIamRoles(null, null, isNow)),
   }),
 ]);

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -49,7 +49,9 @@ class Node {
       .filter(d => !d.isValid(clusterConfig));
 
     if (unsatisfiedDeps.length) {
-      return setIn(toExtraData(this.id), undefined, dispatch);
+      // Dependencies are not all satisfied yet
+      setIn(toExtraData(this.id), undefined, dispatch);
+      return Promise.resolve();
     }
 
     this.updateClock(now);


### PR DESCRIPTION
3 related fixes for validation on the AWS Credentials page.
- Fix `getExtraStuff()` to always return a promise. Looks like this was an old bug that only recently became visible due to AWS Credentials page changes.
- Add `asyncValidator()` for AWS regions field. Needed so that the containing form
notices when the API call fails and the field is therefore invalid.
- Delay `/aws/iam-roles` API call until AWS Credentials page form has been completed. We don't need a region to call `/aws/iam-roles`, so the call we being made as soon as the AWS id and secret key were provided. Unfortunately, that could result in lots of unnecessary API calls as the values are entered. To avoid this, wait until the whole form (include the region dropdown) is completed.