### PR TITLE
Fix example generator rules for openstand + vendored deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,7 +41,7 @@ genrule(
     cmd = "cp $(<) $(@)",
 )
 
-PLATFORMS = ["aws", "azure", "gcp", "govcloud", "metal", "openstack", "vmware"]
+PLATFORMS = ["aws", "azure", "gcp", "govcloud", "metal", "openstack/neutron", "vmware"]
 
 [genrule(
     name = "examples_" + platform,

--- a/contrib/terraform-examples/BUILD.bazel
+++ b/contrib/terraform-examples/BUILD.bazel
@@ -6,9 +6,9 @@ go_library(
     importpath = "github.com/coreos/tectonic-installer/contrib/terraform-examples",
     visibility = ["//visibility:private"],
     deps = [
-        "//vendor/github.com/hashicorp/hcl:go_default_library",
-        "//vendor/github.com/hashicorp/hcl/hcl/ast:go_default_library",
-        "//vendor/github.com/hashicorp/hcl/hcl/token:go_default_library",
+        "//installer/vendor/github.com/hashicorp/hcl:go_default_library",
+        "//installer/vendor/github.com/hashicorp/hcl/hcl/ast:go_default_library",
+        "//installer/vendor/github.com/hashicorp/hcl/hcl/token:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This hand-tweaks the paths to dependencies for the Gazelle generated build files.
What we should really do is unify the vendored packages under a single vendor folder at the top of the repo.