### PR TITLE
frontend: Remove out of date comment

### DIFF
--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -73,7 +73,6 @@ const stateToProps = (state, {history}) => {
 };
 
 // No components have the same path, so this is safe.
-// If a user guesses an invalid URL, they could get in a weird state. Oh well.
 const routes = _.uniq(_.flatMap(trailSections));
 
 const Wizard = withNav(withRouter(connect(stateToProps)(


### PR DESCRIPTION
This should no longer be true. If the user does enter a URL of an
existing page, they will be automatically redirected back to the correct
trail based on the Redux state.