### PR TITLE
tests: Build smoke test env image without cache

### DIFF
--- a/tests/jenkins-jobs/tectonic_smoke_test_docker_image_job.groovy
+++ b/tests/jenkins-jobs/tectonic_smoke_test_docker_image_job.groovy
@@ -34,7 +34,7 @@ job("builders/tectonic-smoke-env-docker-image") {
   steps {
     def cmd = """#!/bin/bash -ex
 export TECTONIC_SMOKE_IMAGE=quay.io/coreos/tectonic-smoke-test-env:\${TECTONIC_SMOKE_TAG}
-docker build -t \${TECTONIC_SMOKE_IMAGE} -f images/tectonic-smoke-test-env/Dockerfile .
+docker build -t \${TECTONIC_SMOKE_IMAGE} -f images/tectonic-smoke-test-env/Dockerfile --no-cache .
 
 if \${DRY_RUN};
 then


### PR DESCRIPTION
Extending the Jenkins job to build the smoke test env image without any
previously cached docker image layers.

As suggested by @erikkn, we should add this.