### PR TITLE
platform/gcp: add move-assets service

### DIFF
--- a/modules/gcp/master-igm/ignition.tf
+++ b/modules/gcp/master-igm/ignition.tf
@@ -13,7 +13,8 @@ data "ignition_config" "main" {
     var.ign_bootkube_service_id,
     var.ign_tectonic_service_id,
     var.ign_bootkube_path_unit_id,
-    var.ign_tectonic_path_unit_id
+    var.ign_tectonic_path_unit_id,
+    data.ignition_systemd_unit.move_assets.id
    ))}"]
 }
 
@@ -25,4 +26,14 @@ data "ignition_file" "kubeconfig" {
   content {
     content = "${var.kubeconfig_content}"
   }
+}
+
+data "template_file" "move_assets" {
+  template = "${file("${path.module}/resources/services/move-assets.service")}"
+}
+
+data "ignition_systemd_unit" "move_assets" {
+  name    = "move-assets.service"
+  enable  = true
+  content = "${data.template_file.move_assets.rendered}"
 }

--- a/modules/gcp/master-igm/resources/services/move-assets.service
+++ b/modules/gcp/master-igm/resources/services/move-assets.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Move Tectonic Assets
+ConditionDirectoryNotEmpty=/home/core/tectonic
+Before=k8s-node-bootstrap.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+
+User=root
+Group=root
+
+ExecStartPre=/usr/bin/bash -c "mkdir -p /opt"
+ExecStartPre=/usr/bin/bash -c "rm -rf /opt/tectonic"
+ExecStartPre=/usr/bin/bash -c 'while [ ! -z "$(ps aux | pgrep scp)" ]; do sleep 1; done'
+ExecStart=/usr/bin/bash -c "mv /home/core/tectonic /opt/"
+
+[Install]
+WantedBy=multi-user.target
+RequiredBy=k8s-node-bootstrap.service bootkube.service kubelet-env.service
+

--- a/modules/gcp/network/loadbalancer.tf
+++ b/modules/gcp/network/loadbalancer.tf
@@ -66,19 +66,6 @@ resource "google_compute_address" "ssh-masters-ip" {
   name = "${var.cluster_name}-masters-ip"
 }
 
-resource "google_compute_forwarding_rule" "api-external-fwd-rule" {
-  load_balancing_scheme = "EXTERNAL"
-  name                  = "${var.cluster_name}-api-external-fwd-rule"
-  ip_address            = "${google_compute_address.ssh-masters-ip.address}"
-  region                = "${var.gcp_region}"
-  target                = "${google_compute_target_pool.master-targetpool.self_link}"
-  port_range            = "443"
-}
-
-resource "google_compute_address" "ingress-ip" {
-  name = "${var.cluster_name}-ingress-ip"
-}
-
 resource "google_compute_forwarding_rule" "api-external-ssh-fwd-rule" {
   load_balancing_scheme = "EXTERNAL"
   name                  = "${var.cluster_name}-api-external-ssh-fwd-rule"
@@ -86,6 +73,10 @@ resource "google_compute_forwarding_rule" "api-external-ssh-fwd-rule" {
   region                = "${var.gcp_region}"
   target                = "${google_compute_target_pool.master-targetpool.self_link}"
   port_range            = "22"
+}
+
+resource "google_compute_address" "ingress-ip" {
+  name = "${var.cluster_name}-ingress-ip"
 }
 
 resource "google_compute_forwarding_rule" "ingress-external-http-fwd-rule" {

--- a/platforms/gcp/bootstrap.tf
+++ b/platforms/gcp/bootstrap.tf
@@ -1,5 +1,4 @@
-module "bootstrapper" {
-  source = "../../modules/bootstrap-ssh"
+locals {
 
   _dependencies = [
     "${module.masters.instance_group}",
@@ -11,6 +10,23 @@ module "bootstrapper" {
     "${module.calico.id}",
     "${module.canal.id}",
   ]
+}
 
-  bootstrapping_host = "${module.network.ssh_master_ip}"
+resource "null_resource" "bootstrapper" {
+  triggers {
+    endpoint     = "${module.network.ssh_master_ip}"
+    dependencies = "${join("", concat(flatten(local._dependencies)))}"
+  }
+
+  connection {
+    host  = "${module.network.ssh_master_ip}"
+    user  = "core"
+    agent = true
+  }
+
+  provisioner "file" {
+    when        = "create"
+    source      = "./generated"
+    destination = "$HOME/tectonic"
+  }
 }

--- a/platforms/gcp/bootstrap.tf
+++ b/platforms/gcp/bootstrap.tf
@@ -1,5 +1,4 @@
 locals {
-
   _dependencies = [
     "${module.masters.instance_group}",
     "${module.etcd.etcd_ip_addresses}",


### PR DESCRIPTION
Problem:
- There is currently a potential race issue between ssh terraform provisioners and reboot triggered by torcx
- Side effects produced by two step terraform file provisioner + terraform remote-exec + reboot

Potential solution:
- This removes remote-exec
- This adds a dependency for the bootstraper node with move-assets while keeping the other masters functional - "such as ConditionPathExists=, ConditionPathIsSymbolicLink=, … — see below) do not cause the start job of a unit with a Requires= dependency on it to fail”
- This would supersede https://github.com/coreos/tectonic-installer/pull/2315

Adding this here for testing purposes with do not merge label as we are still working on a better solution