### PR TITLE
Revert "Remove region specification in aws basic smoke test"

### DIFF
--- a/tests/smoke/aws/vars/aws.tfvars.json
+++ b/tests/smoke/aws/vars/aws.tfvars.json
@@ -6,6 +6,7 @@
   "tectonic_aws_master_root_volume_size": 15,
   "tectonic_aws_master_root_volume_type": "gp2",
   "tectonic_aws_private_endpoints": false,
+  "tectonic_aws_region": "us-west-1",
   "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
   "tectonic_aws_worker_ec2_type": "m4.large",
   "tectonic_aws_worker_root_volume_size": 15,


### PR DESCRIPTION
Reverts coreos/tectonic-installer#2694


We use this in the UI tests. I will check if we can skip this verification.