### PR TITLE
tests: optimize logstash upload script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -504,7 +504,7 @@ def runRSpecTestBareMetal(testFilePath, credentials) {
         archiveArtifacts allowEmptyArchive: true, artifacts: 'build/**/logs/**'
         withCredentials(credentials) {
           sh """#!/bin/bash -xe
-          ./tests/jenkins-jobs/scripts/log-analyzer-copy.sh baremetal-smoke-test-logs ${testFilePath}
+          ./tests/jenkins-jobs/scripts/log-analyzer-copy.sh smoke-test-logs ${testFilePath}
            """
          }
         cleanWs notFailBuild: true

--- a/tests/jenkins-jobs/scripts/log-analyzer-copy.sh
+++ b/tests/jenkins-jobs/scripts/log-analyzer-copy.sh
@@ -12,7 +12,7 @@ additionalFields=""
 mkdir -p ${logfile_location}
 cd ${logfile_location}
 
-if [ "$action" = "smoke-test-logs" ] || [ "$action" = "baremetal-smoke-test-logs" ]; then
+if [ "$action" = "smoke-test-logs" ] ; then
   # Checks whether there are any log files
   if ls ../build/*/*.log 1> /dev/null 2>&1; then
     cp ../build/*/*.log .


### PR DESCRIPTION
Remove the 'baremetal-smoke-test-logs' argument, because this makes no sense. The logic of the script stays the same, so we can just use the smoke-test-logs argument. 
