### PR TITLE
frontend: Fix display of error message when AWS credentials are invalid

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -212,7 +212,7 @@ export const AWS_CloudCredentials = connect(stateToProps)(
 
       <div className="row form-group">
         <div className="col-xs-12">
-          <awsCredsForm.Errors />
+          {regionSelections.error && <Alert severity="error">{regionSelections.error}</Alert>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
This error was already rendered as a field validation error on the
regions dropdown, but that meant it was only shown if the dropdown was
marked as "dirty" in Redux, which doesn't happen until its value is
first set.

Explicitly rendering the AWS API error solves this problem, but it does
mean that the error message can now possibly be displayed twice. Solving
that will require a larger code change, so this is an initial quick fix.

![screenshot-1](https://user-images.githubusercontent.com/460802/34048611-b6b7a2ae-e1f7-11e7-8745-8ed05a78ae2b.png)