### PR TITLE
tests: call forensic to collect the logs when timeout happen during start

### DIFF
--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -163,6 +163,8 @@ class Cluster
         return true if system(env, "make -C ../.. apply | tee ../../build/#{@name}/terraform-apply.log")
       end
     end
+  rescue Timeout::Error
+    forensic
     raise 'Applying cluster failed'
   end
 


### PR DESCRIPTION
When a timeout in RSpec happen during the bootstrap we now collect the logs to analyze later