### PR TITLE
modules/aws: detect-master assumes lb

### DIFF
--- a/modules/aws/master-asg/ignition.tf
+++ b/modules/aws/master-asg/ignition.tf
@@ -23,13 +23,21 @@ data "ignition_config" "main" {
    ))}"]
 }
 
+data "template_file" "detect_master" {
+  template = "${file("${path.module}/resources/detect-master.sh")}"
+
+  vars {
+    load_balancer_name = "${format("%s-%s", var.cluster_name, var.private_endpoints ? "int" : "ext")}"
+  }
+}
+
 data "ignition_file" "detect_master" {
   filesystem = "root"
   path       = "/opt/detect-master.sh"
   mode       = 0755
 
   content {
-    content = "${file("${path.module}/resources/detect-master.sh")}"
+    content = "${data.template_file.detect_master.rendered}"
   }
 }
 

--- a/modules/aws/master-asg/resources/detect-master.sh
+++ b/modules/aws/master-asg/resources/detect-master.sh
@@ -25,7 +25,8 @@ while true; do
   sleep 15
 done
 
-API_HEALTHY=$(aws elb describe-instance-health --region="$REGION" --load-balancer-name "$CLUSTER_NAME-int" | jq -r '[ .InstanceStates[] | select(.State | contains("InService")) ] | length > 1')
+# shellcheck disable=SC2154,SC2086
+API_HEALTHY=$(aws elb describe-instance-health --region="$REGION" --load-balancer-name ${load_balancer_name} | jq -r '[ .InstanceStates[] | select(.State | contains("InService")) ] | length > 1')
 
 if [ "$API_HEALTHY" == "true" ]; then
     echo "Healthy API instances found, cluster is already installed."

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -69,6 +69,11 @@ variable "master_sg_ids" {
   description = "The security group IDs to be applied to the master nodes."
 }
 
+variable "private_endpoints" {
+  description = "If set to true, private-facing ingress resources are created."
+  default     = true
+}
+
 variable "public_endpoints" {
   description = "If set to true, public-facing ingress resources are created."
   default     = true

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -102,7 +102,7 @@ variable "identity_api_service" {
 }
 
 variable "self_hosted_etcd" {
-  default     = ""
+  type        = "string"
   description = "See tectonic_self_hosted_etcd in config.tf"
 }
 

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -141,6 +141,7 @@ module "masters" {
   instance_count                    = "${var.tectonic_master_count}"
   master_iam_role                   = "${var.tectonic_aws_master_iam_role_name}"
   master_sg_ids                     = "${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
+  private_endpoints                 = "${var.tectonic_aws_private_endpoints}"
   public_endpoints                  = "${var.tectonic_aws_public_endpoints}"
   root_volume_iops                  = "${var.tectonic_aws_master_root_volume_iops}"
   root_volume_size                  = "${var.tectonic_aws_master_root_volume_size}"


### PR DESCRIPTION
This commit fixes issue #2419.

This issue occurs because we recently added -o pipefail to the
detect-master.sh script. This causes a previously undetected issue to
surface and break bootstrapping for clusters with no private-endpoints.

API_HEALTHY=$(aws elb describe-instance-health --region="$REGION"
--load-balancer-name "$CLUSTER_NAME-int" | jq -r '[ .InstanceStates[] |
select(.State | contains("InService")) ] | length > 1')
is hardcoded to use the internal loadbalancer. Without pipefail, this
aws command would 404 and the error would get swallowed by the pipe.
API_HEALTHY would never be true, even if the API was actually healthy,
so the rest of the script would run.

Now, since the pipefail option is set, that command correctly errors out
and the script execution is aborted.

We simply need to template the loadbalancer name based on whether
private endpoints are enabled or disabled.

cc @s-urbaniak 