### PR TITLE
frontend: Remove <option> "selected" attribute

### DIFF
--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -189,7 +189,7 @@ const SubnetSelect = ({field, name, subnets, disabled, fieldName}) => <div class
   <div className="col-xs-6">
     <Connect field={field}>
       <Select disabled={disabled}>
-        <option disabled selected value="">Select a subnet</option>
+        <option disabled value="">Select a subnet</option>
         {_.filter(subnets, ({availabilityZone}) => availabilityZone === name)
           .map(({id, instanceCIDR}) => <option value={id} key={instanceCIDR}>{instanceCIDR} ({id})</option>)
         }


### PR DESCRIPTION
Oops, shouldn't use `selected` with React. Fixes a JS warning.