### PR TITLE
remove vanilla kube and self hosted etcd from govcloud

### DIFF
--- a/examples/terraform.tfvars.govcloud
+++ b/examples/terraform.tfvars.govcloud
@@ -267,8 +267,6 @@ tectonic_govcloud_worker_root_volume_type = "gp2"
 // You can download the Tectonic license file from your Account overview page at [1].
 // 
 // [1] https://account.coreos.com/overview
-// 
-// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_license_path = ""
 
 // The number of master nodes to be created.
@@ -296,8 +294,6 @@ tectonic_master_count = "1"
 // [2] https://coreos.com/os/docs/latest/registry-authentication.html#manual-registry-auth-setup
 // 
 // [3] https://account.coreos.com/overview
-// 
-// Note: This field MUST be set manually prior to creating the cluster unless `tectonic_vanilla_k8s` is set to `true`.
 tectonic_pull_secret_path = ""
 
 // (optional) This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
@@ -308,9 +304,6 @@ tectonic_pull_secret_path = ""
 // Default is 3 years.
 // This setting is ignored if user provided certificates are used.
 tectonic_tls_validity_period = "26280"
-
-// If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
-tectonic_vanilla_k8s = false
 
 // The number of worker nodes to be created.
 // This applies only to cloud platforms.

--- a/modules/dns/powerdns/variables.tf
+++ b/modules/dns/powerdns/variables.tf
@@ -78,17 +78,6 @@ variable "api_ip_addresses" {
   type        = "list"
 }
 
-variable "self_hosted_etcd" {
-  default     = ""
-  description = "See tectonic_self_hosted_etcd in config.tf"
-}
-
-variable "tectonic_vanilla_k8s" {
-  description = <<EOF
-If set to true, a vanilla Kubernetes cluster will be deployed, omitting any Tectonic assets.
-EOF
-}
-
 variable "tectonic_extra_tags" {
   type        = "map"
   description = "(optional) Extra tags to be applied to created resources."

--- a/platforms/govcloud/main.tf
+++ b/platforms/govcloud/main.tf
@@ -118,7 +118,6 @@ module "ignition_masters" {
   kubelet_debug_config      = "${var.tectonic_kubelet_debug_config}"
   kubelet_node_label        = "node-role.kubernetes.io/master"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
-  tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
 }
 
 module "masters" {
@@ -149,7 +148,7 @@ module "masters" {
   ign_rm_assets_path_unit_id           = "${module.ignition_masters.rm_assets_path_unit_id}"
   ign_rm_assets_service_id             = "${module.ignition_masters.rm_assets_service_id}"
   ign_s3_puller_id                     = "${module.ignition_masters.s3_puller_id}"
-  ign_tectonic_path_unit_id            = "${var.tectonic_vanilla_k8s ? "" : module.tectonic.systemd_path_unit_id}"
+  ign_tectonic_path_unit_id            = "${module.tectonic.systemd_path_unit_id}"
   ign_tectonic_service_id              = "${module.tectonic.systemd_service_id}"
   ign_update_ca_certificates_dropin_id = "${module.ignition_masters.update_ca_certificates_dropin_id}"
   image_re                             = "${var.tectonic_image_re}"
@@ -184,7 +183,6 @@ module "ignition_workers" {
   kubelet_debug_config    = "${var.tectonic_kubelet_debug_config}"
   kubelet_node_label      = "node-role.kubernetes.io/node"
   kubelet_node_taints     = ""
-  tectonic_vanilla_k8s    = "${var.tectonic_vanilla_k8s}"
 }
 
 module "workers" {
@@ -245,5 +243,4 @@ module "dns" {
   tectonic_extra_tags            = "${var.tectonic_govcloud_extra_tags}"
   tectonic_private_endpoints     = "${var.tectonic_govcloud_private_endpoints}"
   tectonic_public_endpoints      = "${var.tectonic_govcloud_public_endpoints}"
-  tectonic_vanilla_k8s           = "${var.tectonic_vanilla_k8s}"
 }

--- a/platforms/govcloud/tectonic.tf
+++ b/platforms/govcloud/tectonic.tf
@@ -15,7 +15,6 @@ module "bootkube" {
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
   versions         = "${var.tectonic_versions}"
-  self_hosted_etcd = ""
 
   service_cidr = "${var.tectonic_service_cidr}"
   cluster_cidr = "${var.tectonic_cluster_cidr}"
@@ -86,8 +85,8 @@ module "tectonic" {
   container_base_images = "${var.tectonic_container_base_images}"
   versions              = "${var.tectonic_versions}"
 
-  license_path     = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_license_path)}"
-  pull_secret_path = "${var.tectonic_vanilla_k8s ? "/dev/null" : pathexpand(var.tectonic_pull_secret_path)}"
+  license_path     = "${pathexpand(var.tectonic_license_path)}"
+  pull_secret_path = "${pathexpand(var.tectonic_pull_secret_path)}"
 
   admin_email    = "${var.tectonic_admin_email}"
   admin_password = "${var.tectonic_admin_password}"
@@ -111,7 +110,6 @@ module "tectonic" {
   console_client_id = "tectonic-console"
   kubectl_client_id = "tectonic-kubectl"
   ingress_kind      = "NodePort"
-  self_hosted_etcd  = ""
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
 

--- a/tests/rspec/lib/govcloud_vpc.rb
+++ b/tests/rspec/lib/govcloud_vpc.rb
@@ -46,7 +46,7 @@ class GovcloudVPC
     Dir.chdir('../../contrib/govcloud') do
       succeeded = system(env_variables, 'terraform init')
       raise 'could not init Terraform to create VPC' unless succeeded
-      succeeded = system(env_variables, 'terraform apply')
+      succeeded = system(env_variables, 'terraform apply -auto-approve')
       raise 'could not create vpc with Terraform' unless succeeded
 
       parse_terraform_output


### PR DESCRIPTION
remove obsolete vanilla kubernetes and self hosted etcd variables from govcloud
