### PR TITLE
modules/net: Disable Calico termination grace period

### DIFF
--- a/modules/net/calico/resources/manifests/kube-calico.yaml
+++ b/modules/net/calico/resources/manifests/kube-calico.yaml
@@ -172,7 +172,7 @@ spec:
               value: "${cluster_cidr}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "always"
+              value: "Always"
             - name: FELIX_IPINIPENABLED
               value: "true"
             - name: FELIX_IPINIPMTU
@@ -235,6 +235,7 @@ spec:
               name: host-cni-bin
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+      terminationGracePeriodSeconds: 0
       volumes:
         # Used by calico/node.
         - name: lib-modules

--- a/modules/net/canal/resources/manifests/kube-calico.yaml
+++ b/modules/net/canal/resources/manifests/kube-calico.yaml
@@ -171,7 +171,7 @@ spec:
               value: "${cluster_cidr}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "always"
+              value: "Always"
             # Set based on the k8s node name.
             - name: NODENAME
               valueFrom:
@@ -230,6 +230,7 @@ spec:
               name: host-cni-bin
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
+      terminationGracePeriodSeconds: 0
       volumes:
         # Used by calico/node.
         - name: lib-modules


### PR DESCRIPTION
1) Disable termination grace period to account for Kubernetes v1.8 changes to DaemonSet behavior ([projectcalico/calico#1293](https://github.com/projectcalico/calico/pull/1293))
2) Fix IPIP mode casing [projectcalico/calico#1233](https://github.com/projectcalico/calico/pull/1233)

This has already been patched in bootkube: https://github.com/kubernetes-incubator/bootkube/pull/772