### PR TITLE
Use Docker overlay2 storage driver

### DIFF
--- a/modules/ignition/resources/dropins/10-dockeropts.conf
+++ b/modules/ignition/resources/dropins/10-dockeropts.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3 --storage-driver=overlay2"


### PR DESCRIPTION
I am experiencing spurious Docker overlay corruption when creating clusters on DigitalOcean (with my port of Tectonic Installer to this platform). I get errors of this type:

```
Failed to pull image "quay.io/coreos/flannel:v0.8.0-amd64": rpc error: code = Unknown desc = failed to register layer: lstat /var/lib/docker/overlay/c8a44ea6ff42c4996ab84439faf23775e3196f5ca54f981c9ea764ce0af0c89d: no such file or directory
```

While doing research on the problem, I realized that Docker is configured with the _overlay_ storage driver, which seems to be deprecated in favour of [overlay2](https://docs.docker.com/engine/userguide/storagedriver/selectadriver/). Therefore I made the experiment of configuring Docker to use overlay2 as its storage driver, after which my overlay corruption problem went away, and hopefully for good although I don't know for sure yet. For what it's worth I have tested several times now with this configuration change, and every cluster comes up without problems, so it's looking good...

I'm interested in your feedback on my change, as I don't know if there's a reason for Container Linux/Tectonic using the _overlay_ storage driver as opposed to _overlay2_. I have the impression one should use the latter, but I could be wrong.