### PR TITLE
Remove region specification in aws basic smoke test

### DIFF
--- a/tests/smoke/aws/vars/aws.tfvars.json
+++ b/tests/smoke/aws/vars/aws.tfvars.json
@@ -6,7 +6,6 @@
   "tectonic_aws_master_root_volume_size": 15,
   "tectonic_aws_master_root_volume_type": "gp2",
   "tectonic_aws_private_endpoints": false,
-  "tectonic_aws_region": "us-west-1",
   "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
   "tectonic_aws_worker_ec2_type": "m4.large",
   "tectonic_aws_worker_root_volume_size": 15,


### PR DESCRIPTION
@arithx is using the Tectonic installer to test nightly Container Linux
AMIs. They are only present in `us-west-2`.

Terraform lets values in the tfvars file take precedence over
environment variables. To easily configure the regoin for the aws basic
tests, this patch removes the specification. The other smoke test tfvars
files don't have a region specified.

@cpanato @alexsomesan @squat Do you know of a particular reason, why the region is specified here?
