### PR TITLE
*: bump Tectonic Monitoring to 1.9

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -93,7 +93,7 @@ variable "tectonic_container_images" {
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.6.2"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.8.0"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.0"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.5"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
     kubernetes_addon_operator    = "quay.io/coreos/kubernetes-addon-operator:4b83569d763dc95e1f61c77b31989fd3957bfc67"
@@ -127,7 +127,7 @@ variable "tectonic_versions" {
   default = {
     etcd             = "3.1.8"
     kubernetes       = "1.8.4+tectonic.1"
-    monitoring       = "1.8.0"
+    monitoring       = "1.9.0"
     tectonic         = "1.8.4-tectonic.2"
     tectonic-etcd    = "0.0.1"
     cluo             = "0.2.5"


### PR DESCRIPTION
This bump the Tectonic Monitoring stack + Tectonic Prometheus Operator to `v1.9.0`.

@alexsomesan @s-urbaniak 

/cc @pst @sichvoge @ant31 