### PR TITLE
tests: change logic for the kv filter

### DIFF
--- a/tests/rspec/lib/cluster_support.rb
+++ b/tests/rspec/lib/cluster_support.rb
@@ -58,7 +58,7 @@ end
 def save_to_file(cluster_name, service_type, ip, service, output_to_save)
   logs_path = "../../build/#{cluster_name}/logs/#{ip}/#{service_type}"
   FileUtils.mkdir_p(logs_path)
-  save_to_file = File.open("#{logs_path}/#{service}.log", 'w+')
+  save_to_file = File.open("#{logs_path}/ip=#{ip},cluster=#{cluster},service=#{service}.log", 'w+')
   save_to_file << output_to_save
   save_to_file.close
 end


### PR DESCRIPTION
We want to use the Logstash KV plugin (https://www.elastic.co/guide/en/logstash/current/plugins-filters-kv.html). This plugin parses through the log files, looking for key=value expressions. The KV filter uses the '=' and uses the ',' character as split field. 