### PR TITLE
platforms/metal: Add initrd argument to kernel cmdline

### DIFF
--- a/platforms/metal/profiles.tf
+++ b/platforms/metal/profiles.tf
@@ -8,6 +8,7 @@ resource "matchbox_profile" "coreos_install" {
   ]
 
   args = [
+    "initrd=coreos_production_pxe_image.cpio.gz",
     "coreos.config.url=${var.tectonic_metal_matchbox_http_url}/ignition?uuid=$${uuid}&mac=$${mac:hexhyp}",
     "coreos.first_boot=yes",
     "console=tty0",


### PR DESCRIPTION
Fixes #2345
Solution as described here: https://github.com/coreos/docs/commit/3c4bcacd0081e534c5b4943afde5cf1c0a7753a6
Relevant links:
    coreos/bugs#1239
    http://ipxe.org/appnote/debian_preseed