### PR TITLE
operators: Install the tectonic-alm-operator under TVO management

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -96,6 +96,7 @@ variable "tectonic_container_images" {
     tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.8.0"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.5"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
+    tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:v0.2.0"
   }
 }
 
@@ -129,6 +130,7 @@ variable "tectonic_versions" {
     tectonic      = "1.8.2-tectonic.1"
     tectonic-etcd = "0.0.1"
     cluo          = "0.2.5"
+    alm           = "0.2.0"
   }
 }
 

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -24,6 +24,7 @@ resource "template_dir" "tectonic" {
     tectonic_prometheus_operator_image = "${var.container_images["tectonic_prometheus_operator"]}"
     tectonic_etcd_operator_image       = "${var.container_images["tectonic_etcd_operator"]}"
     tectonic_cluo_operator_image       = "${var.container_images["tectonic_cluo_operator"]}"
+    tectonic_alm_operator_image        = "${var.container_images["tectonic_alm_operator"]}"
 
     tectonic_monitoring_auth_base_image = "${var.container_base_images["tectonic_monitoring_auth"]}"
     config_reload_base_image            = "${var.container_base_images["config_reload"]}"
@@ -43,6 +44,7 @@ resource "template_dir" "tectonic" {
     etcd_version                   = "${var.versions["etcd"]}"
     tectonic_etcd_operator_version = "${var.versions["tectonic-etcd"]}"
     tectonic_cluo_operator_version = "${var.versions["cluo"]}"
+    tectonic_alm_operator_version  = "${var.versions["alm"]}"
 
     etcd_cluster_size = "${var.master_count > 2 ? 3 : 1}"
 

--- a/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-alm.yaml
+++ b/modules/tectonic/resources/manifests/updater/app_versions/app-version-tectonic-alm.yaml
@@ -1,0 +1,12 @@
+apiVersion: tco.coreos.com/v1
+kind: AppVersion
+metadata:
+  name: tectonic-alm-operator
+  namespace: tectonic-system
+  labels:
+    managed-by-channel-operator: "true"
+  annotations:
+    tectonic-operators.coreos.com/upgrade-behaviour: "CreateOrUpgrade"
+spec:
+  desiredVersion: ${tectonic_alm_operator_version}
+  paused: false

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: tectonic-alm-operator
+  namespace: tectonic-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: tectonic-alm-operator
+  template:
+    metadata:
+      labels:
+        app: tectonic-alm-operator
+    spec:
+      imagePullSecrets:
+        - name: coreos-pull-secret
+      containers:
+      - name: tectonic-alm-operator
+        image: ${tectonic_alm_operator_image}
+        command:
+        - /tectonic-x-operator
+        - --operator-name=tectonic-alm-operator
+        - --appversion-name=tectonic-alm-operator
+        - --v=2

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -204,12 +204,14 @@ kubectl create -f updater/operators/kube-version-operator.yaml
 kubectl create -f updater/operators/tectonic-channel-operator.yaml
 kubectl create -f updater/operators/tectonic-prometheus-operator.yaml
 kubectl create -f updater/operators/tectonic-cluo-operator.yaml
+kubectl create -f updater/operators/tectonic-alm-operator.yaml
 
 wait_for_crd tectonic-system appversions.tco.coreos.com
 kubectl create -f updater/app_versions/app-version-tectonic-cluster.yaml
 kubectl create -f updater/app_versions/app-version-kubernetes.yaml
 kubectl create -f updater/app_versions/app-version-tectonic-monitoring.yaml
 kubectl create -f updater/app_versions/app-version-tectonic-cluo.yaml
+kubectl create -f updater/app_versions/app-version-tectonic-alm.yaml
 
 if [ "$SELF_HOSTED_ETCD" = "true" ]; then
   echo "Creating self hosted etcd resources"

--- a/modules/update-payload/assets.tf
+++ b/modules/update-payload/assets.tf
@@ -9,6 +9,7 @@ resource "template_dir" "payload_operators" {
     tectonic_prometheus_operator_image = "${var.tectonic_container_images["tectonic_prometheus_operator"]}"
     tectonic_etcd_operator_image       = "${var.tectonic_container_images["tectonic_etcd_operator"]}"
     tectonic_cluo_operator_image       = "${var.tectonic_container_images["tectonic_cluo_operator"]}"
+    tectonic_alm_operator_image        = "${var.tectonic_container_images["tectonic_alm_operator"]}"
     image_re                           = "${var.tectonic_image_re}"
   }
 }
@@ -23,5 +24,6 @@ resource "template_dir" "payload_appversions" {
     tectonic_version               = "${var.tectonic_versions["tectonic"]}"
     tectonic_etcd_operator_version = "${var.tectonic_versions["tectonic-etcd"]}"
     tectonic_cluo_operator_version = "${var.tectonic_versions["cluo"]}"
+    tectonic_alm_operator_version  = "${var.tectonic_versions["alm"]}"
   }
 }


### PR DESCRIPTION
Add the `tectonic-alm-operator` (an x-operator specialization) to the installer.  Version v0.2.0 is what we are targeting when the beta is ready, and does not exist yet.