### PR TITLE
Fix interpolation synatx for kube cert output id

### DIFF
--- a/modules/tls/kube/self-signed/outputs.tf
+++ b/modules/tls/kube/self-signed/outputs.tf
@@ -27,14 +27,5 @@ output "apiserver_key_pem" {
 }
 
 output "id" {
-  value = "${sha1("
-  ${join(" ",
-    local_file.apiserver_key.id,
-    local_file.apiserver_crt.id,
-    local_file.kube_ca_key.id,
-    local_file.kube_ca_crt.id,
-    local_file.kubelet_key.id,
-    local_file.kubelet_crt.id,
-    )}
-  ")}"
+  value = "${sha1(join(" ", var.all_ca_list))}"
 }

--- a/modules/tls/kube/self-signed/variables.tf
+++ b/modules/tls/kube/self-signed/variables.tf
@@ -29,3 +29,15 @@ EOF
 
   type = "string"
 }
+
+variable "all_ca_list" {
+  type = "list"
+  default = [
+    "local_file.apiserver_key.id",
+    "local_file.apiserver_crt.id",
+    "local_file.kube_ca_key.id",
+    "local_file.kube_ca_crt.id",
+    "local_file.kubelet_key.id",
+    "local_file.kubelet_crt.id",
+  ]
+}

--- a/modules/tls/kube/user-provided/outputs.tf
+++ b/modules/tls/kube/user-provided/outputs.tf
@@ -19,13 +19,6 @@ output "apiserver_key_pem" {
 }
 
 output "id" {
-  value = "${sha1("
-  ${join(" ",
-    local_file.apiserver_key.id,
-    local_file.apiserver_crt.id,
-    local_file.kube_ca_crt.id,
-    local_file.kubelet_key.id,
-    local_file.kubelet_crt.id,
-    )}
-  ")}"
+  value = "${sha1(join(" ", var.all_ca_list))}"
 }
+

--- a/modules/tls/kube/user-provided/variables.tf
+++ b/modules/tls/kube/user-provided/variables.tf
@@ -17,3 +17,15 @@ variable "apiserver_cert_pem_path" {
 variable "apiserver_key_pem_path" {
   type = "string"
 }
+
+variable "all_ca_list" {
+  type = "list"
+  default = [
+    "local_file.apiserver_key.id",
+    "local_file.apiserver_crt.id",
+    "local_file.kube_ca_key.id",
+    "local_file.kube_ca_crt.id",
+    "local_file.kubelet_key.id",
+    "local_file.kubelet_crt.id",
+  ]
+}


### PR DESCRIPTION
Get error when try to use autogenerated cert's
```
Error: Error refreshing state: 1 error(s) occurred:

* module.kubernetes.module.kube_certs.output.id: At column 5, line 2: join: argument 1 should be type list, got type string in:

${sha1("
  ${join(" ",
    local_file.apiserver_key.id,
    local_file.apiserver_crt.id,
    local_file.kube_ca_key.id,
    local_file.kube_ca_crt.id,
    local_file.kubelet_key.id,
    local_file.kubelet_crt.id,
    )}
  ")}
```