### PR TITLE
Allow manually setting resolved domains to get around AWS DHCP search path issues

### DIFF
--- a/modules/aws/master-asg/ignition.tf
+++ b/modules/aws/master-asg/ignition.tf
@@ -8,6 +8,7 @@ data "ignition_config" "main" {
     "${var.ign_max_user_watches_id}",
     "${var.ign_s3_puller_id}",
     "${var.ign_ca_cert_id_list}",
+    "${var.ign_resolved_domains_id}",
   ]
 
   systemd = ["${compact(list(

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -147,3 +147,7 @@ variable "dns_server_ip" {
   type    = "string"
   default = ""
 }
+
+variable "ign_resolved_domains_id" {
+  type = "string"
+}

--- a/modules/aws/worker-asg/ignition.tf
+++ b/modules/aws/worker-asg/ignition.tf
@@ -5,6 +5,7 @@ data "ignition_config" "main" {
     "${var.ign_max_user_watches_id}",
     "${var.ign_s3_puller_id}",
     "${var.ign_ca_cert_id_list}",
+    "${var.ign_resolved_domains_id}",
   ]
 
   systemd = [

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -91,3 +91,7 @@ variable "dns_server_ip" {
   type    = "string"
   default = ""
 }
+
+variable "ign_resolved_domains_id" {
+  type = "string"
+}

--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -207,3 +207,16 @@ data "ignition_systemd_unit" "iscsi" {
   name    = "iscsid.service"
   enabled = "${var.iscsi_enabled ? true : false}"
 }
+
+data "ignition_file" "resolved_domains_dropin" {
+  filesystem = "root"
+  path       = "/etc/systemd/resolved.conf.d/10-domains.conf"
+  mode       = 0644
+
+  content {
+    content = <<EOF
+[Resolve]
+Domains=${var.resolved_domains}
+EOF
+  }
+}

--- a/modules/ignition/outputs.tf
+++ b/modules/ignition/outputs.tf
@@ -147,3 +147,7 @@ output "etcd_crt_id_list" {
 output "iscsi_service_id" {
   value = "${data.ignition_systemd_unit.iscsi.id}"
 }
+
+output "resolved_domains_dropin_id" {
+  value = "${data.ignition_file.resolved_domains_dropin.id}"
+}

--- a/modules/ignition/variables.tf
+++ b/modules/ignition/variables.tf
@@ -156,3 +156,8 @@ variable "iscsi_enabled" {
   type    = "string"
   default = "false"
 }
+
+variable "resolved_domains" {
+  type    = "string"
+  default = ""
+}

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -118,6 +118,7 @@ module "ignition_masters" {
   kubelet_debug_config      = "${var.tectonic_kubelet_debug_config}"
   kubelet_node_label        = "node-role.kubernetes.io/master"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
+  resolved_domains          = "${var.resolved_domains}"
 }
 
 module "masters" {
@@ -152,6 +153,7 @@ module "masters" {
   ign_tectonic_path_unit_id            = "${module.tectonic.systemd_path_unit_id}"
   ign_tectonic_service_id              = "${module.tectonic.systemd_service_id}"
   ign_update_ca_certificates_dropin_id = "${module.ignition_masters.update_ca_certificates_dropin_id}"
+  ign_resolved_domains_id              = "${module.ignition_masters.resolved_domains_dropin_id}"
   image_re                             = "${var.tectonic_image_re}"
   instance_count                       = "${var.tectonic_master_count}"
   master_iam_role                      = "${var.tectonic_aws_master_iam_role_name}"
@@ -183,6 +185,7 @@ module "ignition_workers" {
   kubelet_debug_config    = "${var.tectonic_kubelet_debug_config}"
   kubelet_node_label      = "node-role.kubernetes.io/node"
   kubelet_node_taints     = ""
+  resolved_domains        = "${var.resolved_domains}"
 }
 
 module "workers" {
@@ -206,6 +209,7 @@ module "workers" {
   ign_max_user_watches_id              = "${module.ignition_workers.max_user_watches_id}"
   ign_s3_puller_id                     = "${module.ignition_workers.s3_puller_id}"
   ign_update_ca_certificates_dropin_id = "${module.ignition_workers.update_ca_certificates_dropin_id}"
+  ign_resolved_domains_id              = "${module.ignition_workers.resolved_domains_dropin_id}"
   instance_count                       = "${var.tectonic_worker_count}"
   load_balancers                       = "${var.tectonic_aws_worker_load_balancers}"
   root_volume_iops                     = "${var.tectonic_aws_worker_root_volume_iops}"

--- a/platforms/aws/variables.tf
+++ b/platforms/aws/variables.tf
@@ -345,3 +345,8 @@ Example:
  * `["ingress-nginx"]`
 EOF
 }
+
+variable "resolved_domains" {
+  type    = "string"
+  default = ""
+}


### PR DESCRIPTION
Hi, we're running into an issue where we use multiple space separated domain names in our AWS dhcp option set for the VPC we've been installing tectonic into. One of the domain names in the search path is the AWS default, but we're running into this "bug" https://github.com/coreos/bugs/issues/1934. This causes the required default DNS resolution needed by tectonic in AWS to not work.

Hopefully this PR can start a conversation. I'm not completely sure what the best way to generalize the ability to add additional domains to /etc/resolv.conf would be. This approach is working in my testing. It seems to behave as I would expect when the domains string is empty. We would set the region appropriate "us-west-2.compute.internal" domain in "resolved_domains" to make tectonic work in our VPC where dhcp isn't setting the right dns search path. The patch we're currently using in our installer is here - https://github.com/roverdotcom/tectonic-installer/pull/1/files

Does it seem reasonable to include something like this in the installer? If so, I'd be glad to help with a better PR if there are other ideas for generalizing the ability to set custom domain names in the search path.

Thanks!