### PR TITLE
config.tf: Bump KVO to v1.8.4-kvo.3

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -86,7 +86,7 @@ variable "tectonic_container_images" {
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5"
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
-    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.7.9-kvo.6"
+    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.8.4-kvo.3"
     node_agent                   = "quay.io/coreos/node-agent:cd69b4a0f65b0d3a3b30edfce3bb184fd2a22c26"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:e22cc0e3714378de92f45326474874eb602ca0ac"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"
@@ -124,7 +124,7 @@ variable "tectonic_versions" {
 
   default = {
     etcd          = "3.1.8"
-    kubernetes    = "1.7.9+tectonic.2"
+    kubernetes    = "1.8.4+tectonic.1"
     monitoring    = "1.8.0"
     tectonic      = "1.8.2-tectonic.1"
     tectonic-etcd = "0.0.1"


### PR DESCRIPTION
This is to make upgrade test pass as it's trying to upgrade from
179-3, which the current kvo in the config.tf doesn't know about.