### PR TITLE
Bump the aws provider to 1.6.0

### DIFF
--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -1,7 +1,7 @@
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
   profile = "${var.tectonic_aws_profile}"
-  version = "1.1.0"
+  version = "1.6.0"
 }
 
 data "aws_availability_zones" "azs" {}


### PR DESCRIPTION
The ability to use assumed roles via the aws configuration file is important to us. The terraform aws provider has made this work starting in the 1.3 version - https://github.com/terraform-providers/terraform-provider-aws/pull/1608.

I've tested creating a few clusters with the 1.6.0 version of the provider with no issue. I'm not sure how to better test.

Thanks!