### PR TITLE
frontend: Major Form / Field clean up

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -117,8 +117,7 @@ export const __deleteEverything__ = () => {
   [FIELDS, FIELD_TO_DEPS, FORMS, DEFAULT_CLUSTER_CONFIG]
     .forEach(o => _.keys(o).forEach(k => delete o[k]));
 
-  ['error', 'error_async', 'ignore', 'inFly', 'extra']
-    .forEach(k => DEFAULT_CLUSTER_CONFIG[k] = {});
+  ['error', 'ignore', 'inFly', 'extra'].forEach(k => DEFAULT_CLUSTER_CONFIG[k] = {});
 
   return {type: configActionTypes.RESET};
 };

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -131,7 +131,6 @@ export const getTectonicDomain = (cc) => {
 
 export const DEFAULT_CLUSTER_CONFIG = {
   error: {}, // to store validation errors
-  ignore: {}, // to store validation errors
   inFly: {}, // to store inFly
   extra: {}, // extraneous, non-value data for this field
   [BM_MATCHBOX_HTTP]: '',

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -131,7 +131,6 @@ export const getTectonicDomain = (cc) => {
 
 export const DEFAULT_CLUSTER_CONFIG = {
   error: {}, // to store validation errors
-  error_async: {}, // to store async validation errors
   ignore: {}, // to store validation errors
   inFly: {}, // to store inFly
   extra: {}, // extraneous, non-value data for this field

--- a/installer/frontend/components/aws-define-nodes.jsx
+++ b/installer/frontend/components/aws-define-nodes.jsx
@@ -15,7 +15,7 @@ import {
 } from '../cluster-config';
 
 import { Form } from '../form';
-import { toError, toAsyncError } from '../utils';
+import { toError } from '../utils';
 import { validate } from '../validate';
 import { AWS_INSTANCE_TYPES } from '../facts';
 import { NumberInput, Connect, Select } from './ui';
@@ -56,9 +56,7 @@ const IamRoles = connect(
 );
 
 const Errors = connect(
-  ({clusterConfig}, {type}) => ({
-    error: _.get(clusterConfig, toError(type)) || _.get(clusterConfig, toAsyncError(type)),
-  })
+  ({clusterConfig}, {type}) => ({error: _.get(clusterConfig, toError(type))})
 )(props => props.error ? <div className="wiz-error-message">{props.error}</div> : <span />);
 
 export const DefineNode = ({type, max, withIamRole = true}) => <div>

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -22,6 +22,7 @@ import { TectonicGA } from '../tectonic-ga';
 import { KubernetesCIDRs } from './k8s-cidrs';
 import { CIDRRow } from './cidr';
 import { Field, Form } from '../form';
+import { toError } from '../utils';
 
 import {
   AWS_CONTROLLER_SUBNETS,
@@ -56,7 +57,7 @@ const DEFAULT_AWS_VPC_CIDR = '10.0.0.0/16';
 
 const {setIn} = configActions;
 
-const validateVPC = async (data, cc, oldData, oldCC, dispatch) => {
+const validateVPC = async (data, cc, updatedId, dispatch) => {
   const hostedZoneID = data[AWS_HOSTED_ZONE_ID];
   const privateZone = _.get(cc, ['extra', AWS_HOSTED_ZONE_ID, 'privateZones', hostedZoneID]);
   if (privateZone && hostedZoneID && data[AWS_CREATE_VPC] !== VPC_PRIVATE) {
@@ -68,11 +69,13 @@ const validateVPC = async (data, cc, oldData, oldCC, dispatch) => {
 
   if (!isCreate && !awsVpcId) {
     // User hasn't selected a VPC yet. Don't try to validate.
-    return Promise.resolve();
+    return;
   }
 
-  // Fields relevant to the VPC validation
-  const vpcFields = [
+  // Prevent unnecessary calls to validate API by only continuing if a field relevant to VPC validation has changed.
+  // However, we always continue if updatedId is undefined, since that probably means the form has just been loaded and
+  // we are doing initial validation.
+  if (updatedId && ![
     AWS_CONTROLLER_SUBNETS,
     AWS_CONTROLLER_SUBNET_IDS,
     AWS_CREATE_VPC,
@@ -84,13 +87,8 @@ const validateVPC = async (data, cc, oldData, oldCC, dispatch) => {
     DESELECTED_FIELDS,
     POD_CIDR,
     SERVICE_CIDR,
-  ];
-
-  // Prevent unnecessary calls to validate API by only continuing if a field relevant to VPC validation has changed.
-  // However, we always continue if none of the form data has changed, since that probably means the form has just been
-  // loaded and we are doing initial validation.
-  if (_.every(vpcFields, k => _.isEqual(cc[k], oldCC[k])) && !_.isEqual(data, oldData)) {
-    return Promise.resolve();
+  ].includes(updatedId)) {
+    return _.get(cc, toError(AWS_VPC_FORM));
   }
 
   const getSubnets = subnets => {
@@ -116,11 +114,8 @@ const validateVPC = async (data, cc, oldData, oldCC, dispatch) => {
   }
 
   try {
-    return await dispatch(validateSubnets(network)).then(json => {
-      if (!json.valid) {
-        return Promise.reject(json.message);
-      }
-    });
+    return await dispatch(validateSubnets(network))
+      .then(json => json.valid ? undefined : json.message);
   } catch (e) {
     return e.message || e.toString();
   }

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { withNav } from '../nav';
 import { validate } from '../validate';
 import { readFile } from '../readfile';
-import { toError, toAsyncError, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from '../utils';
+import { toError, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from '../utils';
 
 import { dirtyActions, configActions } from '../actions';
 import { DESELECTED_FIELDS } from '../cluster-config.js';
@@ -299,9 +299,7 @@ export const Selector = props => {
 
 const stateToProps = ({clusterConfig, dirty}, {field}) => ({
   value: _.get(clusterConfig, field),
-  invalid: _.get(clusterConfig, toError(field))
-    || _.get(clusterConfig, toAsyncError(field))
-    || _.get(clusterConfig, toExtraDataError(field)),
+  invalid: _.get(clusterConfig, toError(field)) || _.get(clusterConfig, toExtraDataError(field)),
   isDirty: _.get(dirty, field),
   extraData: _.get(clusterConfig, toExtraData(field)),
   inFly: _.get(clusterConfig, toInFly(field)) || _.get(clusterConfig, toExtraDataInFly(field)),

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { dispatch as dispatch_ } from './store';
-import { configActions, registerForm } from './actions';
-import { toError, toIgnore, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from './utils';
+import { configActions, registerForm, validateFields } from './actions';
+import { toError, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from './utils';
 import { ErrorComponent, ConnectedFieldList } from './components/ui';
 import { TectonicGA } from './tectonic-ga';
 import { PLATFORM_TYPE } from './cluster-config';
@@ -12,47 +12,33 @@ import { PLATFORM_TYPE } from './cluster-config';
 const { setIn, batchSetIn, append, removeAt } = configActions;
 const nop = () => undefined;
 
-let clock_ = 0;
-
 class Node {
   constructor (id, opts) {
     if (!id) {
       throw new Error('I need an id');
     }
-    this.clock_ = 0;
+    this.clock = 0;
     this.id = id;
     this.name = opts.name || id;
     this.validator = opts.validator || nop;
     this.dependencies = opts.dependencies || [];
-    this.ignoreWhen_ = opts.ignoreWhen;
+    this.ignoreWhen = opts.ignoreWhen;
     this.getExtraStuff_ = opts.getExtraStuff;
   }
 
-  updateClock (now) {
-    return this.clock_ = Math.max(now || clock_, this.clock_);
-  }
-
-  get isNow () {
-    const now = this.clock_;
-    return () => this.clock_ === now;
-  }
-
-  getExtraStuff (dispatch, cc, FIELDS, now) {
+  getExtraStuff (dispatch, getState, FIELDS, isNow = () => true) {
     if (!this.getExtraStuff_) {
       return Promise.resolve();
     }
 
+    const cc = getState().clusterConfig;
     if (_.some(this.dependencies, d => FIELDS[d] && !FIELDS[d].isValid(cc))) {
       // Dependencies are not all satisfied yet
       return Promise.resolve();
     }
 
-    this.updateClock(now);
-
     const inFlyPath = toExtraDataInFly(this.id);
-
     setIn(inFlyPath, true, dispatch);
-    const isNow = this.isNow;
 
     return this.getExtraStuff_(dispatch, isNow).then(data => {
       if (!isNow()) {
@@ -75,84 +61,26 @@ class Node {
     });
   }
 
-  async validate (dispatch, getState, oldCC) {
-    const id = this.id;
-    const clusterConfig = getState().clusterConfig;
-    const value = this.getData(clusterConfig);
+  async validate (dispatch, getState, updatedId = undefined, isNow = () => true) {
+    const inFlyPath = toInFly(this.id);
+    setIn(inFlyPath, true, dispatch);
 
-    const syncErrorPath = toError(id);
-    const inFlyPath = toInFly(id);
-
-    const oldValue = this.getData(oldCC);
-
-    const batches = [];
-
-    if (_.get(clusterConfig, inFlyPath)) {
-      batches.push([inFlyPath, false]);
+    const cc = getState().clusterConfig;
+    const error = await this.validator(this.getData(cc), cc, updatedId, dispatch);
+    if (isNow()) {
+      await setIn(toError(this.id), _.isEmpty(error) ? undefined : error, dispatch);
     }
-
-    console.debug(`validating ${this.name}`);
-    const syncError = await this.validator(value, clusterConfig, oldValue, oldCC, dispatch);
-    if (!_.isEmpty(syncError)) {
-      console.info(`sync error ${this.name}: ${JSON.stringify(syncError)}`);
-      batches.push([syncErrorPath, syncError]);
-      batchSetIn(dispatch, batches);
-      return false;
-    }
-
-    const oldError = _.get(oldCC, syncErrorPath);
-    if (!_.isEmpty(oldError)) {
-      batches.push([syncErrorPath, undefined]);
-      batchSetIn(dispatch, batches);
-    }
-
-    const isValid = this.isValid(getState().clusterConfig);
-    if (!isValid) {
-      batchSetIn(dispatch, batches);
-      return false;
-    }
-
-    batchSetIn(dispatch, batches);
-    return true;
+    setIn(inFlyPath, false, dispatch);
+    return _.isEmpty(error);
   }
 
-  ignoreWhen (dispatch, clusterConfig) {
-    if (!this.ignoreWhen_) {
-      return false;
-    }
-    const value = !!this.ignoreWhen_(clusterConfig);
-    console.debug(`ignoring ${this.id} value ${value}`);
-    setIn(toIgnore(this.id), value, dispatch);
-    return value;
+  noError (cc) {
+    return _.isEmpty(_.get(cc, toError(this.id))) && _.isEmpty(_.get(cc, toExtraDataError(this.id)));
   }
 
-  isIgnored (clusterConfig) {
-    return _.get(clusterConfig, toIgnore(this.id));
+  isIgnored (cc) {
+    return this.ignoreWhen && !!this.ignoreWhen(cc);
   }
-}
-
-async function promisify (dispatch, getState, oldCC, now, deps, FIELDS) {
-  const { clusterConfig } = getState();
-
-  // TODO: (kans) earlier return [] if not now?
-  const promises = deps.map(field => {
-    const { id } = field;
-    field.ignoreWhen(dispatch, clusterConfig);
-    return field.getExtraStuff(dispatch, clusterConfig, FIELDS, now)
-      .then(() => field.validate(dispatch, getState, oldCC))
-      .then(res => {
-        if (!res) {
-          console.debug(`${id} is invalid`);
-        } else {
-          console.debug(`${id} is valid`);
-        }
-        return res && id;
-      }).catch(err => {
-        console.error(err);
-      });
-  });
-
-  return await Promise.all(promises).then(p => p.filter(id => id));
 }
 
 export class Field extends Node {
@@ -164,74 +92,49 @@ export class Field extends Node {
     this.default = opts.default;
   }
 
-  getData (clusterConfig) {
-    return clusterConfig[this.id];
+  getData (cc) {
+    return cc[this.id];
   }
 
   async update (dispatch, value, getState, FIELDS, FIELD_TO_DEPS, split) {
-    const oldCC = getState().clusterConfig;
+    // Create an isNow() function that only returns true until this.update() is called again. This allows async
+    // callbacks to confirm that we are still dealing with the same Field update event.
+    this.clock = this.clock + 1;
+    const now = this.clock;
+    const isNow = () => this.clock === now;
 
-    const now = ++ clock_;
+    setIn([this.id, ...split], value, dispatch);
+    const isFieldValid = await this.validate(dispatch, getState, this.id, isNow);
 
-    let id = this.id;
-    if (split && split.length) {
-      id = `${id}.${split.join('.')}`;
-    }
-
-    console.info(`updating ${this.name}`);
-    // TODO: (kans) - We need to lock the entire validation chain, not just validate proper
-    setIn(id, value, dispatch);
-
-    const isValid = await this.validate(dispatch, getState, oldCC);
-
-    if (!isValid) {
-      const dirty = getState().dirty;
-      if (dirty[this.name]) {
-        TectonicGA.sendEvent('Validation Error', 'user input', this.name, oldCC[PLATFORM_TYPE]);
+    if (!isFieldValid) {
+      if (getState().dirty[this.name]) {
+        TectonicGA.sendEvent('Validation Error', 'user input', this.name, getState().clusterConfig[PLATFORM_TYPE]);
       }
-
-      console.debug(`${this.name} is invalid`);
       return;
     }
 
-    const visited = new Set();
-    const toVisit = [FIELD_TO_DEPS[this.id]];
-
-    if (!toVisit[0].length) {
-      console.debug(`no deps for ${this.name}`);
-      return;
+    try {
+      // Recursively find all fields that are dependent on this field
+      const depsDeep = id => {
+        const deps = FIELD_TO_DEPS[id];
+        return deps ? _.uniq([...deps, ..._.flatMap(deps, d => depsDeep(d))]) : [];
+      };
+      await validateFields(depsDeep(this.id), getState, dispatch, this.id, isNow);
+    } catch (e) {
+      console.error(e);
     }
-
-    while (toVisit.length) {
-      const deps = toVisit.splice(0, 1)[0];
-      // TODO: check for relationship between deps
-      const nextDepIDs = await promisify(dispatch, getState, oldCC, now, deps, FIELDS);
-      nextDepIDs.forEach(depID => {
-        const nextDeps = _.filter(FIELD_TO_DEPS[depID], d => !visited.has(d.id));
-        if (!nextDeps.length) {
-          return;
-        }
-        nextDeps.forEach(d => visited.add(d.id));
-        toVisit.push(nextDeps);
-      });
-    }
-
-    console.info(`finish validating ${this.name} ${isValid}`);
   }
 
   isValid (cc) {
-    if (_.get(cc, toIgnore(this.id))) {
+    if (this.isIgnored(cc)) {
       return true;
     }
-    const value = _.get(cc, this.id);
-    return value !== '' &&
-      value !== undefined &&
-      _.isEmpty(_.get(cc, toError(this.id))) &&
-      _.isEmpty(_.get(cc, toExtraDataError(this.id)));
+    const value = this.getData(cc);
+    return value !== '' && value !== undefined && this.noError(cc);
   }
 
-  inFly (clusterConfig) {
-    return _.get(clusterConfig, toInFly(this.id)) || _.get(clusterConfig, toExtraDataInFly(this.id));
+  inFly (cc) {
+    return _.get(cc, toInFly(this.id)) || _.get(cc, toExtraDataInFly(this.id));
   }
 }
 
@@ -240,9 +143,7 @@ export class Form extends Node {
     super(id, opts);
     this.isForm = true;
     this.fields = fields;
-    this.fieldIDs = fields.map(f => f.id);
-
-    this.dependencies = [...this.fieldIDs].concat(this.dependencies);
+    this.dependencies = fields.map(f => f.id).concat(this.dependencies);
 
     this.errorComponent = connect(
       ({clusterConfig}) => ({error: _.get(clusterConfig, toError(id))})
@@ -250,29 +151,19 @@ export class Form extends Node {
     registerForm(this, fields);
   }
 
-  isValid (clusterConfig) {
-    const ignore = _.get(clusterConfig, toIgnore(this.id));
-    if (ignore) {
-      return true;
-    }
-
-    if (_.get(clusterConfig, toError(this.id))) {
-      return false;
-    }
-
-    const invalidFields = this.fields.filter(field => !field.isValid(clusterConfig));
-    return invalidFields.length === 0;
+  isValid (cc) {
+    return this.isIgnored(cc) || (this.noError(cc) && _.every(this.fields, f => f.isValid(cc)));
   }
 
-  getData (clusterConfig) {
-    return this.fields.filter(f => !f.isIgnored(clusterConfig)).reduce((acc, f) => {
-      acc[f.name] = f.getData(clusterConfig);
+  getData (cc) {
+    return this.fields.filter(f => !f.isIgnored(cc)).reduce((acc, f) => {
+      acc[f.name] = f.getData(cc);
       return acc;
     }, {});
   }
 
-  inFly (clusterConfig) {
-    return _.get(clusterConfig, toInFly(this.id)) || _.some(this.fields, f => f.inFly(clusterConfig));
+  inFly (cc) {
+    return _.get(cc, toInFly(this.id)) || _.some(this.fields, f => f.inFly(cc));
   }
 
   get canNavigateForward () {
@@ -284,8 +175,8 @@ export class Form extends Node {
   }
 }
 
-const toValidator = (fields, listValidator) => (value, clusterConfig, oldValue) => {
-  const errs = listValidator ? listValidator(value, clusterConfig, oldValue) : [];
+const toValidator = (fields, listValidator) => (value, cc) => {
+  const errs = listValidator ? listValidator(value, cc) : [];
   if (errs && !_.isObject(errs)) {
     throw new Error(`FieldLists validator must return an Array-like Object, not:\n${errs}`);
   }
@@ -297,7 +188,7 @@ const toValidator = (fields, listValidator) => (value, clusterConfig, oldValue) 
       if (!validator) {
         return;
       }
-      const err = validator(childValue, clusterConfig, _.get(oldValue, [i, name]));
+      const err = validator(childValue, cc);
       if (!err) {
         return;
       }
@@ -362,11 +253,11 @@ export class FieldList extends Field {
       child[name] = _.cloneDeep(f.default);
     });
     append(this.id, child, dispatch);
-    this.validate(dispatch, getState, getState().clusterConfig);
+    this.validate(dispatch, getState);
   }
 
   remove (dispatch, i, getState) {
     removeAt(this.id, i, dispatch);
-    this.validate(dispatch, getState, getState().clusterConfig);
+    this.validate(dispatch, getState);
   }
 }

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -126,11 +126,7 @@ export class Field extends Node {
   }
 
   isValid (cc) {
-    if (this.isIgnored(cc)) {
-      return true;
-    }
-    const value = this.getData(cc);
-    return value !== '' && value !== undefined && this.noError(cc);
+    return this.isIgnored(cc) || this.noError(cc);
   }
 
   inFly (cc) {

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -153,8 +153,7 @@ const reducersTogether = combineReducers({
       array.push(index.toString());
       // TODO: (kans) delete all the other stuff too
       const invalidArray = ['error'].concat(array);
-      const asyncArray = ['error_async'].concat(array);
-      const arrays = [array, asyncArray, invalidArray];
+      const arrays = [array, invalidArray];
       return fromJS(state).withMutations(map => {
         arrays.forEach(a => {
           if (map.getIn(a)) {

--- a/installer/frontend/utils.js
+++ b/installer/frontend/utils.js
@@ -56,7 +56,6 @@ const toPath = function (base) {
 };
 
 export const toError = toPath('error');
-export const toAsyncError = toPath('error_async');
 export const toIgnore = toPath('ignore');
 export const toInFly = toPath('inFly');
 export const toExtraData = toPath('extra');

--- a/installer/frontend/utils.js
+++ b/installer/frontend/utils.js
@@ -56,7 +56,6 @@ const toPath = function (base) {
 };
 
 export const toError = toPath('error');
-export const toIgnore = toPath('ignore');
 export const toInFly = toPath('inFly');
 export const toExtraData = toPath('extra');
 export const toExtraDataError = toPath('extraError');


### PR DESCRIPTION
Big form code clean up, mostly related to field validation.
- Remove `asyncValidator()`, which was only used by the AWS VPC form, but added significant complexity to `form.js`. Instead modify the AWS VPC form's `validator()` function to handle the async API call.
- Remove `ignore` from Redux. Instead just re-evaluate whether a field should be ignored when necessary.
- Simplify `promisify()` and `Node.validate()`. This simplifies the logic following a field update, which triggers validation on that field and any dependent fields.
- Simplify `isNow` logic to only increment `this.clock` when a field update begins.
- Stop passing `oldData` and `oldCC` to field `validator()` functions.
- Change `isValid()` to allow empty values. If a field can't be empty, that should be enforced using the field's `validator` function.
- Various minor clean ups.

Also fixes a bug where the AWS VPC validate API endpoint was called even when form field validation had failed.