### PR TITLE
Bump console to v2.5.3.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -71,7 +71,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.8.1"
     calico                       = "quay.io/calico/node:v2.6.3"
     calico_cni                   = "quay.io/calico/cni:v1.11.1"
-    console                      = "quay.io/coreos/tectonic-console:v2.4.0"
+    console                      = "quay.io/coreos/tectonic-console:v2.5.3"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
Changes include:

- Adds lots of ALM stuff (and shows ALM by default now)
- Bug fixes.
- Namespaces are shown in list views.
- Support for k8s 1.8 objects such as CronJobs.
- Better graphs.
- "n crash looping pods" on front page now links to the Pods list, filtered to only show crashlooping pods.
- "n alerts firing" now links to alertmanager UI
- If multi cluster CRD is installed, cluster picker & cluster manager are shown.

See https://github.com/coreos-inc/bridge/compare/v2.5.3...v2.3.4 for the full list of commits.

This should go in the 1.8 release candidate.