### PR TITLE
aws: remove ecr permissions

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -141,19 +141,6 @@ resource "aws_iam_role_policy" "master_policy" {
       "Effect": "Allow"
     },
     {
-      "Action": [
-        "ecr:GetAuthorizationToken",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:GetRepositoryPolicy",
-        "ecr:DescribeRepositories",
-        "ecr:ListImages",
-        "ecr:BatchGetImage"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
       "Action" : [
         "s3:GetObject",
         "s3:HeadObject",

--- a/modules/aws/worker-asg/worker.tf
+++ b/modules/aws/worker-asg/worker.tf
@@ -155,19 +155,6 @@ resource "aws_iam_role_policy" "worker_policy" {
       "Effect": "Allow"
     },
     {
-      "Action": [
-        "ecr:GetAuthorizationToken",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:GetRepositoryPolicy",
-        "ecr:DescribeRepositories",
-        "ecr:ListImages",
-        "ecr:BatchGetImage"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
       "Action" : [
         "s3:GetObject"
       ],

--- a/modules/govcloud/etcd/nodes.tf
+++ b/modules/govcloud/etcd/nodes.tf
@@ -87,15 +87,6 @@ resource "aws_iam_role_policy" "etcd" {
       "Resource": "*"
     },
     {
-      "Action": [
-        "ecr:DescribeRepositories",
-        "ecr:ListImages",
-        "ecr:BatchGetImage"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
       "Action" : [
         "s3:GetObject"
       ],

--- a/modules/govcloud/master-asg/master.tf
+++ b/modules/govcloud/master-asg/master.tf
@@ -141,19 +141,6 @@ resource "aws_iam_role_policy" "master_policy" {
       "Effect": "Allow"
     },
     {
-      "Action": [
-        "ecr:GetAuthorizationToken",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:GetRepositoryPolicy",
-        "ecr:DescribeRepositories",
-        "ecr:ListImages",
-        "ecr:BatchGetImage"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
       "Action" : [
         "s3:GetObject",
         "s3:HeadObject",

--- a/modules/govcloud/worker-asg/worker.tf
+++ b/modules/govcloud/worker-asg/worker.tf
@@ -155,19 +155,6 @@ resource "aws_iam_role_policy" "worker_policy" {
       "Effect": "Allow"
     },
     {
-      "Action": [
-        "ecr:GetAuthorizationToken",
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:GetRepositoryPolicy",
-        "ecr:DescribeRepositories",
-        "ecr:ListImages",
-        "ecr:BatchGetImage"
-      ],
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
       "Action" : [
         "s3:GetObject"
       ],


### PR DESCRIPTION
Fixes: https://jira.coreos.com/browse/INST-773

If the end-user need ecr permission, he can create the role/policy and attach to in the bootstrap.