### PR TITLE
modules/bootkube: unify self-hosted etcd

### DIFF
--- a/modules/bootkube/self-hosted-etcd.tf
+++ b/modules/bootkube/self-hosted-etcd.tf
@@ -57,7 +57,7 @@ data "template_file" "migrate_etcd_cluster" {
 }
 
 resource "local_file" "migrate_etcd_cluster" {
-  count    = "${var.self_hosted_etcd == "enabled" ? 1 : 0}"
+  count    = "${var.self_hosted_etcd != "" ? 1 : 0}"
   content  = "${data.template_file.migrate_etcd_cluster.rendered}"
   filename = "./generated/etcd/migrate-etcd-cluster.json"
 }


### PR DESCRIPTION
most of the counts depend on `self_hosted_etcd != ""`, while one depends on `self_hosted_etcd == "enabled"`. We should normalize this.

cc @s-urbaniak 