### PR TITLE
tests: Remove unused tectonic_aws_az_count var from smoke test input

### DIFF
--- a/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
+++ b/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
@@ -1,5 +1,4 @@
 {
-    "tectonic_aws_az_count": "2",
     "tectonic_aws_etcd_ec2_type": "m4.large",
     "tectonic_aws_public_endpoints": false,
     "tectonic_aws_master_ec2_type": "m4.large",


### PR DESCRIPTION
This var doesn't appear to do anything.