### PR TITLE
Tests: Refactor var naming

### DIFF
--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -47,10 +47,10 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
       cmd = "sudo sh -c 'cat /etc/kubernetes/inactive-manifests/kube-system-kube-apiserver-*.json'"
 
       Retriable.with_retries(limit: 20, sleep: 3) do
-        stdout, stderr, fin = ssh_exec(ip, cmd, 20)
-        unless fin.zero? && JSON.parse(stdout)
+        stdout, stderr, exit_code = ssh_exec(ip, cmd, 20)
+        unless exit_code.zero? && JSON.parse(stdout)
           raise "could not retrieve manifest checkpoints via #{cmd} on ip #{ip}, "\
-                "last try failed with:\n#{stdout}\n#{stderr}\nstatus code: #{fin}"
+                "last try failed with:\n#{stdout}\n#{stderr}\nstatus code: #{exit_code}"
         end
       end
     end
@@ -67,10 +67,10 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
       cmd = "sudo sh -c '#{cmd}'"
 
       Retriable.with_retries(limit: 20, sleep: 3) do
-        stdout, stderr, fin = ssh_exec(ip, cmd, 20)
-        unless fin.zero?
+        stdout, stderr, exit_code = ssh_exec(ip, cmd, 20)
+        unless exit_code.zero?
           raise "could not retrieve secret checkpoints via #{cmd} on ip #{ip}, "\
-                "last try failed with:\n#{stdout}\n#{stderr}\nstatus code: #{fin}"
+                "last try failed with:\n#{stdout}\n#{stderr}\nstatus code: #{exit_code}"
         end
       end
     end


### PR DESCRIPTION
Replace `fin` with `exit_code` as discussed in [1].

[1]
https://github.com/coreos/tectonic-installer/pull/2436/files#r152238782