### PR TITLE
frontend: Set the default assets download filename to "assets.zip"

### DIFF
--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -16,7 +16,7 @@ export const DryRun = () => <div className="row">
     </div>
     <div className="from-group">
       <div className="wiz-giant-button-container">
-        <a href="/terraform/assets" download>
+        <a href="/terraform/assets" download="assets.zip">
           <button className="btn btn-primary wiz-giant-button">
             <i className="fa fa-download"></i>&nbsp;&nbsp;Download Assets
           </button>

--- a/installer/frontend/components/success.jsx
+++ b/installer/frontend/components/success.jsx
@@ -18,7 +18,7 @@ export const Success = connect(stateToProps)(
       <div className="col-xs-12">
         <h4>1. Cluster assets are important, save them now!</h4>
         <p>Download and keep your cluster assets in a safe place. These are needed to destroy, replicate or quickly reinstall.</p>
-        <a href="/terraform/assets" download>
+        <a href="/terraform/assets" download="assets.zip">
           <button className="btn btn-default" style={{marginTop: 10}}>
             <i className="fa fa-download"></i>&nbsp;&nbsp;Download Assets
           </button>

--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -337,7 +337,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
                 <Alert severity="error" noIcon>
                   <b>{_.startCase(action)} Failed</b>. Your installation is blocked. To continue:
                   <ol style={{fontSize: 13, paddingLeft: 30, paddingTop: 10, paddingBottom: 10}}>
-                    <li><a onClick={saveLog}>Save Terraform logs</a> and <a href="/terraform/assets" download>download assets</a> for debugging purposes.</li>
+                    <li><a onClick={saveLog}>Save Terraform logs</a> and <a href="/terraform/assets" download="assets.zip">download assets</a> for debugging purposes.</li>
                     <li>Destroy your cluster to clear anything that may have been created. Or,</li>
                     <li>Reapply Terraform.</li>
                   </ol>
@@ -374,7 +374,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
         {!isTFRunning && !isDestroySuccess &&
           <div className="row">
             <div className="col-xs-12">
-              <a href="/terraform/assets" download>
+              <a href="/terraform/assets" download="assets.zip">
                 <button className={classNames('btn btn-primary wiz-giant-button')}>
                   <i className="fa fa-download"></i>&nbsp;&nbsp;Download Assets
                 </button>


### PR DESCRIPTION
Chrome was already defaulting to `assets.zip`, but Firefox was defaulting to just `assets`.