### PR TITLE
modules/update-payload: fix payload gen failure introduced by #2465

### DIFF
--- a/modules/update-payload/assets.tf
+++ b/modules/update-payload/assets.tf
@@ -19,11 +19,11 @@ resource "template_dir" "payload_appversions" {
   destination_dir = "./generated/app_versions"
 
   vars {
-    kubernetes_version             = "${var.tectonic_versions["kubernetes"]}"
-    monitoring_version             = "${var.tectonic_versions["monitoring"]}"
-    tectonic_version               = "${var.tectonic_versions["tectonic"]}"
-    tectonic_etcd_operator_version = "${var.tectonic_versions["tectonic-etcd"]}"
-    tectonic_cluo_operator_version = "${var.tectonic_versions["cluo"]}"
-    kubernetes_addon_version       = "${var.versions["kubernetes_addon"]}"
+    kubernetes_version                = "${var.tectonic_versions["kubernetes"]}"
+    monitoring_version                = "${var.tectonic_versions["monitoring"]}"
+    tectonic_version                  = "${var.tectonic_versions["tectonic"]}"
+    tectonic_etcd_operator_version    = "${var.tectonic_versions["tectonic-etcd"]}"
+    tectonic_cluo_operator_version    = "${var.tectonic_versions["cluo"]}"
+    kubernetes_addon_operator_version = "${var.tectonic_versions["kubernetes_addon"]}"
   }
 }


### PR DESCRIPTION
The [Latest nightly release build](https://jenkins-tectonic-installer.prod.coreos.systems/job/tectonic-release-automation/job/build-tectonic/job/master/34/) revealed that the payload generation broke after #2465:

```
* resource 'template_dir.payload_appversions' config: unknown variable referenced: 'versions'. define it with 'variable' blocks
```

```
* template_dir.payload_appversions: failed to render ../tectonic/resources/manifests/updater/app_versions/app-version-kubernetes-addon.yaml: 9:21: unknown variable accessed: kubernetes_addon_operator_version
```

The fixes it and re-enables building releases of master.