### PR TITLE
frontend: Clean up FieldList and fix AWS tags validation

### DIFF
--- a/installer/frontend/components/aws-cluster-info.jsx
+++ b/installer/frontend/components/aws-cluster-info.jsx
@@ -1,11 +1,7 @@
-import { connect } from 'react-redux';
 import React from 'react';
 
 import { ClusterInfo } from './cluster-info';
 import { AWS_Tags, tagsForm } from './aws-tags';
-import { CLUSTER_NAME } from '../cluster-config';
-
-const TagsWithPlaceholder = connect(({clusterConfig}) => ({clusterName: clusterConfig[CLUSTER_NAME] || 'myclustername'}))(({clusterName}) => <AWS_Tags placeholder={`e.g. ${clusterName}`} />);
 
 export const AWS_ClusterInfo = () => <div>
   <ClusterInfo />
@@ -14,10 +10,9 @@ export const AWS_ClusterInfo = () => <div>
       <label htmlFor="tags">AWS Tags</label>
     </div>
     <div className="col-xs-9">
-      <TagsWithPlaceholder />
+      <AWS_Tags />
     </div>
   </div>
-  <tagsForm.Errors />
 </div>;
 
 AWS_ClusterInfo.canNavigateForward = state => tagsForm.canNavigateForward(state) &&

--- a/installer/frontend/ui-tests/pages/clusterInfoPage.js
+++ b/installer/frontend/ui-tests/pages/clusterInfoPage.js
@@ -31,11 +31,24 @@ const clusterInfoPageCommands = {
 
     if (platform === 'aws-tf' && !_.isEmpty(json.awsTags)) {
       this
-        .setField('input[id="awsTags.0.value"]', json.awsTags[0].value)
+        .setField('input[id="awsTags.0.key"]', 'abc')
+        .setField('input[id="awsTags.0.value"]', 'abc')
+        .expectNoValidationError()
+        .setField('input[id="awsTags.0.key"]', '')
         .expectValidationErrorContains('Both fields are required')
-        .setField('input[id="awsTags.0.key"]', json.awsTags[0].key)
+        .setField('input[id="awsTags.0.key"]', 'abc')
+        .expectNoValidationError()
         .setField('input[id="awsTags.0.value"]', '')
         .expectValidationErrorContains('Both fields are required')
+        .setField('input[id="awsTags.0.key"]', '')
+        .expectNoValidationError()
+        .click('.fa-plus-circle')
+        .click('.fa-plus-circle')
+        .setField('input[id="awsTags.1.key"]', 'abc')
+        .setField('input[id="awsTags.2.key"]', 'abc')
+        .expectValidationErrorContains('Tag keys must be unique')
+        .click('.fa-minus-circle')
+        .click('.fa-minus-circle')
         .setField('input[id="awsTags.0.key"]', json.awsTags[0].key)
         .setField('input[id="awsTags.0.value"]', json.awsTags[0].value)
         .expectNoValidationError();


### PR DESCRIPTION
Add `FieldRowList` component, which replaces `ConnectedFieldList` and `InnerFieldList_` and also handles the add and remove buttons.

Greatly simplify `FieldList` class.

This makes the `autoFocus` behavior consistent for the 3 field lists (AWS Tags, BM master nodes, BM worker nodes).

Make `appendField` and `removeField` only available to field lists instead of to any component wrapped by `Connect` because they are only applicable to field lists.

Merge `TagsWithPlaceholder` functionality into `AWS_Tags`.

Also fixes the AWS tags validation:
  - Fixes a bug where the `Tag keys must be unique` error was only displayed if the first tag row contained one of the duplicate values.
  - Allow the `Both fields are required` error to be displayed on either the key input or the value input, rather than just on the value input. This fixes an issue where no error was displayed if the key input was cleared, but the value input was not marked as "dirty".

Add more Nightwatch tests for AWS tags validation.