### PR TITLE
tests: bump images and ingore filemode changes in structure-check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,8 @@ quayCreds = [
   )
 ]
 
-defaultBuilderImage = 'quay.io/coreos/tectonic-builder:v1.41'
-tectonicSmokeTestEnvImage = 'quay.io/coreos/tectonic-smoke-test-env:v5.13'
+defaultBuilderImage = 'quay.io/coreos/tectonic-builder:v1.42'
+tectonicSmokeTestEnvImage = 'quay.io/coreos/tectonic-smoke-test-env:v5.14'
 originalCommitId = 'UNKNOWN'
 
 pipeline {

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,8 @@ structure-check:
 	$(eval FMT_ERR := $(shell terraform fmt -list -write=false .))
 	@if [ "$(FMT_ERR)" != "" ]; then echo "misformatted files (run 'terraform fmt .' to fix):" $(FMT_ERR); exit 1; fi
 
-	@if $(MAKE) docs && ! git diff --exit-code; then echo "outdated docs (run 'make docs' to fix)"; exit 1; fi
-	@if $(MAKE) examples && ! git diff --exit-code; then echo "outdated examples (run 'make examples' to fix)"; exit 1; fi
+	@if $(MAKE) docs && ! git diff -c core.fileMode=false --exit-code; then echo "outdated docs (run 'make docs' to fix)"; exit 1; fi
+	@if $(MAKE) examples && ! git diff -c core.fileMode=false --exit-code; then echo "outdated examples (run 'make examples' to fix)"; exit 1; fi
 
 SMOKE_SOURCES := $(shell find $(TOP_DIR)/tests/smoke -name '*.go')
 bin/smoke: $(SMOKE_SOURCES)


### PR DESCRIPTION

With the `-c core.fileMode=false` option, `git diff` ignores any
filemode changes. In the `structure-check` make target filemode changes
can be ignored.