### PR TITLE
tests: Bump conformance test timeout

### DIFF
--- a/tests/rspec/lib/k8s_conformance_tests.rb
+++ b/tests/rspec/lib/k8s_conformance_tests.rb
@@ -12,7 +12,7 @@ class K8sConformanceTest
   end
 
   def run
-    ::Timeout.timeout(90 * 60) do # 1 1/2 hour
+    ::Timeout.timeout(2 * 60 * 60) do # 2 hour
       image = ENV['KUBE_CONFORMANCE_IMAGE']
       succeeded = system("docker run -v #{@kubeconfig_path}:/kubeconfig #{network_config} #{image}")
       raise 'Running k8s conformance tests failed' unless succeeded


### PR DESCRIPTION
With the new 1.82 conformance test image, run time went up. This patch
adjusts the conformance test timeout accordingly to 2 h.