### PR TITLE
*: Upgrade Tectonic Monitoring to 1.8

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -85,7 +85,7 @@ variable "tectonic_container_images" {
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.5.4"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.7.1"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.8.0"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.5"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:installer-latest"
   }
@@ -117,7 +117,7 @@ variable "tectonic_versions" {
   default = {
     etcd          = "3.1.8"
     kubernetes    = "1.7.9+tectonic.1"
-    monitoring    = "1.7.1"
+    monitoring    = "1.8.0"
     tectonic      = "1.8.2-tectonic.1"
     tectonic-etcd = "0.0.1"
     cluo          = "0.2.5"


### PR DESCRIPTION
This change most prominently ships Prometheus 2.0 as the Tectonic
Monitoring Prometheus instance.

@s-urbaniak @alexsomesan 

/cc @robszumski @rezaloo @pst @ant31 