### PR TITLE
frontend: Fix TF action title when action is neither apply nor destroy

### DIFF
--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -265,7 +265,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
         );
       }
 
-      const tfTitle = `${isApply ? 'Applying' : 'Destroying'} Terraform`;
+      const tfTitle = `Terraform ${_.startCase(action)}`;
 
       return <div>
         {!isBareMetal &&


### PR DESCRIPTION
Normally we expect to only have an `apply` or `destroy` action in progress, that is not actually true 100% of the time.

![screenshot-1](https://user-images.githubusercontent.com/460802/34137765-d6b125e8-e4af-11e7-8870-ebb28abc947e.png)