### PR TITLE
Fixes kubelet.env location per #FR-445

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -108,7 +108,7 @@ data "template_file" "installer_kubelet_env" {
 
 data "ignition_file" "installer_kubelet_env" {
   filesystem = "root"
-  path       = "/etc/kubernetes/installer/kubelet.env"
+  path       = "/etc/kubernetes/kubelet.env"
   mode       = 0644
 
   content {


### PR DESCRIPTION
This moves the kubelet.env file back to /etc/kubernetes/kubelet.env
This affects bare metal and vmware installations.