### PR TITLE
Bump console

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -63,7 +63,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.8.1"
     calico                       = "quay.io/calico/node:v2.6.1"
     calico_cni                   = "quay.io/calico/cni:v1.11.0"
-    console                      = "quay.io/coreos/tectonic-console:v2.4.0"
+    console                      = "quay.io/coreos/tectonic-console:v2.5.3"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"

--- a/tests/rspec/lib/pages/login_page.rb
+++ b/tests/rspec/lib/pages/login_page.rb
@@ -11,13 +11,13 @@ class Login < BasePage
 
   USERNAME_INPUT          = { id: 'login' }.freeze
   PASSWORD_INPUT          = { id: 'password' }.freeze
-  SUBMIT_INPUT            = { css: 'body > div.dex-container > div > form > button' }.freeze
-  CLUSTER_STATUS_LABEL    = {
-    css: '#content > div > div.co-p-cluster__body > div.row.co-m-nav-title > div > h1 > div > span'
+  SUBMIT_INPUT            = { id: 'submit-login' }.freeze
+  CLUSTER_STATUS_LABEL    = { id: 'resource-title' }.freeze
+  LOGIN_FAIL              = { id: 'login-error' }.freeze
+  ADMIN_SIDE_BAR          = { css: '#sidebar > div.navigation-container > div:nth-child(6) > div' }.freeze
+  LOGOUT                  = {
+    css: '#sidebar > div.navigation-container > div:nth-child(6) > ul > li:nth-child(2) > a'
   }.freeze
-  LOGIN_FAIL              = { css: 'body > div.dex-container > div > form > div.dex-error-box' }.freeze
-  ADMIN_SIDE_BAR          = { css: '#sidebar > div > div:nth-child(7) > div' }.freeze
-  LOGOUT                  = { css: '#sidebar > div > div:nth-child(7) > ul > li:nth-child(2) > a' }.freeze
 
   def initialize(driver)
     super


### PR DESCRIPTION
As requested in https://github.com/coreos/tectonic-installer/pull/2498, this bumps the console image to v2.5.3. In addition it includes the follow up test fix.