### PR TITLE
tests: Addressing testing related cleanups from k8s 1.8 merge

### DIFF
--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -10,6 +10,7 @@ require 'name_generator'
 require 'password_generator'
 require 'webdriver_helpers'
 require 'k8s_conformance_tests'
+require 'with_retries'
 
 RSpec.shared_examples 'withRunningCluster' do |tf_vars_path, vpn_tunnel = false|
   before(:all) do
@@ -39,17 +40,12 @@ RSpec.shared_examples 'withRunningCluster' do |tf_vars_path, vpn_tunnel = false|
     @cluster.master_ip_addresses.each do |ip|
       cmd = "sudo sh -c 'cat /etc/kubernetes/inactive-manifests/kube-system-kube-apiserver-*.json'"
 
-      retries = 0
-      begin
-        stdout, _, fin = ssh_exec(ip, cmd, 20)
-        raise unless fin.zero?
-        expect { JSON.parse(stdout) }.to_not raise_error
-      rescue
-        retries += 1
-        expect(retries).to be < 20
-        puts "failed to exec '#{cmd}'; retrying in 3 seconds"
-        sleep 3
-        retry
+      Retriable.with_retries(limit: 20, sleep: 3) do
+        stdout, stderr, fin = ssh_exec(ip, cmd, 20)
+        unless fin.zero? && JSON.parse(stdout)
+          raise "could not retrieve manifest checkpoints via #{cmd} on ip #{ip}, "\
+                "last try failed with:\n#{stdout}\n#{stderr}\nstatus code: #{fin}"
+        end
       end
     end
   end
@@ -64,16 +60,12 @@ RSpec.shared_examples 'withRunningCluster' do |tf_vars_path, vpn_tunnel = false|
             .join(' && ')
       cmd = "sudo sh -c '#{cmd}'"
 
-      retries = 0
-      begin
-        _, _, fin = ssh_exec(ip, cmd, 20)
-        raise unless fin.zero?
-      rescue
-        retries += 1
-        expect(retries).to be < 20
-        puts "failed to exec '#{cmd}'; retrying in 3 seconds"
-        sleep 3
-        retry
+      Retriable.with_retries(limit: 20, sleep: 3) do
+        stdout, stderr, fin = ssh_exec(ip, cmd, 20)
+        unless fin.zero?
+          raise "could not retrieve secret checkpoints via #{cmd} on ip #{ip}, "\
+                "last try failed with:\n#{stdout}\n#{stderr}\nstatus code: #{fin}"
+        end
       end
     end
   end


### PR DESCRIPTION
- Retry via `with_retries` lib
- Surfacing `stderr`
- Raising exception on failure

https://github.com/coreos/tectonic-installer/pull/1938#pullrequestreview-73712368