### PR TITLE
modules/tls/kube/self-signed: Make list explicit

### DIFF
--- a/modules/tls/kube/self-signed/outputs.tf
+++ b/modules/tls/kube/self-signed/outputs.tf
@@ -29,12 +29,12 @@ output "apiserver_key_pem" {
 output "id" {
   value = "${sha1("
   ${join(" ",
-    local_file.apiserver_key.id,
+    list(local_file.apiserver_key.id,
     local_file.apiserver_crt.id,
     local_file.kube_ca_key.id,
     local_file.kube_ca_crt.id,
     local_file.kubelet_key.id,
-    local_file.kubelet_crt.id,
+    local_file.kubelet_crt.id,)
     )}
   ")}"
 }

--- a/modules/tls/kube/user-provided/outputs.tf
+++ b/modules/tls/kube/user-provided/outputs.tf
@@ -21,11 +21,11 @@ output "apiserver_key_pem" {
 output "id" {
   value = "${sha1("
   ${join(" ",
-    local_file.apiserver_key.id,
+    list(local_file.apiserver_key.id,
     local_file.apiserver_crt.id,
     local_file.kube_ca_crt.id,
     local_file.kubelet_key.id,
-    local_file.kubelet_crt.id,
+    local_file.kubelet_crt.id,)
     )}
   ")}"
 }


### PR DESCRIPTION
This PR cherry-picks #2494 and #2504 in order to fix several issues that are being filed against the installer regarding issues with Terraform 0.11.x.

cc @s-urbaniak @enxebre 

> The collection of ids being joined was not explicitly
> defined as a list, which is an error in Terraform 0.11.0.