### PR TITLE
tests: Move logs to build folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -345,7 +345,7 @@ pipeline {
                   throw error
                 } finally {
                   reportStatusToGithub((err == null) ? 'success' : 'failure', specFile, originalCommitId)
-                  archiveArtifacts allowEmptyArchive: true, artifacts: 'tests/rspec/logs/**/*.log'
+                  archiveArtifacts allowEmptyArchive: true, artifacts: 'build/**/logs/**'
                   cleanWs notFailBuild: true
                 }
               }
@@ -442,7 +442,7 @@ def runRSpecTest(testFilePath, dockerArgs) {
         throw error
       } finally {
         reportStatusToGithub((err == null) ? 'success' : 'failure', testFilePath, originalCommitId)
-        archiveArtifacts allowEmptyArchive: true, artifacts: 'tests/rspec/logs/**/*.log'
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'build/**/logs/**'
         withDockerContainer(params.builder_image) {
          withCredentials(creds) {
            sh """#!/bin/bash -xe

--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -59,7 +59,6 @@ class Cluster
       return
     end
     destroy
-    clean if Jenkins.environment?
   end
 
   def check_prerequisites
@@ -165,11 +164,6 @@ class Cluster
   end
 
   def recover_from_failed_destroy() end
-
-  def clean
-    succeeded = system(env_variables, 'make -C ../.. clean')
-    raise 'could not clean build directory' unless succeeded
-  end
 
   def wait_til_ready
     wait_for_bootstrapping

--- a/tests/rspec/lib/cluster_support.rb
+++ b/tests/rspec/lib/cluster_support.rb
@@ -43,14 +43,14 @@ def print_service_logs(ip, service, cluster_name)
     output += "\nEnd of journal of #{service} service on #{ip}"
     puts output
 
-    save_to_file(cluster_name, 'journal', ip, service, output)
+    save_to_file(cluster_name, 'systemd', ip, service, output)
   rescue => e
     puts "Cannot retrieve logs of service #{service} - failed to ssh exec on ip #{ip} with: #{e}"
   end
 end
 
 def save_to_file(cluster_name, service_type, ip, service, output_to_save)
-  logs_path = "logs/#{service_type}_logs_#{cluster_name}_#{ip}"
+  logs_path = "../../build/#{cluster_name}/logs/#{ip}/#{service_type}"
   FileUtils.mkdir_p(logs_path)
   save_to_file = File.open("#{logs_path}/#{service}.log", 'w+')
   save_to_file << output_to_save

--- a/tests/rspec/lib/metal_support.rb
+++ b/tests/rspec/lib/metal_support.rb
@@ -157,7 +157,7 @@ module MetalSupport
   end
 
   def self.save_to_file(service_name, output)
-    logs_path = "#{root_path}build/#{ENV['CLUSTER']}/logs/services"
+    logs_path = "#{root_path}build/#{ENV['CLUSTER']}/logs/systemd"
     save_file = File.open("#{logs_path}/#{service_name}.log", 'w+')
     save_file << output
     save_file.close

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -26,6 +26,10 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
     @cluster.start
   end
 
+  after(:all) do
+    @cluster.stop
+  end
+
   # See https://stackoverflow.com/a/45936219/4011134
   after(:each) do |example|
     @exceptions << example.exception
@@ -33,10 +37,6 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
 
   after(:all) do
     @cluster.forensic if @exceptions.any?
-  end
-
-  after(:all) do
-    @cluster.stop
   end
 
   it 'generates operator manifests' do


### PR DESCRIPTION
This patch adds the log files to the `build` folder instead of the
`tests` folder. By doing so, we limit the mutability of the repo to the
`build` folder.