### PR TITLE
*/rm-assets: activate using path activation

### DIFF
--- a/Documentation/dev/node-bootstrap-flow.md
+++ b/Documentation/dev/node-bootstrap-flow.md
@@ -118,8 +118,14 @@ ExecStartPost=/bin/touch /opt/tectonic/init_tectonic.done
 Tectonic service unit is not enabled by default. It is instead triggered by a path unit, which waits for assets written synchronously by terraform.
 
 This service waits for bootkube process to be *completed* via systemd dependency.
-It is a oneshot service, thus marked as started only once the script return with success.
+It is a oneshot service, thus marked as started only once the script returns with success.
 It is skipped on further boots, as the condition-path exists.
+
+### `rm-assets.path` and `rm-assets.service`
+
+This service waits for the bootkube and tectonic process to be completed.
+It is a oneshot service, thus marked as started only once the script returns with success.
+This is an optional service only present on platforms which pull assets from block storage.
 
 ## Diagram
 
@@ -135,29 +141,31 @@ Legend:
  * b.s   -> bootkube.service
  * t.p   -> tectonic.path
  * t.s   -> tectonic.service
+ * rm.p  -> rm-assets.path
+ * rm.s  -> rm-assets.service
 
-.------------------------------------------------------------------------------------------------------------------.
-|                                                                                                                  |
-|           Provision cloud/userdata                  +----------+                Provision files                  |
-|     ,----------------------------------------------o|    TF    |o-----------------.------------------------.     |
-|     |                                               +----------+                  |                        |     |
-|     |                                                                             v                        v     |
-|     |                  +----------+                                            +-----+                 +-------+ |
-|     |             .--->| (reboot) |----.                                       | b.p |                 |  t.p  | |
-|     |             |    +----------+    |                                       +-----+                 +-------+ |
-|     V             |                    |                                          o                        o     |
-| +-------+         |                    v  Before   +------------+   Before        | Trigger        Trigger |     |
-| |  IGN  |         |                    *---------->|    k.s     |o--------.       |                        |     |
-| +-------+         o                    ^           +------------+         |       v                        v     |
-|     |       +----------+               |              ^      |            |    +-----+      Before     +-------+ |
-|     '------>|   knb.s  |o--------------'              |      v            '--->| b.s |o--------------->|  t.s  | |
-|   Enable    +----------+                              '------'                 +-----+                 +-------+ |
-|                ^    |                                                                                            |
-|                |    v                                                                                            |
-|                '----'                        o                            o                                      |
-|                                              |                            |                                      |
-|               * First boot                   |        * Each boot         |         * First boot                 |
-|               * All nodes                    |        * All nodes         |         * Bootkube master            |
-|                                              |                            |                                      |
-'----------------------------------------------o----------------------------o--------------------------------------'
+.---------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                                                                       |
+|           Provision cloud/userdata                  +----------+                Provision files                                       |
+|     ,----------------------------------------------o|    TF    |o-----------------.------------------------.-----------------+        |
+|     |                                               +----------+                  |                        |                 |        |
+|     |                                                                             v                        v                 v        |
+|     |                  +----------+                                            +-----+                 +-------+         +------+     |
+|     |             .--->| (reboot) |----.                                       | b.p |                 |  t.p  |         | rm.p |     |
+|     |             |    +----------+    |                                       +-----+                 +-------+         +------+     |
+|     V             |                    |                                          o                        o                 o        |
+| +-------+         |                    v  Before   +------------+   Before        | Trigger        Trigger |         Trigger |        |
+| |  IGN  |         |                    *---------->|    k.s     |o--------.       |                        |                 |        |
+| +-------+         o                    ^           +------------+         |       v                        v                 v        |
+|     |       +----------+               |              ^      |            |    +-----+      Before     +-------+   Before +-----+     |
+|     '------>|   knb.s  |o--------------'              |      v            '--->| b.s |o--------------->|  t.s  |--------> |rm.s |     |
+|   Enable    +----------+                              '------'                 +-----+                 +-------+          +-----+     |
+|                ^    |                                                                                                                 |
+|                |    v                                                                                                                 |
+|                '----'                        o                            o                                                           |
+|                                              |                            |                                                           |
+|               * First boot                   |        * Each boot         |         * First boot                                      |
+|               * All nodes                    |        * All nodes         |         * Bootkube master                                 |
+|                                              |                            |                                                           |
+'----------------------------------------------o----------------------------o-----------------------------------------------------------+
 ```

--- a/modules/aws/master-asg/ignition.tf
+++ b/modules/aws/master-asg/ignition.tf
@@ -19,6 +19,7 @@ data "ignition_config" "main" {
     var.ign_tectonic_service_id,
     var.ign_bootkube_path_unit_id,
     var.ign_tectonic_path_unit_id,
+    var.ign_rm_assets_path_unit_id,
    ))}"]
 }
 

--- a/modules/aws/master-asg/resources/rm-assets.sh
+++ b/modules/aws/master-asg/resources/rm-assets.sh
@@ -16,21 +16,6 @@ s3_clean() {
     '
 }
 
-# shellcheck disable=SC2086,SC2154
-/usr/bin/docker run \
-  --volume /run/metadata:/run/metadata \
-  --volume /opt/detect-master.sh:/detect-master.sh:ro \
-  --network=host \
-  --env CLUSTER_NAME=${cluster_name} \
-  --entrypoint=/detect-master.sh \
-  ${awscli_image}
-
-# Don't do anything if cluster is still in startup
-STARTUP=$(cat /run/metadata/master)
-if [ "$STARTUP" == "true" ]; then
-    exit 0
-fi
-
 until s3_clean; do
   echo "failed to clean up S3 assets. retrying in 5 seconds."
   sleep 5

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -129,3 +129,7 @@ variable "ign_init_assets_service_id" {
 variable "ign_rm_assets_service_id" {
   type = "string"
 }
+
+variable "ign_rm_assets_path_unit_id" {
+  type = "string"
+}

--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -74,9 +74,15 @@ data "ignition_systemd_unit" "init_assets" {
   content = "${file("${path.module}/resources/services/init-assets.service")}"
 }
 
+data "ignition_systemd_unit" "rm_assets_path_unit" {
+  name    = "rm-assets.path"
+  enable  = true
+  content = "${file("${path.module}/resources/paths/rm-assets.path")}"
+}
+
 data "ignition_systemd_unit" "rm_assets" {
   name    = "rm-assets.service"
-  enable  = "${var.assets_location != "" ? true : false}"
+  enable  = false
   content = "${file("${path.module}/resources/services/rm-assets.service")}"
 }
 

--- a/modules/ignition/outputs.tf
+++ b/modules/ignition/outputs.tf
@@ -38,6 +38,10 @@ output "rm_assets_service_id" {
   value = "${data.ignition_systemd_unit.rm_assets.id}"
 }
 
+output "rm_assets_path_unit_id" {
+  value = "${data.ignition_systemd_unit.rm_assets_path_unit.id}"
+}
+
 output "s3_puller_id" {
   value = "${data.ignition_file.s3_puller.id}"
 }

--- a/modules/ignition/resources/paths/rm-assets.path
+++ b/modules/ignition/resources/paths/rm-assets.path
@@ -1,0 +1,7 @@
+[Unit]
+Description=Trigger for rm-assets.service
+[Path]
+PathExists=/opt/tectonic/manifests
+Unit=rm-assets.service
+[Install]
+WantedBy=multi-user.target

--- a/modules/ignition/resources/services/rm-assets.service
+++ b/modules/ignition/resources/services/rm-assets.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Clean up install assets from S3
-ConditionPathExists=/opt/tectonic/init_tectonic.done
-After=tectonic.service
+ConditionPathExists=!/opt/tectonic/init_rm_assets.done
+After=bootkube.service tectonic.service
 
 [Service]
 Type=oneshot
@@ -13,6 +13,7 @@ Group=root
 
 ExecStartPre=/usr/bin/bash /opt/rm-assets.sh
 ExecStart=/usr/bin/echo "cleaned up installation assets"
+ExecStartPost=/bin/touch /opt/tectonic/init_rm_assets.done
 
 [Install]
 WantedBy=multi-user.target

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -104,7 +104,16 @@ wait_for_pods() {
 
 asset_cleanup() {
   echo "Cleaning up installation assets"
-  rm -rf "$${ASSETS_PATH:?}/"*
+
+  # shellcheck disable=SC2034
+  for d in "manifests" "auth" "bootstrap-manifests" "net-manifests" "tectonic" "tls"; do
+      rm -rf "$${ASSETS_PATH:?}/$${d:?}/"*
+  done
+
+  # shellcheck disable=SC2034
+  for f in "bootkube.sh" "tectonic.sh" "tectonic-wrapper.sh"; do
+      rm -f "$${ASSETS_PATH:?}/$${f:?}"
+  done
 }
 
 # chdir into the assets path directory

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -132,6 +132,7 @@ module "masters" {
   ign_kubelet_service_id            = "${module.ignition_masters.kubelet_service_id}"
   ign_locksmithd_service_id         = "${module.ignition_masters.locksmithd_service_id}"
   ign_max_user_watches_id           = "${module.ignition_masters.max_user_watches_id}"
+  ign_rm_assets_path_unit_id        = "${module.ignition_masters.rm_assets_path_unit_id}"
   ign_rm_assets_service_id          = "${module.ignition_masters.rm_assets_service_id}"
   ign_s3_puller_id                  = "${module.ignition_masters.s3_puller_id}"
   ign_tectonic_path_unit_id         = "${var.tectonic_vanilla_k8s ? "" : module.tectonic.systemd_path_unit_id}"


### PR DESCRIPTION
This is a follow-up for #2358.

It fxes a few concerns:
- we delete only known local assets in `tectonic.sh` omitting service unit `*.done` files.
- it path activates `rm-assets.service` omitting the necessity to do master election.

/cc @squat @kalmog 