### PR TITLE
frontend: Don't output tectonic_dns_name TF var for bare metal

### DIFF
--- a/installer/frontend/__tests__/examples/metal.json
+++ b/installer/frontend/__tests__/examples/metal.json
@@ -12,7 +12,6 @@
     "tectonic_cluster_cidr": "10.2.0.0/16",
     "tectonic_cluster_name": "my-cluster",
     "tectonic_container_linux_version": "1520.9.0",
-    "tectonic_dns_name": "",
     "tectonic_metal_controller_domain": "cluster.example.com",
     "tectonic_metal_controller_domains": [
       "node1.example.com"

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -271,7 +271,6 @@ export const toBaremetal_TF = ({clusterConfig: cc}, FORMS) => {
       tectonic_ssh_authorized_key: sshKey[SSH_AUTHORIZED_KEY],
       tectonic_cluster_cidr: cc[POD_CIDR],
       tectonic_service_cidr: cc[SERVICE_CIDR],
-      tectonic_dns_name: cc[CLUSTER_SUBDOMAIN],
       tectonic_base_domain: 'unused',
     },
   };

--- a/installer/frontend/ui-tests/output/metal.tfvars
+++ b/installer/frontend/ui-tests/output/metal.tfvars
@@ -5,7 +5,6 @@
   "tectonic_cluster_cidr": "10.2.0.0/16",
   "tectonic_cluster_name": "my-cluster",
   "tectonic_container_linux_version": "1520.9.0",
-  "tectonic_dns_name": "",
   "tectonic_kube_apiserver_service_ip": "10.3.0.1",
   "tectonic_kube_dns_service_ip": "10.3.0.10",
   "tectonic_kube_etcd_service_ip": "10.3.0.15",

--- a/installer/frontend/ui-tests/utils/terraformTfvars.js
+++ b/installer/frontend/ui-tests/utils/terraformTfvars.js
@@ -7,7 +7,6 @@ const request = require('request');
 const ignoredKeys = [
   'tectonic_admin_email',
   'tectonic_admin_password',
-  'tectonic_dns_name',
   'tectonic_license_path',
   'tectonic_pull_secret_path',
   'tectonic_stats_url',


### PR DESCRIPTION
We don't set this field for the bare metal, so it was always "".

This also means we no longer need to ignore `tectonic_dns_name` in the GUI tests.