### PR TITLE
frontend: Fix Google Analytics Next event and clean up Base / Wizard

### DIFF
--- a/installer/frontend/app.jsx
+++ b/installer/frontend/app.jsx
@@ -11,6 +11,7 @@ import createHistory from 'history/createBrowserHistory';
 import Cookie from 'js-cookie';
 
 import { clusterReadyActionTypes, restoreActionTypes, validateAllFields } from './actions';
+import { PLATFORM_TYPE } from './cluster-config';
 import { trail } from './trail';
 import { TectonicGA } from './tectonic-ga';
 import { savable } from './reducer';
@@ -52,9 +53,13 @@ try {
 history.listen(({pathname, state}) => {
   // Process next step / previous step navigation trigger if present
   if (state && (state.next || state.previous)) {
-    const t = trail(store.getState());
+    const storeState = store.getState();
+    const t = trail(storeState);
     const currentPage = t.pageByPath.get(history.location.pathname);
     const nextPage = state.next ? t.nextFrom(currentPage) : t.previousFrom(currentPage);
+    if (state.next) {
+      TectonicGA.sendEvent('Page Navigation Next', 'click', 'next on', storeState.clusterConfig[PLATFORM_TYPE]);
+    }
     history.replace(_.get(nextPage, 'path'));
     return;
   }

--- a/installer/frontend/trail.js
+++ b/installer/frontend/trail.js
@@ -221,7 +221,7 @@ trailSections.forEach((v, k) => {
 });
 
 // A Trail is an immutable representation of the navigation options available to a user.
-export class Trail {
+class Trail {
   constructor(sections, whitelist) {
     this.sections = sections;
     const sectionPages = this.sections.reduce((ls, l) => ls.concat(l), []);


### PR DESCRIPTION
Fix `Page Navigation Next` Google Analytics event.

Clean up `Base`, `Wizard` and `NavSection`.
  - Modify `Wizard` so we don't need the whole state object as a property.
  - Remove `Wizard.navigate()` by moving the `history.push()` action to `NavSection` and moving the Google Analytics event to `app.jsx`.
  - Remove unnecessary `withNav()` wrapper from `Wizard`.