### PR TITLE
test: using rkt in metal platform to run conformance tests

### DIFF
--- a/tests/rspec/lib/k8s_conformance_tests.rb
+++ b/tests/rspec/lib/k8s_conformance_tests.rb
@@ -6,15 +6,24 @@ require 'timeout'
 class K8sConformanceTest
   attr_reader :kubeconfig_path, :vpn_tunnel
 
-  def initialize(kubeconfig_path, vpn_tunnel)
+  def initialize(kubeconfig_path, vpn_tunnel, platform)
     @kubeconfig_path = kubeconfig_path
     @vpn_tunnel = vpn_tunnel
+    @platform = platform
   end
 
   def run
     ::Timeout.timeout(2 * 60 * 60) do # 2 hour
       image = ENV['KUBE_CONFORMANCE_IMAGE']
-      succeeded = system("docker run -v #{@kubeconfig_path}:/kubeconfig #{network_config} #{image}")
+      command = if @platform.include?('metal')
+                  "sudo rkt run --volume kubecfg,kind=host,readOnly=false,source=#{@kubeconfig_path} \
+                  --mount volume=kubecfg,target=/kubeconfig #{network_config} --dns=host \
+                  --insecure-options=image #{image}"
+                else
+                  "docker run -v #{@kubeconfig_path}:/kubeconfig #{network_config} #{image}"
+                end
+
+      succeeded = system(command)
       raise 'Running k8s conformance tests failed' unless succeeded
     end
   end

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -131,7 +131,7 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
   end
 
   it 'passes the k8s conformance tests', :conformance_tests do
-    conformance_test = K8sConformanceTest.new(@cluster.kubeconfig, vpn_tunnel)
+    conformance_test = K8sConformanceTest.new(@cluster.kubeconfig, vpn_tunnel, @cluster.env_variables['PLATFORM'])
     expect { conformance_test.run }.to_not raise_error
   end
 end


### PR DESCRIPTION
in our packet.net configuration, we don't provision the machine with `docker`, only with `rkt`. To run the conformance tests on this platform we need to do a small adjustment in our RSpec framework