### PR TITLE
frontend: Hide Start Over button until Terraform step completes

### DIFF
--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -115,7 +115,7 @@ const Wizard = withNav(withRouter(connect(stateToProps)(
 
       const nav = page => this.navigate(currentPage, page);
 
-      const {canNavigateForward} = currentPage.component;
+      const {canNavigateForward, canReset} = currentPage.component;
       const disableNext = canNavigateForward ? !canNavigateForward(state) : false;
 
       return (
@@ -159,7 +159,7 @@ const Wizard = withNav(withRouter(connect(stateToProps)(
                 {currentPage.hidePager || <div className="wiz-form__actions">
                   <div className="wiz-form__actions__prev">
                     {t.previousFrom(currentPage) && <PreviousButton />}
-                    {currentPage.canReset && <ResetButton />}
+                    {canReset && canReset(state) && <ResetButton />}
                   </div>
                   <div className="wiz-form__actions__next">
                     {t.nextFrom(currentPage) && <NextButton disabled={disableNext} />}

--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -27,3 +27,4 @@ export const DryRun = () => <div className="row">
 </div>;
 
 DryRun.canNavigateForward = () => false;
+DryRun.canReset = () => true;

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -407,3 +407,6 @@ TF_PowerOn.canNavigateForward = ({cluster}) => {
 
   return ready;
 };
+
+// Don't allow resetting the wizard until Terraform has completed
+TF_PowerOn.canReset = ({cluster}) => _.get(cluster, 'status.terraform.status', '').toLowerCase() !== 'running';

--- a/installer/frontend/trail.js
+++ b/installer/frontend/trail.js
@@ -51,7 +51,6 @@ const dryRunPage = {
   path: '/define/advanced',
   component: DryRun,
   title: 'Download Assets',
-  canReset: true,
 };
 
 const etcdPage = {
@@ -78,7 +77,6 @@ const TFPowerOnPage = {
   path: '/boot/tf/poweron',
   component: TF_PowerOn,
   title: 'Start Installation',
-  canReset: true,
 };
 
 const usersPage = {


### PR DESCRIPTION
The Start Over button doesn't cancel any Terraform apply / destroy that is currently running, so hide it until the Terraform step completes.