### PR TITLE
frontend: Fix bug where master's volume IOPS was also used for workers

### DIFF
--- a/installer/frontend/__tests__/examples/aws-vpc.json
+++ b/installer/frontend/__tests__/examples/aws-vpc.json
@@ -37,7 +37,7 @@
     "tectonic_aws_region": "us-west-1",
     "tectonic_aws_ssh_key": "some-ssh-key",
     "tectonic_aws_worker_ec2_type": "t2.medium",
-    "tectonic_aws_worker_root_volume_iops": 1000,
+    "tectonic_aws_worker_root_volume_iops": 1500,
     "tectonic_aws_worker_root_volume_size": 1000,
     "tectonic_aws_worker_root_volume_type": "io1",
     "tectonic_base_domain": "example.com",

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -177,7 +177,7 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
       tectonic_aws_master_root_volume_type: controllers[STORAGE_TYPE],
       tectonic_aws_worker_ec2_type: workers[INSTANCE_TYPE],
       tectonic_aws_worker_iam_role_name: workers[IAM_ROLE] === IAM_ROLE_CREATE_OPTION ? undefined : workers[IAM_ROLE],
-      tectonic_aws_worker_root_volume_iops: workers[STORAGE_TYPE] === 'io1' ? controllers[STORAGE_IOPS] : undefined,
+      tectonic_aws_worker_root_volume_iops: workers[STORAGE_TYPE] === 'io1' ? workers[STORAGE_IOPS] : undefined,
       tectonic_aws_worker_root_volume_size: workers[STORAGE_SIZE_IN_GIB],
       tectonic_aws_worker_root_volume_type: workers[STORAGE_TYPE],
       tectonic_aws_ssh_key: cc[AWS_SSH],


### PR DESCRIPTION
Unit test expected output was also incorrect.

This appears to have been the case since `tectonic_aws_worker_root_volume_iops ` was first added by https://github.com/coreos/tectonic-installer/commit/03fadb2e692f41913e3ea34f9a6ed3dd2a5ac19d.