### PR TITLE
frontend: Fix handling of errors when loading IAM roles from AWS API

### DIFF
--- a/installer/frontend/components/aws-define-nodes.jsx
+++ b/installer/frontend/components/aws-define-nodes.jsx
@@ -47,9 +47,10 @@ const IamRoles = connect(
     <Connect field={toKey(type, IAM_ROLE)}>
       <Select id={`${type}--iam-role`}>
         <option value={IAM_ROLE_CREATE_OPTION}>Create an IAM role for me (default)</option>
-        {roles.map(r => <option value={r} key={r}>{r}</option>)}
+        {_.isArray(roles) && roles.map(r => <option value={r} key={r}>{r}</option>)}
       </Select>
     </Connect>
+    {!_.isArray(roles) && <div className="wiz-error-message">Could not load IAM role list</div>}
   </Row>
 );
 


### PR DESCRIPTION
If `/aws/iam-roles` returned an error, that error case was not being handled, resulting in a JS error.

![screenshot-1](https://user-images.githubusercontent.com/460802/32777126-5d2ef9d6-c978-11e7-84dc-d16f71d82263.png)
