### PR TITLE
Azure: add German locations to fault domain map

### DIFF
--- a/platforms/azure/variables.tf
+++ b/platforms/azure/variables.tf
@@ -292,5 +292,7 @@ EOF
     usgovarizona       = 2
     usdodcentral       = 2
     usdodeast          = 2
+    germanycentral     = 2
+    germanynortheast   = 2
   }
 }


### PR DESCRIPTION
## Purpose

Set the default fault domain count for Germany

## Approach
Although not documented in  https://docs.microsoft.com/en-us/azure/virtual-machines/windows/manage-availability, I faced the same problems as in #2211.

## Where did they keys come from:

```
az account list-locations
[
  {
    "displayName": "Germany Central",
    "id": "/subscriptions/xxxxxxxxx/locations/germanycentral",
    "latitude": "50.117",
    "longitude": "8.683",
    "name": "germanycentral",
    "subscriptionId": null
  },
  {
    "displayName": "Germany Northeast",
    "id": "/subscriptions/xxxxxxxxx/locations/germanynortheast",
    "latitude": "51.333",
    "longitude": "12.383",
    "name": "germanynortheast",
    "subscriptionId": null
  }
]
```


## Related Issues
Fixes #2211