### PR TITLE
frontend: Remove commitToServer()'s unused "opts" parameter

### DIFF
--- a/installer/frontend/__tests__/protocols.js
+++ b/installer/frontend/__tests__/protocols.js
@@ -96,7 +96,7 @@ describe('progress file example', () => {
       }));
 
       // TODO: wait for this action to finish & then check expected state
-      commitToServer(false, false, {salt: '$2a$12$96LR7NxL/T7LaijR0fxl3.'})(dispatch, () => restored);
+      commitToServer(false, false)(dispatch, () => restored);
 
       expect(fetch.mock.calls.length).toBe(1);
       const body = JSON.parse(fetch.mock.calls[0][1].body);

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -75,7 +75,7 @@ const platformToFunc = {
 let observeInterval;
 
 // An action creator that builds a server message, calls fetch on that message, fires the appropriate actions
-export const commitToServer = (dryRun = false, retry = false, opts = {}) => (dispatch, getState) => {
+export const commitToServer = (dryRun = false, retry = false) => (dispatch, getState) => {
   setIn(DRY_RUN, dryRun, dispatch);
   setIn(RETRY, retry, dispatch);
 
@@ -90,7 +90,7 @@ export const commitToServer = (dryRun = false, retry = false, opts = {}) => (dis
     throw Error(`unknown platform type "${state.clusterConfig[PLATFORM_TYPE]}"`);
   }
 
-  const body = f(state, FORMS, opts);
+  const body = f(state, FORMS);
   fetch('/terraform/apply', {
     credentials: 'same-origin',
     method: 'POST',


### PR DESCRIPTION
This param is no longer used by `toAWS_TF()` or `toBaremetal_TF()`.