### PR TITLE
tests: Run conformance tests on all platforms nightly

### DIFF
--- a/tests/jenkins-jobs/tectonic_installer_nightly_trigger_with_k8s_conformance.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_nightly_trigger_with_k8s_conformance.groovy
@@ -32,18 +32,6 @@ job("triggers/tectonic-installer-nightly-trigger_with_k8s_conformance") {
                   name('RUN_CONFORMANCE_TESTS')
                   value(true)
                 }
-                booleanParameterConfig {
-                  name('PLATFORM/AWS')
-                  value(false)
-                }
-                booleanParameterConfig {
-                  name('PLATFORM/AZURE')
-                  value(false)
-                }
-                booleanParameterConfig {
-                  name('PLATFORM/GCP')
-                  value(false)
-                }
               }
             }
           }


### PR DESCRIPTION
So far conformance tests were only run on bare-metal nightly. This PR
includes all remaining platforms (AWS, Azure, GCP) as well.