### PR TITLE
platforms/aws: Pass tectonic_self_hosted_etcd variable to bootkube module

### DIFF
--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -88,7 +88,7 @@ variable "etcd_server_key_pem" {
 }
 
 variable "self_hosted_etcd" {
-  default     = ""
+  type        = "string"
   description = "See tectonic_self_hosted_etcd in config.tf"
 }
 

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -56,6 +56,7 @@ module "bootkube" {
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
+  self_hosted_etcd = "${var.tectonic_self_hosted_etcd}"
 
   service_cidr = "${var.tectonic_service_cidr}"
   cluster_cidr = "${var.tectonic_cluster_cidr}"


### PR DESCRIPTION
Pass the variable `tectonic_self_hosted_etcd` to the bootkube module, as this is currently omitted. BTW, why is there a default value for `tectonic_self_hosted_etcd` in bootkube? If there were no default, this omission would be detected.