### PR TITLE
frontend: Fix resetting the AWS existing subnet dropdown

### DIFF
--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -189,7 +189,7 @@ const SubnetSelect = ({field, name, subnets, disabled, fieldName}) => <div class
   <div className="col-xs-6">
     <Connect field={field}>
       <Select disabled={disabled}>
-        <option disabled>Select a subnet</option>
+        <option disabled selected value="">Select a subnet</option>
         {_.filter(subnets, ({availabilityZone}) => availabilityZone === name)
           .map(({id, instanceCIDR}) => <option value={id} key={instanceCIDR}>{instanceCIDR} ({id})</option>)
         }


### PR DESCRIPTION
This fixes a bug where resetting the subnet IDs in Redux (e.g. by selecting a different VPC), did not reset the dropdowns to the default "Select a subnet" option.

If there was only one subnet in the dropdown, this bug stopped you selecting that single subnet. Clicking / changing any other form element on the page reset the subnet dropdowns, fixing the problem.