### PR TITLE
modules: retry init assets

### DIFF
--- a/modules/aws/master-asg/resources/detect-master.sh
+++ b/modules/aws/master-asg/resources/detect-master.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 # Wait for the ASG to run at the expected scale.
 while true; do

--- a/modules/aws/master-asg/resources/init-assets.sh
+++ b/modules/aws/master-asg/resources/init-assets.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
-# Defer cleanup rkt containers and images.
-trap "{ /usr/bin/rkt gc --grace-period=0; /usr/bin/rkt image gc --grace-period 0; } &> /dev/null" EXIT
+detect_master() {
+    mkdir -p /run/metadata
+    # shellcheck disable=SC2086,SC2154
+    /usr/bin/docker run \
+        --volume /run/metadata:/run/metadata \
+        --volume /opt/detect-master.sh:/detect-master.sh:ro \
+        --network=host \
+        --env CLUSTER_NAME=${cluster_name} \
+        --entrypoint=/detect-master.sh \
+        ${awscli_image}
+}
 
-mkdir -p /run/metadata
-# shellcheck disable=SC2086,SC2154
-/usr/bin/docker run \
-    --volume /run/metadata:/run/metadata \
-    --volume /opt/detect-master.sh:/detect-master.sh:ro \
-    --network=host \
-    --env CLUSTER_NAME=${cluster_name} \
-    --entrypoint=/detect-master.sh \
-    ${awscli_image}
+until detect_master; do
+    echo "failed to detect master; retrying in 5 seconds"
+    sleep 5
+done
 
 MASTER=$(cat /run/metadata/master)
 if [ "$MASTER" != "true" ]; then

--- a/modules/ignition/resources/bin/s3-puller.sh
+++ b/modules/ignition/resources/bin/s3-puller.sh
@@ -1,23 +1,38 @@
 #!/bin/bash
+set -e
+set -o pipefail
 
 if [ "$#" -ne "2" ]; then
     echo "Usage: $0 location destination"
     exit 1
 fi
 
-# shellcheck disable=SC2086,SC2154,SC2016
-/usr/bin/docker run \
-    --volume /tmp:/tmp \
-    --network=host \
-    --env LOCATION="$1" \
-    --entrypoint=/bin/bash \
-    ${awscli_image} \
-    -c '
-        REGION=$(wget -q -O - http://169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/[a-zA-Z]$//')
-        until /usr/bin/aws --region=$${REGION} s3 cp s3://$${LOCATION} /tmp/$${LOCATION//\//+}; do
-            echo "Could not pull from S3, retrying in 5 seconds"
-            sleep 5
-        done
-    '
-# shellcheck disable=SC1001,SC1083,SC2086
-/usr/bin/sudo mv /tmp/$${1//\//+} $2
+# shellcheck disable=SC2034
+LOCATION=$1
+# shellcheck disable=SC1083,SC1001
+LOCATION_ESCAPED=$${1//\//+}
+DESTINATION=$2
+
+s3_pull() {
+    # shellcheck disable=SC2086,SC2154,SC2016
+    /usr/bin/docker run \
+        --volume /tmp:/tmp \
+        --network=host \
+        --env LOCATION=$LOCATION \
+        --env LOCATION_ESCAPED=$LOCATION_ESCAPED \
+        --entrypoint=/bin/bash \
+        ${awscli_image} \
+        -c '
+            set -e
+            set -o pipefail
+            REGION=$(wget -q -O - http://169.254.169.254/latest/meta-data/placement/availability-zone | sed '"'"'s/[a-zA-Z]$//'"'"')
+            /usr/bin/aws --region="$REGION" s3 cp s3://"$LOCATION" /tmp/"$LOCATION_ESCAPED"
+        '
+}
+
+until s3_pull; do
+    echo "failed to pull from S3; retrying in 5 seconds"
+    sleep 5
+done
+
+/usr/bin/sudo mv /tmp/"$LOCATION_ESCAPED" "$DESTINATION"


### PR DESCRIPTION
This commit makees several modifications to ensure the init-assets
service will retry any network operations, e.g. wget, curl, aws etc.
Rather than adding individual retries for each of the dozens of
operations that could fail, this commit adds retries to the docker
commands that encompass those operations.

Fixes: INST-341, INST-574

cc @s-urbaniak 