### PR TITLE
frontend: Handle case where cluster state data is not populated

### DIFF
--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -121,6 +121,9 @@ export const getTectonicDomain = (cc) => {
   if (cc[PLATFORM_TYPE] === BARE_METAL_TF) {
     return cc[BM_TECTONIC_DOMAIN];
   }
+  if (!cc[CLUSTER_SUBDOMAIN]) {
+    return;
+  }
   return cc[CLUSTER_SUBDOMAIN] + (cc[CLUSTER_SUBDOMAIN].endsWith('.') ? '' : '.') + getAwsZoneDomain(cc);
 };
 


### PR DESCRIPTION
This happens if the app detects that an installation is already in progress and jumps to the Start Installation page.

Hide the Terraform actions menu and the Tectonic domain since they will not work without the cluster state data. The UI will still allow you to download assets to destroy the cluster manually.