### PR TITLE
frontend: Remove redundant CSS class "wiz-dirty"

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -466,7 +466,7 @@ input.wiz-super-short-input {
   margin: 20px 0 0 20px;
 }
 
-.wiz-invalid.wiz-dirty {
+.wiz-invalid {
   border-color: #f04c5c !important;
   border-bottom-left-radius: 0px !important;
   border-bottom-right-radius: 0px !important;

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -74,14 +74,9 @@ const Field = withNav(connect(
   (dispatch, {id}) => ({makeDirty: () => dispatch(dirtyActions.add(id))}),
 )(props => {
   const tag = props.tag || 'input';
-  const dirty = props.forceDirty || props.isDirty;
-  const fieldClasses = classNames(props.className, {
-    'wiz-dirty': dirty,
-    'wiz-invalid': props.invalid,
-  });
-  const errorClasses = classNames('wiz-error-message', {
-    hidden: !(dirty && props.invalid),
-  });
+  const isInvalid = props.invalid && (props.forceDirty || props.isDirty);
+  const fieldClasses = classNames(props.className, {'wiz-invalid': isInvalid});
+  const errorClasses = classNames('wiz-error-message', {hidden: !isInvalid});
 
   const elementProps = {};
   Object.keys(props).filter(k => FIELD_PROPS.has(k)).forEach(k => {


### PR DESCRIPTION
`wiz-invalid` and `wiz-dirty` are only ever used together, so we only need one.