### PR TITLE
platform/gcp: reduce service account name terraform google provider #671

### DIFF
--- a/modules/gcp/master-igm/iam.tf
+++ b/modules/gcp/master-igm/iam.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "master-node-sa" {
-  account_id   = "${var.cluster_name}-master-node"
+  account_id   = "${format("%.28s", var.cluster_name)}-m"
   display_name = "Master node"
 }
 

--- a/modules/gcp/worker-igm/iam.tf
+++ b/modules/gcp/worker-igm/iam.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "worker-node-sa" {
-  account_id   = "${var.cluster_name}-worker-node"
+  account_id   = "${format("%.28s", var.cluster_name)}-w"
   display_name = "Worker node"
 }
 


### PR DESCRIPTION
We use the branch name on the temporary cluster_name for testing which make us suffering this issue https://github.com/terraform-providers/terraform-provider-google/issues/671
This should restrain it