### PR TITLE
config.tf: fix monitoring-grafana quay repo.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -109,7 +109,7 @@ variable "tectonic_container_base_images" {
     config_reload            = "quay.io/coreos/configmap-reload"
     addon_resizer            = "quay.io/coreos/addon-resizer"
     kube_state_metrics       = "quay.io/coreos/kube-state-metrics"
-    grafana                  = "quay.io/coreos/grafana-monitoring"
+    grafana                  = "quay.io/coreos/monitoring-grafana"
     grafana_watcher          = "quay.io/coreos/grafana-watcher"
     prometheus_operator      = "quay.io/coreos/prometheus-operator"
     prometheus_config_reload = "quay.io/coreos/prometheus-config-reloader"

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -13,6 +13,9 @@ data:
       baseImage: ${prometheus_base_image}
     alertmanagerMain:
       baseImage: ${alertmanager_base_image}
+    grafana:
+      baseImage: ${grafana_base_image}
+      grafanaWatcherBaseImage: ${grafana_watcher_base_image}
     ingress:
       baseAddress: ${console_base_host}
     auth:


### PR DESCRIPTION
Also add it to the tectonic-monitoring-config since it was previously
(and mysteriously) unused.