### PR TITLE
Pin and add master toleration for tno

### DIFF
--- a/modules/bootkube/resources/manifests/tectonic-network-operator.yaml
+++ b/modules/bootkube/resources/manifests/tectonic-network-operator.yaml
@@ -47,6 +47,12 @@ spec:
           items:
           - key: network-config
             path: network-config
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1


### PR DESCRIPTION
When trying to deploy a single node cluster, bootkube hangs on trying to deploy the controller-manager and the scheduler as the single node is on "not ready" status because no network config. This allows the network operator to run on master, hence node gets "ready" status and the bootstrap process can move forward  