### PR TITLE
operators: Add necessary annotation for alm-operator.

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -1,8 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: tectonic-alm-operator
   namespace: tectonic-system
+  labels:
+    k8s-app: tectonic-alm-operator
+    managed-by-channel-operator: "true"
+  annotations:
+    tectonic-operators.coreos.com/upgrade-behaviour: 'CreateOrUpgrade'
 spec:
   replicas: 1
   strategy:
@@ -11,11 +16,11 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app: tectonic-alm-operator
+      k8s-app: tectonic-alm-operator
   template:
     metadata:
       labels:
-        app: tectonic-alm-operator
+        k8s-app: tectonic-alm-operator
     spec:
       imagePullSecrets:
         - name: coreos-pull-secret


### PR DESCRIPTION
In order to install the operator for old clusters during upgrade,
'CreateOrUpgrade' annotation is required for the operator's deployment
manifest.

Also the "managed-by-channel-operator" label is necessary as well.