### PR TITLE
bootkube: change cluster config component name.

### DIFF
--- a/modules/bootkube/resources/manifests/cluster-config.yaml
+++ b/modules/bootkube/resources/manifests/cluster-config.yaml
@@ -4,9 +4,9 @@ metadata:
   name: cluster-config-v1
   namespace: kube-system
 data:
-  kvo-config: |
+  kco-config: |
     apiVersion: v1
-    kind: KubeVersionOperatorConfig
+    kind: KubeCoreOperatorConfig
     authConfig:
       oidc_client_id: ${oidc_client_id}
       oidc_issuer_url: ${oidc_issuer_url}


### PR DESCRIPTION
The operator that manages the control plane is going to be called the
KubeCoreOperator, not the KubeVersionOperator.
  