### PR TITLE
modules,platforms: variables cannot be "version"

### DIFF
--- a/modules/container_linux/main.tf
+++ b/modules/container_linux/main.tf
@@ -1,3 +1,3 @@
 data "external" "version" {
-  program = ["sh", "-c", "curl https://${var.channel}.release.core-os.net/amd64-usr/current/version.txt | sed -n 's/COREOS_VERSION=\\(.*\\)$/{\"version\": \"\\1\"}/p'"]
+  program = ["sh", "-c", "curl https://${var.release_channel}.release.core-os.net/amd64-usr/current/version.txt | sed -n 's/COREOS_VERSION=\\(.*\\)$/{\"version\": \"\\1\"}/p'"]
 }

--- a/modules/container_linux/outputs.tf
+++ b/modules/container_linux/outputs.tf
@@ -1,3 +1,3 @@
 output "version" {
-  value = "${var.version == "latest" ? data.external.version.result["version"] : var.version}"
+  value = "${var.release_version == "latest" ? data.external.version.result["version"] : var.release_version}"
 }

--- a/modules/container_linux/variables.tf
+++ b/modules/container_linux/variables.tf
@@ -1,4 +1,4 @@
-variable "channel" {
+variable "release_channel" {
   type = "string"
 
   description = <<EOF
@@ -8,7 +8,7 @@ Examples: `stable`, `beta`, `alpha`
 EOF
 }
 
-variable "version" {
+variable "release_version" {
   type = "string"
 
   description = <<EOF

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -9,8 +9,8 @@ data "aws_availability_zones" "azs" {}
 module "container_linux" {
   source = "../../modules/container_linux"
 
-  channel = "${var.tectonic_container_linux_channel}"
-  version = "${var.tectonic_container_linux_version}"
+  release_channel = "${var.tectonic_container_linux_channel}"
+  release_version = "${var.tectonic_container_linux_version}"
 }
 
 module "vpc" {

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -9,8 +9,8 @@ data "azurerm_client_config" "current" {}
 module "container_linux" {
   source = "../../modules/container_linux"
 
-  channel = "${var.tectonic_container_linux_channel}"
-  version = "${var.tectonic_container_linux_version}"
+  release_channel = "${var.tectonic_container_linux_channel}"
+  release_version = "${var.tectonic_container_linux_version}"
 }
 
 module "resource_group" {

--- a/platforms/gcp/main.tf
+++ b/platforms/gcp/main.tf
@@ -22,8 +22,8 @@ provider "google" {
 module "container_linux" {
   source = "../../modules/container_linux"
 
-  channel = "${var.tectonic_container_linux_channel}"
-  version = "${var.tectonic_container_linux_version}"
+  release_channel = "${var.tectonic_container_linux_channel}"
+  release_version = "${var.tectonic_container_linux_version}"
 }
 
 module "network" {

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -1,8 +1,8 @@
 module "container_linux" {
   source = "../../modules/container_linux"
 
-  channel = "${var.tectonic_container_linux_channel}"
-  version = "${var.tectonic_container_linux_version}"
+  release_channel = "${var.tectonic_container_linux_channel}"
+  release_version = "${var.tectonic_container_linux_version}"
 }
 
 // Install CoreOS to disk


### PR DESCRIPTION
Cherry-picks https://github.com/coreos/tectonic-installer/pull/2471
Fixes: TECREL-134
cc @s-urbaniak @enxebre 

> Terraform minor version 0.11.0 contains improved module support,
> with real support for pinning module versions using the `version`
> directive, e.g.:
> 
> ```hcl
> module "foo" {
>   source = "bar"
>   version = "baz"
> }
> ```
> 
> Unfortunately, this directive clashes with a variable in the
> `container_linux` module by the same name; Terraform is unable to
> handle variables and directives with the same name in a given module
> block, so the `version` _variable_ is never passed to the module.
> 