### PR TITLE
frontend: Add help text for Download Assets button

### DIFF
--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -18,7 +18,7 @@ export const DryRun = () => <div className="row">
       <div className="wiz-giant-button-container">
         <a href="/terraform/assets" download>
           <button className="btn btn-primary wiz-giant-button">
-            <i className="fa fa-download"></i>&nbsp;&nbsp;Download assets
+            <i className="fa fa-download"></i>&nbsp;&nbsp;Download Assets
           </button>
         </a>
       </div>

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -376,9 +376,14 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
             <div className="col-xs-12">
               <a href="/terraform/assets" download>
                 <button className={classNames('btn btn-primary wiz-giant-button')}>
-                  <i className="fa fa-download"></i>&nbsp;&nbsp;Download assets
+                  <i className="fa fa-download"></i>&nbsp;&nbsp;Download Assets
                 </button>
               </a>
+            </div>
+            <div className="col-xs-12">
+              <div className="wiz-pending-fg">
+                <p>The assets contain TLS certificates used by Kubelets and manifests for all Tectonic components.</p>
+              </div>
             </div>
           </div>
         }


### PR DESCRIPTION
Also capitalize "Assets" in button text.

This text was in the mocks (see https://github.com/coreos/tectonic-installer/issues/356#issuecomment-317838399), but seems to have been overlooked.

![screenshot-1](https://user-images.githubusercontent.com/460802/34213919-126d39ac-e5e4-11e7-8615-fdf2b346fce6.png)