### PR TITLE
frontend: Don't set custom subnets unless those fields have been edited

### DIFF
--- a/installer/frontend/__tests__/examples/aws.json
+++ b/installer/frontend/__tests__/examples/aws.json
@@ -18,10 +18,6 @@
     "tectonic_aws_extra_tags": {
       "test_tag": "testing"
     },
-    "tectonic_aws_master_custom_subnets": {
-      "us-west-1a": "10.0.0.0/19",
-      "us-west-1c": "10.0.32.0/19"
-    },
     "tectonic_aws_master_ec2_type": "t2.medium",
     "tectonic_aws_master_root_volume_size": 30,
     "tectonic_aws_master_root_volume_type": "gp2",
@@ -29,10 +25,6 @@
     "tectonic_aws_region": "us-west-1",
     "tectonic_aws_ssh_key": "tectonic-jenkins",
     "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
-    "tectonic_aws_worker_custom_subnets": {
-      "us-west-1a": "10.0.64.0/19",
-      "us-west-1c": "10.0.96.0/19"
-    },
     "tectonic_aws_worker_ec2_type": "t2.medium",
     "tectonic_aws_worker_root_volume_size": 30,
     "tectonic_aws_worker_root_volume_type": "gp2",

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -160,7 +160,7 @@ export const DEFAULT_CLUSTER_CONFIG = {
   [RETRY]: false, // whether we're retrying a terraform apply
 };
 
-export const toAWS_TF = (cc, FORMS) => {
+export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
   const controllers = FORMS[AWS_CONTROLLERS].getData(cc);
   const etcds = FORMS[AWS_ETCDS].getData(cc);
   const workers = FORMS[AWS_WORKERS].getData(cc);
@@ -242,8 +242,12 @@ export const toAWS_TF = (cc, FORMS) => {
   }
   if (cc[AWS_CREATE_VPC] === VPC_CREATE) {
     ret.variables.tectonic_aws_vpc_cidr_block = cc[AWS_VPC_CIDR];
-    ret.variables.tectonic_aws_master_custom_subnets = controllerSubnets;
-    ret.variables.tectonic_aws_worker_custom_subnets = workerSubnets;
+
+    // If the subnets have not been edited, omit these variables so that sensible default subnets will be created
+    if (dirty[AWS_CONTROLLER_SUBNETS] || dirty[AWS_WORKER_SUBNETS]) {
+      ret.variables.tectonic_aws_master_custom_subnets = controllerSubnets;
+      ret.variables.tectonic_aws_worker_custom_subnets = workerSubnets;
+    }
   } else {
     ret.variables.tectonic_aws_external_vpc_id = cc[AWS_VPC_ID];
     ret.variables.tectonic_aws_external_master_subnet_ids = controllerSubnets;
@@ -263,7 +267,7 @@ export const toAWS_TF = (cc, FORMS) => {
   return ret;
 };
 
-export const toBaremetal_TF = (cc, FORMS) => {
+export const toBaremetal_TF = ({clusterConfig: cc}, FORMS) => {
   const sshKey = FORMS[BM_SSH_KEY].getData(cc);
   const masters = cc[BM_MASTERS];
   const workers = cc[BM_WORKERS];

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -1,8 +1,16 @@
 import _ from 'lodash';
 
-import { getTectonicDomain, toAWS_TF, toBaremetal_TF, DRY_RUN, PULL_SECRET, RETRY, TECTONIC_LICENSE } from './cluster-config';
+import {
+  DRY_RUN,
+  PLATFORM_TYPE,
+  PULL_SECRET,
+  RETRY,
+  TECTONIC_LICENSE,
+  getTectonicDomain,
+  toAWS_TF,
+  toBaremetal_TF,
+} from './cluster-config';
 import { clusterReadyActionTypes, configActions, loadFactsActionTypes, serverActionTypes, FORMS } from './actions';
-import { savable } from './reducer';
 import { AWS_TF, BARE_METAL_TF } from './platforms';
 
 const { addIn, setIn } = configActions;
@@ -76,14 +84,13 @@ export const commitToServer = (dryRun = false, retry = false, opts = {}) => (dis
   dispatch({type: COMMIT_REQUESTED});
 
   const state = getState();
-  const request = Object.assign({}, state.clusterConfig, {progress: savable(state)});
 
-  const f = platformToFunc[request.platformType];
+  const f = platformToFunc[state.clusterConfig[PLATFORM_TYPE]];
   if (!_.isFunction(f)) {
-    throw Error(`unknown platform type "${request.platformType}"`);
+    throw Error(`unknown platform type "${state.clusterConfig[PLATFORM_TYPE]}"`);
   }
 
-  const body = f(request, FORMS, opts);
+  const body = f(state, FORMS, opts);
   fetch('/terraform/apply', {
     credentials: 'same-origin',
     method: 'POST',


### PR DESCRIPTION
Don't include `tectonic_aws_master_custom_subnets` or `tectonic_aws_worker_custom_subnets` in the generated tfvars file unless one of those subnet fields was edited. This will also work when
restoring .progress files since those files include the `dirty` fields.

Note that currently, just opening the advanced VPC options is enough to mark the subnet fields as `dirty`.

Also removes the `progress` attribute that was being passed to `toAWS_TF()` / `toBaremetal_TF()` because they don't use it.