### PR TITLE
tests: add jenkins build status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,6 +365,7 @@ pipeline {
           withCredentials(creds) {
             unstash 'clean-repo'
             sh """#!/bin/bash -xe
+            export BUILD_RESULT=${currentBuild.currentResult}
             ./tests/jenkins-jobs/scripts/log-analyzer-copy.sh jenkins-logs
             """
           }

--- a/tests/jenkins-jobs/scripts/log-analyzer-copy.sh
+++ b/tests/jenkins-jobs/scripts/log-analyzer-copy.sh
@@ -27,6 +27,11 @@ fi
 SOURCE_BRANCH=${BRANCH_NAME//[=,]/_}
 TARGET_BRANCH=${CHANGE_TARGET//[=,]/_}
 
+#Check whether the BUILD_RESULT is not empty. If the variable is not empty (so success/failure/*), add the value to the additionalField variable.
+if [ -n "${BUILD_RESULT}" ]; then
+   additionalFields="${additionalFields}build_result=${BUILD_RESULT},"
+fi
+
 if [ -n "$testFilePath" ]; then
         platform=$(echo "${testFilePath}" | cut -d'/' -f2)
         specName=$(echo "${testFilePath}" | cut -d'/' -f3 | sed 's/_spec\.rb//')


### PR DESCRIPTION
Get the build job status and add it to the document file name.The value is used by Logstash to add this as as an attribute to all the documents.