### PR TITLE
tests: Enable teams to run component tests via provided containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,11 @@ pipeline {
       description: ''
     )
     booleanParam(
+      name: 'RUN_COMPONENT_TESTS',
+      defaultValue: true,
+      description: ''
+    )
+    booleanParam(
       name: 'RUN_GUI_TESTS',
       defaultValue: true,
       description: ''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,7 @@ pipeline {
     stage("Smoke Tests") {
       when {
         expression {
-          return params.RUN_SMOKE_TESTS || params.RUN_CONFORMANCE_TESTS
+          return params.RUN_SMOKE_TESTS || params.RUN_CONFORMANCE_TESTS || params.RUN_COMPONENT_TESTS
         }
       }
       environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -404,7 +404,7 @@ def runRSpecTest(testFilePath, dockerArgs) {
         timeout(time: 5, unit: 'HOURS') {
           forcefullyCleanWorkspace()
           ansiColor('xterm') {
-            withCredentials(creds) {
+            withCredentials(creds + quayCreds) {
               withDockerContainer(
                 image: tectonicSmokeTestEnvImage,
                 args: '-u root -v /var/run/docker.sock:/var/run/docker.sock ' + dockerArgs
@@ -414,8 +414,12 @@ def runRSpecTest(testFilePath, dockerArgs) {
                 sh """#!/bin/bash -ex
                   mkdir -p templogfiles && chmod 777 templogfiles
                   cd tests/rspec
+                  docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
+
                   # Directing test output both to stdout as well as a log file
                   rspec ${testFilePath} --format RspecTap::Formatter --format RspecTap::Formatter --out ../../templogfiles/format=tap.log
+
+                  docker logout quay.io
                 """
               }
             }
@@ -451,9 +455,10 @@ def runRSpecTestBareMetal(testFilePath) {
           ansiColor('xterm') {
             unstash 'clean-repo'
             unstash 'smoke-test-binary'
-            withCredentials(creds) {
+            withCredentials(creds + quayCreds) {
               sh """#!/bin/bash -ex
               cd tests/rspec
+              docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
               export RBENV_ROOT=/usr/local/rbenv
               export PATH="/usr/local/rbenv/bin:$PATH"
               eval \"\$(rbenv init -)\"
@@ -461,6 +466,7 @@ def runRSpecTestBareMetal(testFilePath) {
               gem install bundler
               bundler install
               bundler exec rspec ${testFilePath} --format RspecTap::Formatter
+              docker logout quay.io
               """
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,14 +80,14 @@ pipeline {
       description: ''
     )
     booleanParam(
-      name: 'RUN_COMPONENT_TESTS',
-      defaultValue: true,
-      description: ''
-    )
-    booleanParam(
       name: 'RUN_GUI_TESTS',
       defaultValue: true,
       description: ''
+    )
+    string(
+      name: 'COMPONENT_TEST_IMAGES',
+      defaultValue: '',
+      description: 'List of container images for component tests to run (comma-separated)'
     )
     booleanParam(
       name: 'PLATFORM/AWS',
@@ -262,7 +262,7 @@ pipeline {
     stage("Smoke Tests") {
       when {
         expression {
-          return params.RUN_SMOKE_TESTS || params.RUN_CONFORMANCE_TESTS || params.RUN_COMPONENT_TESTS
+          return params.RUN_SMOKE_TESTS || params.RUN_CONFORMANCE_TESTS || params.COMPONENT_TEST_IMAGES != ''
         }
       }
       environment {

--- a/Makefile
+++ b/Makefile
@@ -197,9 +197,9 @@ tests/smoke: bin/smoke smoke-test-env-docker-image
 	-e TF_VAR_tectonic_admin_password \
 	-e TECTONIC_TESTS_DONT_CLEAN_UP \
 	-e RUN_SMOKE_TESTS \
-	-e RUN_COMPONENT_TESTS \
 	-e RUN_CONFORMANCE_TESTS \
 	-e KUBE_CONFORMANCE_IMAGE \
+	-e COMPONENT_TEST_IMAGES \
 	--cap-add NET_ADMIN \
 	--device /dev/net/tun \
 	quay.io/coreos/tectonic-smoke-test-env \

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ tests/smoke: bin/smoke smoke-test-env-docker-image
 	-e TF_VAR_tectonic_admin_password \
 	-e TECTONIC_TESTS_DONT_CLEAN_UP \
 	-e RUN_SMOKE_TESTS \
+	-e RUN_COMPONENT_TESTS \
 	-e RUN_CONFORMANCE_TESTS \
 	-e KUBE_CONFORMANCE_IMAGE \
 	--cap-add NET_ADMIN \

--- a/tests/README.md
+++ b/tests/README.md
@@ -124,8 +124,8 @@ TF_VAR_tectonic_admin_password
 TECTONIC_TESTS_DONT_CLEAN_UP // If you want to keep the cluster alive after the tests
 RUN_SMOKE_TESTS=true
 RUN_CONFORMANCE_TESTS=true
-RUN_COMPONENT_TESTS=true
 KUBE_CONFORMANCE_IMAGE=quay.io/coreos/kube-conformance:v1.7.5_coreos.0_golang1.9.1
+COMPONENT_TEST_IMAGES=quay.io/coreos/tectonic-console-tester:v2.7.1,
 ```
 
 And depending on your platform:

--- a/tests/README.md
+++ b/tests/README.md
@@ -124,6 +124,7 @@ TF_VAR_tectonic_admin_password
 TECTONIC_TESTS_DONT_CLEAN_UP // If you want to keep the cluster alive after the tests
 RUN_SMOKE_TESTS=true
 RUN_CONFORMANCE_TESTS=true
+RUN_COMPONENT_TESTS=true
 KUBE_CONFORMANCE_IMAGE=quay.io/coreos/kube-conformance:v1.7.5_coreos.0_golang1.9.1
 ```
 

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -169,10 +169,10 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
   end
 
   COMPONENT_TESTS.map do |test|
-    it "passes #{test.name} component tests", :component_tests do
+    it "passes #{test['name']} component tests", :component_tests do
       test_container = TestContainer.new(
-        test.image,
-        @cluster.kubeconfig,
+        test['image'],
+        @cluster,
         vpn_tunnel,
         @cluster.env_variables['PLATFORM']
       )

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -161,9 +161,8 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
   it 'passes the k8s conformance tests', :conformance_tests do
     conformance_test = TestContainer.new(
       ENV['KUBE_CONFORMANCE_IMAGE'],
-      @cluster.kubeconfig,
-      vpn_tunnel,
-      @cluster.env_variables['PLATFORM']
+      @cluster,
+      vpn_tunnel
     )
     expect { conformance_test.run }.to_not raise_error
   end
@@ -173,8 +172,7 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
       test_container = TestContainer.new(
         test['image'],
         @cluster,
-        vpn_tunnel,
-        @cluster.env_variables['PLATFORM']
+        vpn_tunnel
       )
       expect { test_container.run }.to_not raise_error
     end

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -13,10 +13,6 @@ require 'webdriver_helpers'
 require 'test_container'
 require 'with_retries'
 
-COMPONENT_TESTS = [
-  { 'name' => 'console', 'image' => 'quay.io/coreos/tectonic-console-tester:v2.7.1' }
-].freeze
-
 RSpec.shared_examples 'withRunningCluster' do |tf_vars_path, vpn_tunnel = false|
   include_examples('withBuildFolderSetup', tf_vars_path)
   include_examples('withRunningClusterExistingBuildFolder', vpn_tunnel)
@@ -167,10 +163,10 @@ RSpec.shared_examples 'withRunningClusterExistingBuildFolder' do |vpn_tunnel = f
     expect { conformance_test.run }.to_not raise_error
   end
 
-  COMPONENT_TESTS.map do |test|
-    it "passes #{test['name']} component tests", :component_tests do
+  (ENV['COMPONENT_TEST_IMAGES'] || '').split(',').each do |image|
+    it "passes component test '#{image}'", :component_tests do
       test_container = TestContainer.new(
-        test['image'],
+        image.chomp,
         @cluster,
         vpn_tunnel
       )

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -14,7 +14,7 @@ require 'test_container'
 require 'with_retries'
 
 COMPONENT_TESTS = [
-  { 'name' => 'console', 'image' => 'quay.io/coreos/tectonic-console-tester:v2.6.2' }
+  { 'name' => 'console', 'image' => 'quay.io/coreos/tectonic-console-tester:v2.7.1' }
 ].freeze
 
 RSpec.shared_examples 'withRunningCluster' do |tf_vars_path, vpn_tunnel = false|

--- a/tests/rspec/lib/shared_examples/k8s.rb
+++ b/tests/rspec/lib/shared_examples/k8s.rb
@@ -14,7 +14,7 @@ require 'test_container'
 require 'with_retries'
 
 COMPONENT_TESTS = [
-  { 'name' => 'console', 'image' => 'quay.io/repository/coreos/tectonic-console-tester:v11' }
+  { 'name' => 'console', 'image' => 'quay.io/coreos/tectonic-console-tester:v2.6.2' }
 ].freeze
 
 RSpec.shared_examples 'withRunningCluster' do |tf_vars_path, vpn_tunnel = false|

--- a/tests/rspec/lib/test_container.rb
+++ b/tests/rspec/lib/test_container.rb
@@ -22,7 +22,7 @@ class TestContainer
                 end
 
       succeeded = system(command)
-      raise 'Running k8s conformance tests failed' unless succeeded
+      raise 'Running container tests failed' unless succeeded
     end
   end
 

--- a/tests/rspec/lib/test_container.rb
+++ b/tests/rspec/lib/test_container.rb
@@ -3,24 +3,22 @@
 require 'timeout'
 
 # K8sConformanceTest represents the Kubernetes upstream conformance tests
-class K8sConformanceTest
-  attr_reader :kubeconfig_path, :vpn_tunnel
-
-  def initialize(kubeconfig_path, vpn_tunnel, platform)
+class TestContainer
+  def initialize(image, kubeconfig_path, vpn_tunnel, platform)
+    @image = image
     @kubeconfig_path = kubeconfig_path
     @vpn_tunnel = vpn_tunnel
     @platform = platform
   end
 
   def run
-    ::Timeout.timeout(3 * 60 * 60) do # 2 hour
-      image = ENV['KUBE_CONFORMANCE_IMAGE']
+    ::Timeout.timeout(3 * 60 * 60) do # 3 hour
       command = if @platform.include?('metal')
                   "sudo rkt run --volume kubecfg,kind=host,readOnly=false,source=#{@kubeconfig_path} \
                   --mount volume=kubecfg,target=/kubeconfig #{network_config} --dns=host \
-                  --insecure-options=image #{image}"
+                  --insecure-options=image #{@image}"
                 else
-                  "docker run -v #{@kubeconfig_path}:/kubeconfig #{network_config} #{image}"
+                  "docker run -v #{@kubeconfig_path}:/kubeconfig #{network_config} #{@image}"
                 end
 
       succeeded = system(command)

--- a/tests/rspec/lib/test_container.rb
+++ b/tests/rspec/lib/test_container.rb
@@ -42,6 +42,8 @@ class TestContainer
   # build the environment parameters here.
   def container_env(engine)
     env = {
+      'KUBECONFIG' => '/kubeconfig',
+
       'BRIDGE_AUTH_USERNAME' => @cluster.tectonic_admin_email,
       'BRIDGE_AUTH_PASSWORD' => @cluster.tectonic_admin_password,
       'BRIDGE_BASE_ADDRESS' => 'https://' + @cluster.tectonic_console_url,

--- a/tests/rspec/spec/spec_helper.rb
+++ b/tests/rspec/spec/spec_helper.rb
@@ -32,10 +32,6 @@ RSpec.configure do |config|
     config.filter_run_excluding smoke_tests: true
   end
 
-  unless ENV['RUN_COMPONENT_TESTS'] == 'true'
-    config.filter_run_excluding component_tests: true
-  end
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/tests/rspec/spec/spec_helper.rb
+++ b/tests/rspec/spec/spec_helper.rb
@@ -31,6 +31,11 @@ RSpec.configure do |config|
   unless ENV['RUN_SMOKE_TESTS'] == 'true'
     config.filter_run_excluding smoke_tests: true
   end
+
+  unless ENV['RUN_COMPONENT_TESTS'] == 'true'
+    config.filter_run_excluding component_tests: true
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
- Generalize conformance test container runner to run arbitrary images
- Add `RUN_COMPONENT_TESTS` Jenkins pipeline parameter and make RSpec
aware of option
- Add array to specify component test images
- Iterate over component test image array and generate rspec examples
(`it`)

Missing:
- Authentication to download component images from Quay

//CC @sudhaponnaganti @cpanato @Quentin-M (Please mind *work in progress* status, feel free to comment)