### PR TITLE
frontend: Remove ClusterInfo.canNavigateForward hack

### DIFF
--- a/installer/frontend/app.jsx
+++ b/installer/frontend/app.jsx
@@ -48,9 +48,6 @@ export const fixLocation = () => {
 store.subscribe(_.debounce(saveState, 5000));
 window.addEventListener('beforeunload', saveState);
 
-// Stuff we need to load before we can run anything
-loadFacts(dispatch);
-
 try {
   const state = JSON.parse(sessionStorage.getItem('state'));
   dispatch({
@@ -62,7 +59,28 @@ try {
   console.error(`Error restoring state from sessionStorage: ${e.message || e.toString()}`);
 }
 
-store.dispatch(validateAllFields(() => {
+history.listen(({pathname, state}) => {
+  // Process next step / previous step navigation trigger if present
+  if (state && (state.next || state.previous)) {
+    const t = trail(store.getState());
+    const currentPage = t.pageByPath.get(history.location.pathname);
+    const nextPage = state.next ? t.nextFrom(currentPage) : t.previousFrom(currentPage);
+    history.replace(_.get(nextPage, 'path'));
+    return;
+  }
+  TectonicGA.sendPageView(pathname);
+});
+
+ReactDom.render(
+  <Provider store={store}>
+    <Router history={history}>
+      <Base />
+    </Router>
+  </Provider>,
+  document.getElementById('application')
+);
+
+const init = () => {
   TectonicGA.initialize();
 
   try {
@@ -76,28 +94,11 @@ store.dispatch(validateAllFields(() => {
   } catch (e) {
     console.error(`Error restoring state from sessionStorage: ${e.message || e.toString()}`);
   }
+};
 
-  history.listen(({pathname, state}) => {
-    // Process next step / previous step navigation trigger if present
-    if (state && (state.next || state.previous)) {
-      const t = trail(store.getState());
-      const currentPage = t.pageByPath.get(history.location.pathname);
-      const nextPage = state.next ? t.nextFrom(currentPage) : t.previousFrom(currentPage);
-      history.replace(_.get(nextPage, 'path'));
-      return;
-    }
-    TectonicGA.sendPageView(pathname);
-  });
-
-  ReactDom.render(
-    <Provider store={store}>
-      <Router history={history}>
-        <Base />
-      </Router>
-    </Provider>,
-    document.getElementById('application')
-  );
-}));
+// Stuff we need to load before we can run anything
+loadFacts(dispatch)
+  .then(() => store.dispatch(validateAllFields(init)));
 
 window.onerror = (message, source, lineno, colno, optError = {}) => {
   try {

--- a/installer/frontend/components/cluster-info.jsx
+++ b/installer/frontend/components/cluster-info.jsx
@@ -50,7 +50,7 @@ const pullSecretField = new Field(PULL_SECRET, {
   },
 });
 
-new Form(LICENSING, [fields[CLUSTER_NAME], licenseField, pullSecretField]);
+const form = new Form(LICENSING, [fields[CLUSTER_NAME], licenseField, pullSecretField]);
 
 const FileInput = ({id, onValue}) => {
   const upload = e => {
@@ -137,6 +137,4 @@ export const ClusterInfo = () => <div>
   </div>
 </div>;
 
-ClusterInfo.canNavigateForward = ({clusterConfig: cc}) => !fields[CLUSTER_NAME].validator(cc[CLUSTER_NAME], cc) &&
-  !licenseField.validator(cc[TECTONIC_LICENSE]) &&
-  !pullSecretField.validator(cc[PULL_SECRET]);
+ClusterInfo.canNavigateForward = form.canNavigateForward;

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -132,5 +132,6 @@ export const loadFacts = (dispatch) => {
         type: loadFactsActionTypes.ERROR,
         payload: err,
       });
-    }).catch(err => console.error(err));
+    })
+    .catch(err => console.error(err));
 };


### PR DESCRIPTION
Delay initial field validation until `facts` API call has completed.

The `facts` response contains initial values for the Tectonic license and pull secret, so making this change allows us to remove the `ClusterInfo.canNavigateForward()` hack.