### PR TITLE
Added cloud provider to addon-operator config

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -96,7 +96,7 @@ variable "tectonic_container_images" {
     tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.8.0"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.5"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
-    kubernetes_addon_operator    = "quay.io/coreos/kubernetes-addon-operator:54a613dae60a068aa83c0361319c804ee366a228"
+    kubernetes_addon_operator    = "quay.io/coreos/kubernetes-addon-operator:4b83569d763dc95e1f61c77b31989fd3957bfc67"
   }
 }
 

--- a/modules/tectonic/resources/manifests/cluster-config.yaml
+++ b/modules/tectonic/resources/manifests/cluster-config.yaml
@@ -35,6 +35,7 @@ data:
       heapsterConfig:
       dnsConfig:
           clusterIP: ${kube_dns_service_ip}
+      cloudProvider: ${platform}
   network-config: |
       apiVersion: v1
       kind: NetworkConfig


### PR DESCRIPTION
Have addon-operator track the cloud provider: CORS-389 
For future addition of adding a default storage class.

Related tectonic-operators PR: https://github.com/coreos-inc/tectonic-operators/pull/148