### PR TITLE
tests/frontend: Ignore fewer TF vars

### DIFF
--- a/installer/frontend/ui-tests/tests/aws.js
+++ b/installer/frontend/ui-tests/tests/aws.js
@@ -5,7 +5,7 @@ const tfvarsUtil = require('../utils/terraformTfvars');
 const REQUIRED_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'TF_VAR_tectonic_license_path', 'TF_VAR_tectonic_pull_secret_path'];
 
 // Expects an input file <prefix>.progress to exist
-const steps = (prefix, expectedOutputFilePath) => {
+const steps = (prefix, expectedOutputFilePath, ignoredKeys) => {
   // Test input cluster config
   const cc = tfvarsUtil.loadJson(`${prefix}.progress`).clusterConfig;
 
@@ -27,7 +27,7 @@ const steps = (prefix, expectedOutputFilePath) => {
     [`${prefix}: Networking`]: ({page}) => testPage(page.networkingPage()),
     [`${prefix}: Console Login`]: ({page}) => testPage(page.consoleLoginPage()),
 
-    [`${prefix}: Manual Boot`]: client => tfvarsUtil.testManualBoot(client, expectedOutputFilePath),
+    [`${prefix}: Manual Boot`]: client => tfvarsUtil.testManualBoot(client, expectedOutputFilePath, ignoredKeys),
   };
 };
 
@@ -47,8 +47,17 @@ const toExport = {
   },
 };
 
+const ignoredKeys = [
+  'tectonic_admin_email',
+  'tectonic_admin_password',
+  'tectonic_aws_ssh_key',
+  'tectonic_license_path',
+  'tectonic_pull_secret_path',
+  'tectonic_stats_url',
+];
+
 module.exports = Object.assign(
   toExport,
-  steps('aws', '../../../../tests/smoke/aws/vars/aws.tfvars.json'),
+  steps('aws', '../../../../tests/smoke/aws/vars/aws.tfvars.json', ignoredKeys),
   steps('aws-custom-vpc', '../output/aws-custom-vpc.tfvars')
 );

--- a/installer/frontend/ui-tests/tests/metal.js
+++ b/installer/frontend/ui-tests/tests/metal.js
@@ -5,7 +5,7 @@ const tfvarsUtil = require('../utils/terraformTfvars');
 const REQUIRED_ENV_VARS = ['TF_VAR_tectonic_license_path', 'TF_VAR_tectonic_pull_secret_path'];
 
 // Expects an input file <prefix>.progress to exist
-const steps = (prefix, expectedOutputFilePath) => {
+const steps = (prefix, expectedOutputFilePath, ignoredKeys) => {
   // Test input cluster config
   const cc = tfvarsUtil.loadJson(`${prefix}.progress`).clusterConfig;
 
@@ -31,7 +31,7 @@ const steps = (prefix, expectedOutputFilePath) => {
     [`${prefix}: SSH Key`]: ({page}) => testPage(page.sshKeysPage()),
     [`${prefix}: Console Login`]: ({page}) => testPage(page.consoleLoginPage()),
 
-    [`${prefix}: Manual Boot`]: client => tfvarsUtil.testManualBoot(client, expectedOutputFilePath),
+    [`${prefix}: Manual Boot`]: client => tfvarsUtil.testManualBoot(client, expectedOutputFilePath, ignoredKeys),
   };
 };
 
@@ -51,8 +51,19 @@ const toExport = {
   },
 };
 
+const ignoredKeys = [
+  'tectonic_admin_email',
+  'tectonic_admin_password',
+  'tectonic_license_path',
+  'tectonic_pull_secret_path',
+  'tectonic_stats_url',
+  'tectonic_update_app_id',
+  'tectonic_update_channel',
+  'tectonic_update_server',
+];
+
 module.exports = Object.assign(
   toExport,
   steps('metal', '../output/metal.tfvars'),
-  steps('metal-smoke', '../../../../tests/smoke/bare-metal/vars/metal.tfvars.json')
+  steps('metal-smoke', '../../../../tests/smoke/bare-metal/vars/metal.tfvars.json', ignoredKeys)
 );

--- a/installer/frontend/ui-tests/utils/terraformTfvars.js
+++ b/installer/frontend/ui-tests/utils/terraformTfvars.js
@@ -4,19 +4,7 @@ const JSZip = require('jszip');
 const path = require('path');
 const request = require('request');
 
-const ignoredKeys = [
-  'tectonic_aws_ssh_key',
-  'tectonic_admin_email',
-  'tectonic_admin_password',
-  'tectonic_license_path',
-  'tectonic_pull_secret_path',
-  'tectonic_stats_url',
-  'tectonic_update_app_id',
-  'tectonic_update_channel',
-  'tectonic_update_server',
-];
-
-const diffTfvars = (client, assetsZip, expected) => {
+const diffTfvars = (client, assetsZip, expected, ignoredKeys = []) => {
   JSZip.loadAsync(assetsZip).then(zip => {
     zip.file(/tfvars$/)[0].async('string').then(tfvars => {
       const actual = JSON.parse(tfvars);
@@ -35,7 +23,7 @@ const diffTfvars = (client, assetsZip, expected) => {
   });
 };
 
-const testManualBoot = (client, expectedOutputFilePath) => {
+const testManualBoot = (client, expectedOutputFilePath, ignoredKeys) => {
   const page = client.page.submitPage();
   page
     .click('@manuallyBoot')
@@ -59,7 +47,7 @@ const testManualBoot = (client, expectedOutputFilePath) => {
       // eslint-disable-next-line no-sync
       const expected = JSON.parse(fs.readFileSync(path.join(__dirname, expectedOutputFilePath), 'utf8'));
 
-      diffTfvars(client, assetsZip, expected);
+      diffTfvars(client, assetsZip, expected, ignoredKeys);
     });
   });
 


### PR DESCRIPTION
- Some tests don't output TF vars for smoke tests, so they don't need to ignore any TF vars.
- Some TF vars are specific to a single platform, so only the tests for that platform need to ignore them.