### PR TITLE
frontend: Combine some navigation logic

### DIFF
--- a/installer/frontend/app.jsx
+++ b/installer/frontend/app.jsx
@@ -35,16 +35,6 @@ window.reset = () => {
     .then(() => window.location = '/');
 };
 
-export const fixLocation = () => {
-  const state = store.getState();
-  const t = trail(state);
-  const {pathname} = history.location;
-  const fixed = t.fixPath(pathname, state);
-  if (fixed !== pathname) {
-    history.push(fixed);
-  }
-};
-
 store.subscribe(_.debounce(saveState, 5000));
 window.addEventListener('beforeunload', saveState);
 
@@ -88,7 +78,6 @@ const init = () => {
       if (res && res.type === clusterReadyActionTypes.STATUS) {
         setInterval(() => observeClusterStatus(dispatch, store.getState), 10000);
       }
-      fixLocation();
     });
 };
 

--- a/installer/frontend/components/base.jsx
+++ b/installer/frontend/components/base.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Route, Switch, withRouter } from 'react-router-dom';
 
 import { withNav } from '../nav';
-import { sections, trail } from '../trail';
+import { trail, trailSections } from '../trail';
 
 import { Loader } from './loader';
 import { PLATFORM_TYPE } from '../cluster-config';
@@ -13,8 +13,8 @@ import { TectonicGA } from '../tectonic-ga';
 import { Header } from './header';
 import { Footer } from './footer';
 
-const NavSection = ({canNavigateForward, currentPage, navigate, navSections, navTrail, title}) => {
-  const section = _.find(navTrail.sections, s => navSections.includes(s) && s.includes(currentPage));
+const NavSection = ({canNavigateForward, currentPage, navigate, sections, navTrail, title}) => {
+  const section = _.find(navTrail.sections, s => sections.includes(s) && s.includes(currentPage));
   let disabled = false;
 
   return <ul className="wiz-wizard__nav__section">
@@ -65,7 +65,7 @@ const stateToProps = (state, {history}) => {
 };
 
 // No components have the same path, so this is safe.
-const routes = _.uniq(_.flatMap(sections));
+const routes = _.uniq(_.flatMap(trailSections));
 
 const Wizard = withNav(withRouter(connect(stateToProps)(
   class Wizard_ extends React.Component {
@@ -142,15 +142,15 @@ const Wizard = withNav(withRouter(connect(stateToProps)(
                 <NavSection
                   {...navProps}
                   title="1. Choose Cluster Type"
-                  navSections={[sections.choose]} />
+                  sections={[trailSections.choose]} />
                 <NavSection
                   {...navProps}
                   title="2. Define Cluster"
-                  navSections={[sections.defineBaremetal, sections.defineAWS]} />
+                  sections={[trailSections.defineBaremetal, trailSections.defineAWS]} />
                 <NavSection
                   {...navProps}
                   title="3. Boot Cluster"
-                  navSections={[sections.bootBaremetalTF, sections.bootAWSTF, sections.bootDryRun]} />
+                  sections={[trailSections.bootBaremetalTF, trailSections.bootAWSTF, trailSections.bootDryRun]} />
               </div>
               <div className="wiz-wizard__content wiz-wizard__cell">
                 <div className="wiz-form__header">

--- a/installer/frontend/trail.js
+++ b/installer/frontend/trail.js
@@ -171,7 +171,7 @@ const loadingPage = {
   title: 'Tectonic',
 };
 
-export const sections = new Map([
+export const trailSections = new Map([
   ['loading', [
     loadingPage,
   ]],
@@ -215,15 +215,15 @@ export const sections = new Map([
   ]],
 ]);
 
-// Lets us do 'sections.defineAWS' instead of using sections.get('defineAWS')
-sections.forEach((v, k) => {
-  sections[k] = v;
+// Lets us do 'trailSections.defineAWS' instead of using trailSections.get('defineAWS')
+trailSections.forEach((v, k) => {
+  trailSections[k] = v;
 });
 
 // A Trail is an immutable representation of the navigation options available to a user.
 export class Trail {
-  constructor(trailSections, whitelist) {
-    this.sections = trailSections;
+  constructor(sections, whitelist) {
+    this.sections = sections;
     const sectionPages = this.sections.reduce((ls, l) => ls.concat(l), []);
     sectionPages.forEach(p => {
       if (!p.component) {
@@ -252,14 +252,14 @@ const doingStuff = ImmutableSet([commitPhases.REQUESTED, commitPhases.WAITING]);
 
 const platformToSection = {
   [AWS_TF]: {
-    choose: new Trail([sections.choose, sections.defineAWS]),
-    define: new Trail([sections.defineAWS], [submitDefinitionPage]),
-    boot: new Trail([sections.bootAWSTF]),
+    choose: new Trail([trailSections.choose, trailSections.defineAWS]),
+    define: new Trail([trailSections.defineAWS], [submitDefinitionPage]),
+    boot: new Trail([trailSections.bootAWSTF]),
   },
   [BARE_METAL_TF]: {
-    choose: new Trail([sections.choose, sections.defineBaremetal]),
-    define: new Trail([sections.defineBaremetal], [submitDefinitionPage]),
-    boot: new Trail([sections.bootBaremetalTF]),
+    choose: new Trail([trailSections.choose, trailSections.defineBaremetal]),
+    define: new Trail([trailSections.defineBaremetal], [submitDefinitionPage]),
+    boot: new Trail([trailSections.bootBaremetalTF]),
   },
 };
 
@@ -267,10 +267,10 @@ export const trail = ({cluster, clusterConfig, commitState}) => {
   const platform = clusterConfig[PLATFORM_TYPE];
 
   if (platform === '') {
-    return new Trail([sections.loading]);
+    return new Trail([trailSections.loading]);
   }
   if (!isSupported(platform)) {
-    return new Trail([sections.choose]);
+    return new Trail([trailSections.choose]);
   }
 
   const {phase} = commitState;
@@ -279,7 +279,7 @@ export const trail = ({cluster, clusterConfig, commitState}) => {
     // If we detected a dry run in progress when the app started, then clusterConfig will not be populated, so also
     // check for a Terraform "show" (dry run) action
     if (clusterConfig[DRY_RUN] || _.get(cluster, 'status.terraform.action') === 'show') {
-      return new Trail([sections.bootDryRun]);
+      return new Trail([trailSections.bootDryRun]);
     }
     return platformToSection[platform].boot;
   }


### PR DESCRIPTION
Combine some navigation logic that was split between `Trail`, `app.jsx` and `Base`.
- Refactor away `Trail.canNavigateForward()` method.
- Merge `fixLocation()` and `fixPath()` and move to `Base`.
- Remove unused `Trail.cmp()` method.
- Remove unnecessary `Trail.navigable()` method. This was only used by the sidebar and the sidebar should be able to assume that all pages in the current `Trail` section are navigable.