### PR TITLE
bazel: create tarball target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -102,3 +102,83 @@ alias(
     name = "backend",
     actual = "//installer/cmd/installer:installer",
 )
+
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+# We use a genrule here to combine the tarballs rather than a pkg_tar
+# because we want to be able to optionally add a version string to the
+# directory name and pkg_tar does not allow for formatted names.
+genrule(
+    name = "tarball",
+    srcs = [
+        # Cross compiling to darwin using goos is currently broken.
+        # Instead we can cross compile ad hoc on the terminal
+        # by explicitly setting the toolchain: https://github.com/bazelbuild/rules_go/issues/1148
+        #":tarball_installer_binary_darwin",
+        ":tarball_installer_binary_linux",
+        ":tarball_terraform_configuration",
+        ":tarball_terraform_binary_darwin",
+        ":tarball_terraform_binary_linux",
+        ":tarball_terraform_provider_matchbox_darwin",
+        ":tarball_terraform_provider_matchbox_linux",
+    ],
+    outs = ["tectonic.tar.gz"],
+    cmd = '\n'.join([
+            "VERSION=$${VERSION:-}",
+            "DIR=tectonic",
+            "[ ! -z $$VERSION ] && DIR=\"$$DIR\"_\"$$VERSION\"",
+            "for s in $(SRCS); do",
+                "tar --extract --file $$s --transform s,^,./$$DIR/,",
+            "done",
+            "tar --create --gzip --file $@ $$DIR"
+    ]),
+    output_to_bindir = 1,
+)
+
+pkg_tar(
+    name = "tarball_terraform_configuration",
+    mode = "0644",
+    srcs = ["config.tf", "modules", "platforms"],
+)
+
+pkg_tar(
+    name = "tarball_installer_binary_darwin",
+    mode = "0755",
+    package_dir = "tectonic-installer/darwin",
+    srcs = ["//installer/cmd/installer:installer_darwin"],
+)
+
+pkg_tar(
+    name = "tarball_installer_binary_linux",
+    mode = "0755",
+    package_dir = "tectonic-installer/linux",
+    srcs = ["//installer/cmd/installer:installer_linux"],
+)
+
+pkg_tar(
+    name = "tarball_terraform_binary_darwin",
+    mode = "0755",
+    package_dir = "tectonic-installer/darwin",
+    srcs = ["@terraform_runtime_darwin//:terraform"],
+)
+
+pkg_tar(
+    name = "tarball_terraform_binary_linux",
+    mode = "0755",
+    package_dir = "tectonic-installer/linux",
+    srcs = ["@terraform_runtime_linux//:terraform"],
+)
+
+pkg_tar(
+    name = "tarball_terraform_provider_matchbox_darwin",
+    mode = "0755",
+    package_dir = "tectonic-installer/darwin",
+    srcs = ["@terraform_provider_matchbox_darwin//:terraform-provider-matchbox"],
+)
+
+pkg_tar(
+    name = "tarball_terraform_provider_matchbox_linux",
+    mode = "0755",
+    package_dir = "tectonic-installer/linux",
+    srcs = ["@terraform_provider_matchbox_linux//:terraform-provider-matchbox"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,10 +9,13 @@ supported_platforms = [
     "darwin",
 ]
 
-http_archive(
+# Latest working commit for cross compilation [0] until fix [1] lands.
+# [0] https://github.com/bazelbuild/rules_go/issues/1240#issuecomment-357789209
+# [1] https://github.com/bazelbuild/rules_go/pull/1248
+git_repository(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.8.1/rules_go-0.8.1.tar.gz",
-    sha256 = "90bb270d0a92ed5c83558b2797346917c46547f6f7103e648941ecdb6b9d0e72",
+    remote = "https://github.com/bazelbuild/rules_go.git",
+    commit = "3f38260eda98d23e9142bb905caede5912508770"
 )
 
 http_archive(

--- a/installer/cmd/installer/BUILD.bazel
+++ b/installer/cmd/installer/BUILD.bazel
@@ -21,4 +21,29 @@ go_binary(
     embed = [":go_default_library"],
     importpath = "github.com/coreos/tectonic-installer/installer/cmd/installer",
     visibility = ["//visibility:public"],
+    # Use pure to build a pure-go binary.
+    # This has the nice side effect of making the binary statically linked.
+    pure = "on",
+)
+
+go_binary(
+    name = "installer_darwin",
+    embed = [":go_default_library"],
+    importpath = "github.com/coreos/tectonic-installer/installer/cmd/installer",
+    visibility = ["//visibility:public"],
+    # Use pure to build a pure-go binary.
+    # This has the nice side effect of making the binary statically linked.
+    pure = "on",
+    goos = "darwin",
+)
+
+go_binary(
+    name = "installer_linux",
+    embed = [":go_default_library"],
+    importpath = "github.com/coreos/tectonic-installer/installer/cmd/installer",
+    visibility = ["//visibility:public"],
+    # Use pure to build a pure-go binary.
+    # This has the nice side effect of making the binary statically linked.
+    pure = "on",
+    goos = "linux",
 )


### PR DESCRIPTION
This commit adds tarball targets for Bazel.

We can now create tarballs using:

```sh
bazel build tarball
```

This will create a gzip compressed tarball named tectonic.tar.gz. The
contents of the tarball will be nested in a directory named `tectonic`.

To create a tarball with a version string in the directory name, we can
build the tarball using:

```sh
export VERSION=<some version>
bazel build tarball --action_env=VERSION
```

In this case, the file structure will be nested in a directory called
`tectonic_<some version>`.

This commit also makes the installer binaries pure go so that they are
statically linked, which is nicer for containers.

cc @alexsomesan 