### PR TITLE
tests: set bash as shell and set -o pipefail to return the correct error code

### DIFF
--- a/tests/rspec/lib/cluster.rb
+++ b/tests/rspec/lib/cluster.rb
@@ -160,7 +160,8 @@ class Cluster
         env['TF_LOG'] = 'TRACE' if idx.positive?
         env['TF_APPLY_OPTIONS'] = '-no-color'
         env['TF_INIT_OPTIONS'] = '-no-color'
-        return true if system(env, "make -C ../.. apply | tee ../../build/#{@name}/terraform-apply.log")
+        return true if system(env, "bash -co pipefail 'make -C ../.. apply |
+                                    tee ../../build/#{@name}/terraform-apply.log'")
       end
     end
     raise 'Applying cluster failed'
@@ -173,7 +174,8 @@ class Cluster
         env['TF_LOG'] = 'TRACE' if idx.positive?
         env['TF_DESTROY_OPTIONS'] = '-no-color'
         env['TF_INIT_OPTIONS'] = '-no-color'
-        return true if system(env, "make -C ../.. destroy | tee ../../build/#{@name}/terraform-destroy.log")
+        return true if system(env, "bash -co pipefail 'make -C ../.. destroy |
+                                    tee ../../build/#{@name}/terraform-destroy.log'")
       end
     end
 


### PR DESCRIPTION
when using "command 1 | tee bla.log" if the command 1 fails it will return always 0 if tee did not fail. 

using -o pipefail will return the correct error code.

I observed some errors in the tests when the terraform fail but the execution continues. using this it will not continue and fail properly.
