### PR TITLE
frontend: Make autoFocus use more consistent

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -127,7 +127,7 @@ const awsCreds = <div>
     </div>
     <div className="col-xs-8">
       <Connect field={AWS_ACCESS_KEY_ID}>
-        <Input id="accessKeyId" autoFocus="true" placeholder="AKxxxxxxxxxxxxxxxxxx" />
+        <Input id="accessKeyId" autoFocus={true} placeholder="AKxxxxxxxxxxxxxxxxxx" />
       </Connect>
     </div>
   </div>

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -242,7 +242,6 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
       const fieldName = `${AWS_SUBNETS}.${az}`;
       return <DeselectField key={az} field={fieldName}>
         <CIDRRow
-          autoFocus={az.endsWith('a')}
           field={`${AWS_CONTROLLER_SUBNETS}.${az}`}
           fieldName={fieldName}
           name={az}
@@ -463,7 +462,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
       </div>
       }
       <hr />
-      <KubernetesCIDRs />
+      <KubernetesCIDRs autoFocus={false} />
     </div>
     }
   </div>;

--- a/installer/frontend/components/bm-credentials.jsx
+++ b/installer/frontend/components/bm-credentials.jsx
@@ -24,7 +24,7 @@ export const BM_Credentials = () => <div>
     </div>
     <div className="col-xs-9">
       <Connect field={BM_MATCHBOX_CA}>
-        <CertArea autoFocus="true" />
+        <CertArea autoFocus={true} />
       </Connect>
     </div>
   </div>

--- a/installer/frontend/components/bm-hostname.jsx
+++ b/installer/frontend/components/bm-hostname.jsx
@@ -24,9 +24,7 @@ export const BM_Hostname = () =>
       </div>
       <div className="col-xs-9">
         <Connect field={CONTROLLER_DOMAIN}>
-          <Input id={CONTROLLER_DOMAIN}
-            placeholder="masters.example.com"
-            autoFocus="true" />
+          <Input autoFocus={true} id={CONTROLLER_DOMAIN} placeholder="masters.example.com" />
         </Connect>
       </div>
     </div>

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -127,7 +127,7 @@ export const BM_Matchbox = connect(stateToProps, dispatchToProps)(
               <div className="col-xs-9">
                 <Input id={BM_MATCHBOX_HTTP}
                   className="wiz-inline-field wiz-inline-field--prefix"
-                  autoFocus="true"
+                  autoFocus={true}
                   prefix={<span className="input__prefix">http://</span>}
                   placeholder="matchbox.example.com:8080"
                   forceDirty={!!osError}

--- a/installer/frontend/components/bm-sshkeys.jsx
+++ b/installer/frontend/components/bm-sshkeys.jsx
@@ -38,10 +38,7 @@ export const BM_SSHKeys = () => <div>
     <div className="col-xs-9">
       <div className="wiz-ssh-key-container">
         <Connect field={SSH_AUTHORIZED_KEY}>
-          <FileArea
-            className="wiz-ssh-key-container__input"
-            placeholder={keyPlaceholder}
-            autoFocus />
+          <FileArea autoFocus={true} className="wiz-ssh-key-container__input" placeholder={keyPlaceholder} />
         </Connect>
       </div>
     </div>

--- a/installer/frontend/components/certificate-authority.jsx
+++ b/installer/frontend/components/certificate-authority.jsx
@@ -59,7 +59,7 @@ export const CertificateAuthority = connect(
           <div className="row form-group">
             <div className="col-xs-12">
               <Connect field={CA_CERTIFICATE}>
-                <CertArea autoFocus="true" uploadButtonLabel="Upload CA Certificate" />
+                <CertArea autoFocus={true} uploadButtonLabel="Upload CA Certificate" />
               </Connect>
             </div>
           </div>

--- a/installer/frontend/components/cluster-info.jsx
+++ b/installer/frontend/components/cluster-info.jsx
@@ -114,7 +114,7 @@ export const ClusterInfo = () => <div>
     </div>
     <div className="col-xs-9">
       <Connect field={CLUSTER_NAME}>
-        <Input placeholder="production" autoFocus="true" />
+        <Input placeholder="production" autoFocus={true} />
       </Connect>
       <p className="text-muted">Give this cluster a name that will help you identify it.</p>
     </div>

--- a/installer/frontend/components/etcd.jsx
+++ b/installer/frontend/components/etcd.jsx
@@ -93,7 +93,7 @@ export const Etcd = connect(({clusterConfig}) => ({
           <div className="col-xs-8">
             <Connect field={EXTERNAL_ETCD_CLIENT}>
               <Input id={EXTERNAL_ETCD_CLIENT}
-                autoFocus
+                autoFocus={true}
                 className="wiz-inline-field wiz-inline-field--suffix"
                 suffix={<span className="input__suffix">:2379</span>}
                 placeholder="https://etcd.example.com" />

--- a/installer/frontend/components/k8s-cidrs.jsx
+++ b/installer/frontend/components/k8s-cidrs.jsx
@@ -83,10 +83,10 @@ const form = new Form('K8S_CIDRS_FORM', [
   new Field(SERVICE_CIDR, {default: DEFAULT_SERVICE_CIDR, validator}),
 ]);
 
-export const KubernetesCIDRs = () => <div id="k8sCIDRs" className="row form-group">
+export const KubernetesCIDRs = ({autoFocus = true}) => <div id="k8sCIDRs" className="row form-group">
   <div className="col-xs-12">
     <h4>Kubernetes</h4>
-    <CIDRRow name="Pod Range" field={POD_CIDR} placeholder={DEFAULT_POD_CIDR} />
+    <CIDRRow autoFocus={autoFocus} name="Pod Range" field={POD_CIDR} placeholder={DEFAULT_POD_CIDR} />
     <CIDRRow name="Service Range" field={SERVICE_CIDR} placeholder={DEFAULT_SERVICE_CIDR} />
     <DockerBridgeWarning />
     <PodRangeWarning />

--- a/installer/frontend/components/users.jsx
+++ b/installer/frontend/components/users.jsx
@@ -27,7 +27,7 @@ export const Users = () => <div>
     </div>
     <div className="col-sm-8">
       <Connect field={ADMIN_EMAIL}>
-        <Input type="email" placeholder="admin@example.com" />
+        <Input autoFocus={true} type="email" placeholder="admin@example.com" />
       </Connect>
     </div>
   </div>


### PR DESCRIPTION
Generally, if the first field on a page is a `text` or `textarea` input, it should be focused.
- Add `autoFocus` to first input on Console Login page.
- Remove `autoFocus` from AWS VPC field that is actually half way down the page.
- Consistently use `autoFocus={true}` syntax rather than `autoFocus="true"` or just `autoFocus`.

cc @tlwu2013 