### PR TITLE
platforms/metal: fix iscsi variable in Matchbox templates

### DIFF
--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -52,7 +52,7 @@ systemd:
       contents: {{.ign_tectonic_service_json}}
 {{end}}
     - name: iscsid.service
-      enable: {{.iscsi.enabled}}
+      enable: {{.iscsi_enabled}}
 storage:
   files:
     - path: /etc/hostname

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -33,7 +33,7 @@ systemd:
         - name: 10-alwaysrun.conf
           contents: {{.ign_update_ca_certificates_dropin_json}}
     - name: iscsid.service
-      enable: {{.iscsi.enabled}}
+      enable: {{.iscsi_enabled}}
 
 storage:
   files:


### PR DESCRIPTION
cherry pick from https://github.com/coreos/tectonic-installer/pull/2748
