### PR TITLE
tests: ignore was region in the UI tests

### DIFF
--- a/installer/frontend/ui-tests/tests/aws.js
+++ b/installer/frontend/ui-tests/tests/aws.js
@@ -54,6 +54,7 @@ const ignoredKeys = [
   'tectonic_license_path',
   'tectonic_pull_secret_path',
   'tectonic_stats_url',
+  'tectonic_aws_region',
 ];
 
 module.exports = Object.assign(


### PR DESCRIPTION
We remove the harcoded aws region from the tfvars used in one of our tests. however the UI tests check the aws region, and now it is not there. This PR remove the check against aws region