### PR TITLE
modules/tls/kube/self-signed: Make list explicit

### DIFF
--- a/modules/tls/kube/self-signed/outputs.tf
+++ b/modules/tls/kube/self-signed/outputs.tf
@@ -29,12 +29,12 @@ output "apiserver_key_pem" {
 output "id" {
   value = "${sha1("
   ${join(" ",
-    local_file.apiserver_key.id,
+    list(local_file.apiserver_key.id,
     local_file.apiserver_crt.id,
     local_file.kube_ca_key.id,
     local_file.kube_ca_crt.id,
     local_file.kubelet_key.id,
-    local_file.kubelet_crt.id,
+    local_file.kubelet_crt.id,)
     )}
   ")}"
 }


### PR DESCRIPTION
The collection of ids being joined was not explicitly
defined as a list, which is an error in Terraform 0.11.0.