### PR TITLE
platform/vmware: Revert vsphere provider version to 0.2.2

### DIFF
--- a/platforms/vmware/provider.tf
+++ b/platforms/vmware/provider.tf
@@ -1,11 +1,10 @@
 provider "vsphere" {
-  version              = "0.4.2"
+  version              = "0.2.2"
   vsphere_server       = "${var.tectonic_vmware_server}"
   allow_unverified_ssl = "${var.tectonic_vmware_sslselfsigned}"
 }
 
 resource "vsphere_folder" "tectonic_vsphere_folder" {
-  path          = "${var.tectonic_vmware_folder}"
-  type          = "${var.tectonic_vmware_type}"
-  datacenter_id = "${var.tectonic_vmware_worker_datacenters[0]}"
+  path       = "${var.tectonic_vmware_folder}"
+  datacenter = "${var.tectonic_vmware_worker_datacenters[0]}"
 }


### PR DESCRIPTION
The latest version 0.4.2 is causing mysterious errors - like preventing
the CA cert from being generated on self-signed installs.  Reverting
until the new version can be properly tested.


