### PR TITLE
frontend: Merge file upload handlers

### DIFF
--- a/installer/frontend/components/cluster-info.jsx
+++ b/installer/frontend/components/cluster-info.jsx
@@ -6,10 +6,9 @@ import { validate } from '../validate';
 import { CLUSTER_NAME, PULL_SECRET, TECTONIC_LICENSE, LICENSING } from '../cluster-config';
 import fields from '../fields';
 import { Field, Form } from '../form';
-import { readFile } from '../readfile';
 
 import { Alert } from './alert';
-import { Connect, Input } from './ui';
+import { Connect, FileInput, Input } from './ui';
 
 // eslint-disable-next-line react/jsx-no-target-blank
 const accountLink = <a href="https://account.coreos.com" rel="noopener" target="_blank">account.coreos.com</a>;
@@ -51,18 +50,6 @@ const pullSecretField = new Field(PULL_SECRET, {
 });
 
 const form = new Form(LICENSING, [fields[CLUSTER_NAME], licenseField, pullSecretField]);
-
-const FileInput = ({id, onValue}) => {
-  const upload = e => {
-    readFile(e.target.files.item(0))
-      .then(onValue)
-      .catch(msg => console.error(msg));
-
-    // Reset value so that onChange fires if you pick the same file again.
-    e.target.value = null;
-  };
-  return <input type="file" id={id} onChange={upload} style={{display: 'none'}} />;
-};
 
 const FileUpload = ({buttonTitle, description, ErrorHelp, field, id, onValue, value}) => {
   const invalid = field.validator(value);

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -186,40 +186,34 @@ export const ToggleButton = props => <button className={props.className} style={
   <i style={{marginLeft: 7}} className={classNames('fa', {'fa-chevron-up': props.value, 'fa-chevron-down': !props.value})}></i>
 </button>;
 
-// A textarea/file-upload combo
-// <FileArea id:REQUIRED invalid="error message" placeholder value onValue>
-export const FileArea = connect(
-  () => ({tag: 'textarea'}),
+export const FileInput = connect(
+  null,
   (dispatch, {id}) => ({makeDirty: () => dispatch(dirtyActions.add(id))}),
-)((props) => {
-  const {onValue, makeDirty, uploadButtonLabel} = props;
-  const handleUpload = (e) => {
+)(({id, makeDirty, onValue}) => {
+  const upload = e => {
     readFile(e.target.files.item(0))
-      .then((value) => {
-        onValue(value);
-      })
-      .catch((msg) => {
-        console.error(msg);
-      })
-      .then(() => {
-        makeDirty();
-      });
+      .then(onValue)
+      .catch(msg => console.error(msg))
+      .then(makeDirty);
+
     // Reset value so that onChange fires if you pick the same file again.
     e.target.value = null;
   };
-
-  return (
-    <div>
-      <label className="btn btn-sm btn-link">
-        <span className="fa fa-upload"></span>&nbsp;&nbsp;{uploadButtonLabel || 'Upload'} {' '}
-        <input style={{display: 'none'}}
-          type="file"
-          onChange={handleUpload} />
-      </label>
-      <Field {...props} />
-    </div>
-  );
+  return <input type="file" id={id} onChange={upload} style={{display: 'none'}} />;
 });
+
+// A textarea/file-upload combo
+// <FileArea id:REQUIRED invalid="error message" placeholder value onValue>
+export const FileArea = props => {
+  const {id, onValue, uploadButtonLabel} = props;
+  return <div>
+    <label className="btn btn-sm btn-link">
+      <span className="fa fa-upload"></span>&nbsp;&nbsp;{uploadButtonLabel || 'Upload'}
+      <FileInput id={id} onValue={onValue} />
+    </label>
+    <Field {...props} tag="textarea" />
+  </div>;
+};
 
 // <Select id:REQUIRED value onValue>
 //   <option....>


### PR DESCRIPTION
Add a new component `FileInput` to extract out the file upload handler logic from `FileArea` and `cluster-info.jsx`.

Also clean up `FileArea` a bit.