### PR TITLE
frontend: Remove unnecessary entries when saving progress file

### DIFF
--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -20,8 +20,10 @@ import { Footer } from './footer';
 const downloadState = (state) => {
   const toSave = _.cloneDeep(savable(state));
 
-  // Extra field data doesn't need to be saved
-  _.unset(toSave, 'clusterConfig.extra');
+  // Remove state entries that aren't field inputs and shouldn't be saved
+  ['error', 'error_async', 'extra', 'extraError', 'extraInFly', 'ignore', 'inFly'].forEach(key => {
+    _.unset(toSave, `clusterConfig.${key}`);
+  });
 
   const saved = JSON.stringify(toSave, null, 2);
   const stateBlob = new Blob([saved], {type: 'application/json'});


### PR DESCRIPTION
We shouldn't be relying on any of these entries when restoring progress, and removing them ensures that we are not.

`error`, `error_async`, `extraError` and `ignore` don't need to be saved because validation is run on all fields when the progress file is loaded, which recalculates all of these values.

`inFly` and `extraInFly` indicate whether an API is in progress, which doesn't make sense to store in the progress file.