### PR TITLE
frontend: Fix max value validation for instance count fields

### DIFF
--- a/installer/frontend/components/aws-define-nodes.jsx
+++ b/installer/frontend/components/aws-define-nodes.jsx
@@ -16,6 +16,7 @@ import {
 
 import { Form } from '../form';
 import { toError, toAsyncError } from '../utils';
+import { validate } from '../validate';
 import { AWS_INSTANCE_TYPES } from '../facts';
 import { NumberInput, Connect, Select } from './ui';
 import { makeNodeForm, toKey } from './make-node-form';
@@ -101,10 +102,13 @@ export const DefineNode = ({type, max, withIamRole = true}) => <div>
   <Errors type={type} />
 </div>;
 
+const MAX_MASTERS = 10;
+const MAX_WORKERS = 1000;
+
 // TODO (kans): add ectdForm here
 const fields = [
-  makeNodeForm(AWS_CONTROLLERS),
-  makeNodeForm(AWS_WORKERS),
+  makeNodeForm(AWS_CONTROLLERS, validate.int({min: 1, max: MAX_MASTERS})),
+  makeNodeForm(AWS_WORKERS, validate.int({min: 1, max: MAX_WORKERS})),
 ];
 
 const form = new Form('DefineNodesForm', fields);
@@ -112,11 +116,11 @@ const form = new Form('DefineNodesForm', fields);
 export const AWS_DefineNodes = () => <div>
   <h3>Master Nodes</h3>
   <br />
-  <DefineNode type={AWS_CONTROLLERS} max={10} />
+  <DefineNode type={AWS_CONTROLLERS} max={MAX_MASTERS} />
   <hr />
   <h3>Worker Nodes</h3>
   <br />
-  <DefineNode type={AWS_WORKERS} max={1000} />
+  <DefineNode type={AWS_WORKERS} max={MAX_WORKERS} />
   <form.Errors />
   <hr />
   <h3>etcd Nodes</h3>

--- a/installer/frontend/components/etcd.jsx
+++ b/installer/frontend/components/etcd.jsx
@@ -22,7 +22,7 @@ const fields = [
   new Field(ETCD_OPTION, {
     default: ETCD_OPTIONS.PROVISIONED,
   }),
-  makeNodeForm(AWS_ETCDS, false, compose(validate.int({min: 1, max: 9}), validate.isOdd), {
+  makeNodeForm(AWS_ETCDS, compose(validate.int({min: 1, max: 9}), validate.isOdd), false, {
     dependencies: [ETCD_OPTION],
     ignoreWhen: cc => cc[ETCD_OPTION] !== ETCD_OPTIONS.PROVISIONED,
   }),

--- a/installer/frontend/components/make-node-form.jsx
+++ b/installer/frontend/components/make-node-form.jsx
@@ -28,7 +28,7 @@ new Form('DUMMY_NODE_FORM', [
   }),
 ]);
 
-export const makeNodeForm = (name, withIamRole = true, instanceValidator = validate.int({min: 1, max: 999}), opts) => {
+export const makeNodeForm = (name, instanceValidator, withIamRole = true, opts) => {
   const storageType = toKey(name, STORAGE_TYPE);
 
   // all fields must have a unique name!

--- a/installer/frontend/ui-tests/pages/nodesPage.js
+++ b/installer/frontend/ui-tests/pages/nodesPage.js
@@ -8,14 +8,29 @@ const nodesPageCommands = {
     this.expect.element('@etcdCount').to.be.present;
     this.expect.element('@externalEtcdAddress').to.not.be.present;
 
+    const testInstanceCount = (field, value, max) => {
+      this
+        // Browser won't let us set this to zero because of the min="0" attribute, so use -1 instead
+        .setField(field, -1)
+        .expectValidationErrorContains('Cannot be less than 1')
+        .setField(field, 1)
+        .expectNoValidationError()
+        .setField(field, max)
+        .expectNoValidationError()
+        .setField(field, max + 1)
+        .expectValidationErrorContains(`Cannot be greater than ${max}`)
+        .setField(field, value);
+    };
+
+    testInstanceCount('@mastersCount', json['aws_controllers-numberOfInstances'], 10);
+    testInstanceCount('@workersCount', json['aws_workers-numberOfInstances'], 1000);
+    testInstanceCount('@etcdCount', json['aws_etcds-numberOfInstances'], 9);
+
     this
-      .setField('[id=aws_controllers--number]', json['aws_controllers-numberOfInstances'])
       .selectOption(`[id=aws_controllers--instance] [value="${json['aws_controllers-instanceType']}"]`)
       .setField('[id=aws_controllers--storage-size]', json['aws_controllers-storageSizeInGiB'])
-      .setField('[id=aws_workers--number]', json['aws_workers-numberOfInstances'])
       .selectOption(`[id=aws_workers--instance] [value="${json['aws_workers-instanceType']}"]`)
       .setField('[id=aws_workers--storage-size]', json['aws_workers-storageSizeInGiB'])
-      .setField('@etcdCount', json['aws_etcds-numberOfInstances'])
       .selectOption(`[id=aws_etcds--instance] [value="${json['aws_etcds-instanceType']}"]`)
       .setField('[id=aws_etcds--storage-size]', json['aws_etcds-storageSizeInGiB']);
   },
@@ -26,5 +41,7 @@ module.exports = {
   elements: {
     etcdCount: '[id=aws_etcds--number]',
     externalEtcdAddress: 'input#externalETCDClient[type=text]',
+    mastersCount: '[id=aws_controllers--number]',
+    workersCount: '[id=aws_workers--number]',
   },
 };

--- a/installer/frontend/validate.js
+++ b/installer/frontend/validate.js
@@ -207,11 +207,11 @@ export const validate = {
       }
 
       if (min !== undefined && value < min) {
-        return `Invalid value. Provide a value greater than ${min - 1}.`;
+        return `Invalid value. Cannot be less than ${min}.`;
       }
 
       if (max !== undefined && value > max) {
-        return `Invalid value. Provide a value less than ${max + 1}.`;
+        return `Invalid value. Cannot be greater than ${max}.`;
       }
 
       return;


### PR DESCRIPTION
Also change validation error wording from e.g. "Provide a value less than 11" to "Cannot be greater than 10".

cc: @robszumski 

![screenshot-1](https://user-images.githubusercontent.com/460802/33817576-96e96678-de83-11e7-9b86-477edcfd39b4.png)
