### PR TITLE
platforms/aws: set fqdns correctly if internal zone is disabled

### DIFF
--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -9,7 +9,7 @@ module "kube_certs" {
   ca_cert_pem        = "${var.tectonic_ca_cert}"
   ca_key_alg         = "${var.tectonic_ca_key_alg}"
   ca_key_pem         = "${var.tectonic_ca_key}"
-  kube_apiserver_url = "https://${module.dns.api_internal_fqdn}:443"
+  kube_apiserver_url = "https://${var.tectonic_aws_private_endpoints ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
   service_cidr       = "${var.tectonic_service_cidr}"
   validity_period    = "${var.tectonic_tls_validity_period}"
 }
@@ -28,7 +28,7 @@ module "etcd_certs" {
 module "ingress_certs" {
   source = "../../modules/tls/ingress/self-signed"
 
-  base_address    = "${module.dns.ingress_internal_fqdn}"
+  base_address    = "${var.tectonic_aws_private_endpoints ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
   ca_cert_pem     = "${module.kube_certs.ca_cert_pem}"
   ca_key_alg      = "${module.kube_certs.ca_key_alg}"
   ca_key_pem      = "${module.kube_certs.ca_key_pem}"


### PR DESCRIPTION
Currently provisioning TLS certificates fails if the internal DNS zone
is disabled.

This fixes it.

/cc @squat @soggiest 