### PR TITLE
modules/tectonic: clean up unused variables.

### DIFF
--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -1,10 +1,3 @@
-locals {
-  calico_config_yaml   = "${var.tectonic_networking == "calico-ipip" ? "calicoConfig:\n    mtu: ${var.calico_mtu}" : ""}"
-  network_config_yaml  = "${join("\n", compact(list(local.network_profile_yaml, local.pod_cidr_yaml, local.calico_config_yaml)))}"
-  network_profile_yaml = "networkProfile: ${var.tectonic_networking}"
-  pod_cidr_yaml        = "${var.tectonic_networking != "none" ? "podCIDR: ${var.cluster_cidr}" : ""}"
-}
-
 # Unique Cluster ID (uuid)
 resource "random_id" "cluster_id" {
   byte_length = 16
@@ -26,7 +19,6 @@ resource "template_dir" "tectonic" {
     tectonic_cluo_operator_image       = "${var.container_images["tectonic_cluo_operator"]}"
     tectonic_alm_operator_image        = "${var.container_images["tectonic_alm_operator"]}"
     tectonic_utility_operator_image    = "${var.container_images["tectonic_utility_operator"]}"
-    tectonic_network_operator_image    = "${var.container_images["tectonic_network_operator"]}"
 
     tectonic_monitoring_auth_base_image = "${var.container_base_images["tectonic_monitoring_auth"]}"
     config_reload_base_image            = "${var.container_base_images["config_reload"]}"
@@ -89,7 +81,6 @@ resource "template_dir" "tectonic" {
     kubectl_secret    = "${random_id.kubectl_secret.b64}"
 
     kube_apiserver_url = "${var.kube_apiserver_url}"
-    oidc_issuer_url    = "https://${var.base_address}/identity"
     stats_url          = "${var.stats_url}"
 
     # TODO: We could also patch https://www.terraform.io/docs/providers/random/ to add an UUID resource.
@@ -102,8 +93,6 @@ resource "template_dir" "tectonic" {
 
     image_re            = "${var.image_re}"
     kube_dns_service_ip = "${cidrhost(var.service_cidr, 10)}"
-
-    network_config = "${indent(6, local.network_config_yaml)}"
   }
 }
 

--- a/modules/tectonic/resources/manifests/cluster-config.yaml
+++ b/modules/tectonic/resources/manifests/cluster-config.yaml
@@ -4,6 +4,13 @@ metadata:
   name: cluster-config-v1
   namespace: tectonic-system
 data:
+  addon-config: |
+      apiVersion: v1
+      kind: AddonConfig
+      heapsterConfig:
+      dnsConfig:
+          clusterIP: ${kube_dns_service_ip}
+      cloudProvider: ${platform}
   utility-config: |
     apiVersion: v1
     kind: UtilityConfig
@@ -29,14 +36,3 @@ data:
       installerPlatform: ${platform}
       kubeAPIserverURL: ${kube_apiserver_url}
       tectonicVersion: ${tectonic_version}
-  addon-config: |
-      apiVersion: v1
-      kind: AddonConfig
-      heapsterConfig:
-      dnsConfig:
-          clusterIP: ${kube_dns_service_ip}
-      cloudProvider: ${platform}
-  network-config: |
-      apiVersion: v1
-      kind: NetworkConfig
-      ${network_config}

--- a/modules/tectonic/variables.tf
+++ b/modules/tectonic/variables.tf
@@ -151,18 +151,3 @@ variable "service_cidr" {
   description = "A CIDR notation IP range from which to assign service cluster IPs"
   type        = "string"
 }
-
-variable "cluster_cidr" {
-  description = "A CIDR notation IP range from which to assign pod IPs"
-  type        = "string"
-}
-
-variable "calico_mtu" {
-  description = "sets the MTU size for workload interfaces and the IP-in-IP tunnel device"
-  type        = "string"
-}
-
-variable "tectonic_networking" {
-  description = "configures the network to be used in the cluster"
-  type        = "string"
-}

--- a/platforms/aws/tectonic.tf
+++ b/platforms/aws/tectonic.tf
@@ -93,10 +93,6 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "1480"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/azure/tectonic.tf
+++ b/platforms/azure/tectonic.tf
@@ -102,8 +102,4 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "1480"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }

--- a/platforms/gcp/tectonic.tf
+++ b/platforms/gcp/tectonic.tf
@@ -107,10 +107,6 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "1440"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/govcloud/tectonic.tf
+++ b/platforms/govcloud/tectonic.tf
@@ -92,10 +92,6 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "1480"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/metal/tectonic.tf
+++ b/platforms/metal/tectonic.tf
@@ -96,10 +96,6 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "${var.tectonic_metal_calico_mtu}"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }
 
 data "archive_file" "assets" {

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -142,10 +142,6 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "1480"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }
 
 module "etcd" {

--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -137,10 +137,6 @@ module "tectonic" {
   stats_url         = "${var.tectonic_stats_url}"
 
   image_re = "${var.tectonic_image_re}"
-
-  tectonic_networking = "${var.tectonic_networking}"
-  calico_mtu          = "1480"
-  cluster_cidr        = "${var.tectonic_cluster_cidr}"
 }
 
 data "archive_file" "assets" {


### PR DESCRIPTION
The tectonic-network-operator ended up in modules/bootkube, so remove
all irrelevant code from modules/tectonic.