### PR TITLE
modules/tls: make certs a list

### DIFF
--- a/modules/tls/kube/user-provided/outputs.tf
+++ b/modules/tls/kube/user-provided/outputs.tf
@@ -21,11 +21,11 @@ output "apiserver_key_pem" {
 output "id" {
   value = "${sha1("
   ${join(" ",
-    local_file.apiserver_key.id,
+    list(local_file.apiserver_key.id,
     local_file.apiserver_crt.id,
     local_file.kube_ca_crt.id,
     local_file.kubelet_key.id,
-    local_file.kubelet_crt.id,
+    local_file.kubelet_crt.id,)
     )}
   ")}"
 }


### PR DESCRIPTION
This commit is a follow up of the changes made in #2494 and converts the
user-provided certs to an explicit Terraform list for compatibility with
Terraform 0.11.x.

Related:
https://github.com/coreos/terraform-aws-kubernetes/issues/13
https://github.com/coreos/tectonic-installer/pull/2494
https://github.com/coreos/tectonic-installer/pull/2502