### PR TITLE
frontend: Fix to not clear "extra data" when dependencies are unsatisfied

### DIFF
--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -50,7 +50,6 @@ class Node {
 
     if (unsatisfiedDeps.length) {
       // Dependencies are not all satisfied yet
-      setIn(toExtraData(this.id), undefined, dispatch);
       return Promise.resolve();
     }
 


### PR DESCRIPTION
Not sure why this line ever existed, but dependencies will flip between invalid and valid, so it doesn't make sense to clear a field's "extra data" just because a dependency becomes invalid.