### PR TITLE
frontend: Check for "extra data" errors when doing field validation

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -9,7 +9,6 @@ import { Alert } from './alert';
 import { getRegions } from '../aws-actions';
 import { Field, Form } from '../form';
 import { TectonicGA } from '../tectonic-ga';
-import { toExtraDataError } from '../utils';
 
 import {
   AWS_ACCESS_KEY_ID,
@@ -82,10 +81,6 @@ const selectRegionForm = new Form(AWS_REGION_FORM, [
     validator: validate.nonEmpty,
     dependencies: [AWS_CREDS],
     getExtraStuff: dispatch => dispatch(getRegions()),
-    asyncValidator: (dispatch, getState) => {
-      const error = _.get(getState().clusterConfig, toExtraDataError('awsRegion'));
-      return _.isEmpty(error) ? Promise.resolve() : Promise.reject(error);
-    },
   }),
 ]);
 

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -283,7 +283,7 @@ export class Field extends Node {
     const ignore = _.get(clusterConfig, toIgnore(id));
     let error = _.get(clusterConfig, toError(id));
     if (!error && !syncOnly) {
-      error = _.get(clusterConfig, toAsyncError(id));
+      error = _.get(clusterConfig, toAsyncError(id)) || _.get(clusterConfig, toExtraDataError(id));
     }
 
     return ignore || value !== '' && value !== undefined && _.isEmpty(error);


### PR DESCRIPTION
This makes `Field`'s `isValid()` also check for "extra data" errors.

This allows the AWS region field's `asyncValidator()` to be removed since it was just checking for the existence of an "extra data" error.