### PR TITLE
frontend: Remove 10 master nodes limit

### DIFF
--- a/installer/frontend/components/bm-nodeforms.jsx
+++ b/installer/frontend/components/bm-nodeforms.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 
 import { configActions, dirtyActions } from '../actions';
 import { Alert } from './alert';
+import { MAX_MASTERS, MAX_WORKERS } from './nodes';
 import { validate } from '../validate';
 import { readFile } from '../readfile';
 import { FieldList, Form } from '../form';
@@ -299,7 +300,7 @@ class NodeForm extends React.Component {
   }
 }
 
-const mastersFields = generateField(BM_MASTERS, 'Master', 9);
+const mastersFields = generateField(BM_MASTERS, 'Master', MAX_MASTERS);
 const mastersForm = new Form('MASTERSFORM', [mastersFields]);
 
 export const BM_Controllers = () => <NodeForm
@@ -311,7 +312,7 @@ export const BM_Controllers = () => <NodeForm
 
 BM_Controllers.canNavigateForward = mastersForm.canNavigateForward;
 
-const workerFields = generateField(BM_WORKERS, 'Worker', 1000);
+const workerFields = generateField(BM_WORKERS, 'Worker', MAX_WORKERS);
 const workersForm = new Form('WORKERS_FORM', [workerFields]);
 
 export const BM_Workers = () => <NodeForm

--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -105,8 +105,8 @@ export const DefineNode = ({type, max, withIamRole = true}) => <div>
   <Errors type={type} />
 </div>;
 
-const MAX_MASTERS = 10;
-const MAX_WORKERS = 1000;
+export const MAX_MASTERS = 100;
+export const MAX_WORKERS = 1000;
 
 const etcdForm = new Form('etcdForm', [
   new Field(ETCD_OPTION, {default: ETCD_OPTIONS.PROVISIONED}),

--- a/installer/frontend/ui-tests/pages/nodesPage.js
+++ b/installer/frontend/ui-tests/pages/nodesPage.js
@@ -22,7 +22,7 @@ const nodesPageCommands = {
         .setField(field, value);
     };
 
-    testInstanceCount('@mastersCount', json['aws_controllers-numberOfInstances'], 10);
+    testInstanceCount('@mastersCount', json['aws_controllers-numberOfInstances'], 100);
     testInstanceCount('@workersCount', json['aws_workers-numberOfInstances'], 1000);
     testInstanceCount('@etcdCount', json['aws_etcds-numberOfInstances'], 9);
 


### PR DESCRIPTION
Leave a limit of 100 in place just as a sanity check.

Also fixes bare metal to use the same limit as AWS (was 9 for metal and 10 for AWS).