### PR TITLE
platforms/*: Fix variable duplication

### DIFF
--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -88,8 +88,6 @@ module "etcd" {
   subnets                    = "${module.vpc.worker_subnet_ids}"
   tls_enabled                = "${var.tectonic_etcd_tls_enabled}"
   etcd_iam_role              = "${var.tectonic_aws_etcd_iam_role_name}"
-  ign_profile_env_id         = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "ignition_masters" {
@@ -127,9 +125,6 @@ module "ignition_masters" {
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
   no_proxy                  = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
-  http_proxy                = "${var.tectonic_http_proxy_address}"
-  https_proxy               = "${var.tectonic_https_proxy_address}"
-  no_proxy                  = "${var.tectonic_no_proxy}"
 }
 
 module "masters" {
@@ -178,8 +173,6 @@ module "masters" {
   s3_bucket                            = "${aws_s3_bucket.tectonic.bucket}"
   ssh_key                              = "${var.tectonic_aws_ssh_key}"
   subnet_ids                           = "${module.vpc.master_subnet_ids}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "ignition_workers" {
@@ -204,9 +197,6 @@ module "ignition_workers" {
   kubelet_node_taints     = ""
   no_proxy                = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s    = "${var.tectonic_vanilla_k8s}"
-  http_proxy              = "${var.tectonic_http_proxy_address}"
-  https_proxy             = "${var.tectonic_https_proxy_address}"
-  no_proxy                = "${var.tectonic_no_proxy}"
 }
 
 module "workers" {
@@ -243,8 +233,6 @@ module "workers" {
   subnet_ids                           = "${module.vpc.worker_subnet_ids}"
   vpc_id                               = "${module.vpc.vpc_id}"
   worker_iam_role                      = "${var.tectonic_aws_worker_iam_role_name}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.systemd_default_env_id : ""}"
 }
 
 module "dns" {

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -78,8 +78,6 @@ module "etcd" {
   tls_enabled                = "${var.tectonic_etcd_tls_enabled}"
   versions                   = "${var.tectonic_versions}"
   vm_size                    = "${var.tectonic_azure_etcd_vm_size}"
-  ign_profile_env_id         = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 # Workaround for https://github.com/hashicorp/terraform/issues/4084
@@ -138,9 +136,6 @@ module "ignition_masters" {
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
   no_proxy                  = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
-  http_proxy                = "${var.tectonic_http_proxy_address}"
-  https_proxy               = "${var.tectonic_https_proxy_address}"
-  no_proxy                  = "${var.tectonic_no_proxy}"
 }
 
 module "masters" {
@@ -180,8 +175,6 @@ module "masters" {
   storage_id                           = "${module.resource_group.storage_id}"
   storage_type                         = "${var.tectonic_azure_master_storage_type}"
   vm_size                              = "${var.tectonic_azure_master_vm_size}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "ignition_workers" {
@@ -206,9 +199,6 @@ module "ignition_workers" {
   kubelet_node_taints     = ""
   no_proxy                = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s    = "${var.tectonic_vanilla_k8s}"
-  http_proxy              = "${var.tectonic_http_proxy_address}"
-  https_proxy             = "${var.tectonic_https_proxy_address}"
-  no_proxy                = "${var.tectonic_no_proxy}"
 }
 
 module "workers" {
@@ -245,8 +235,6 @@ module "workers" {
   tectonic_kube_dns_service_ip         = "${module.bootkube.kube_dns_service_ip}"
   vm_size                              = "${var.tectonic_azure_worker_vm_size}"
   worker_count                         = "${var.tectonic_worker_count}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.systemd_default_env_id : ""}"
 }
 
 module "dns" {

--- a/platforms/gcp/main.tf
+++ b/platforms/gcp/main.tf
@@ -61,8 +61,6 @@ module "etcd" {
   public_ssh_key             = "${var.tectonic_gcp_ssh_key}"
   tls_enabled                = "${var.tectonic_etcd_tls_enabled}"
   zone_list                  = "${data.google_compute_zones.available.names}"
-  ign_profile_env_id         = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "masters" {
@@ -113,8 +111,6 @@ module "masters" {
   master_targetpool_self_link          = "${module.network.master_targetpool_self_link}"
   public_ssh_key                       = "${var.tectonic_gcp_ssh_key}"
   region                               = "${var.tectonic_gcp_region}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "workers" {
@@ -144,8 +140,6 @@ module "workers" {
   region                               = "${var.tectonic_gcp_region}"
   worker_subnetwork_name               = "${module.network.worker_subnetwork_name}"
   worker_targetpool_self_link          = "${module.network.worker_targetpool_self_link}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.systemd_default_env_id : ""}"
 }
 
 module "ignition_masters" {
@@ -180,9 +174,6 @@ module "ignition_masters" {
   custom_ca_cert_pem_list   = "${var.tectonic_custom_ca_pem_list}"
   etcd_ca_cert_pem          = "${module.etcd_certs.etcd_ca_crt_pem}"
   ingress_ca_cert_pem       = "${module.ingress_certs.ca_cert_pem}"
-  http_proxy                = "${var.tectonic_http_proxy_address}"
-  https_proxy               = "${var.tectonic_https_proxy_address}"
-  no_proxy                  = "${var.tectonic_no_proxy}"
 }
 
 module "ignition_workers" {
@@ -206,9 +197,6 @@ module "ignition_workers" {
   custom_ca_cert_pem_list = "${var.tectonic_custom_ca_pem_list}"
   etcd_ca_cert_pem        = "${module.etcd_certs.etcd_ca_crt_pem}"
   ingress_ca_cert_pem     = "${module.ingress_certs.ca_cert_pem}"
-  http_proxy              = "${var.tectonic_http_proxy_address}"
-  https_proxy             = "${var.tectonic_https_proxy_address}"
-  no_proxy                = "${var.tectonic_no_proxy}"
 }
 
 module "dns" {

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -51,9 +51,6 @@ module "ignition_masters" {
   no_proxy                  = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
   use_metadata              = false
-  http_proxy                = "${var.tectonic_http_proxy_address}"
-  https_proxy               = "${var.tectonic_https_proxy_address}"
-  no_proxy                  = "${var.tectonic_no_proxy}"
 }
 
 resource "matchbox_group" "controller" {
@@ -88,8 +85,6 @@ resource "matchbox_group" "controller" {
     ign_tectonic_path_unit_json            = "${jsonencode(module.tectonic.systemd_path_unit_rendered)}"
     ign_tectonic_service_json              = "${jsonencode(module.tectonic.systemd_service_rendered)}"
     ign_update_ca_certificates_dropin_json = "${jsonencode(module.ignition_masters.update_ca_certificates_dropin_rendered)}"
-    ign_profile_env_json                   = "${local.tectonic_http_proxy_enabled ? jsonencode(module.ignition_masters.profile_env_rendered) : ""}"
-    ign_systemd_default_env_json           = "${local.tectonic_http_proxy_enabled ? jsonencode(module.ignition_masters.systemd_default_env_rendered) : ""}"
   }
 }
 
@@ -113,9 +108,6 @@ module "ignition_workers" {
   kubelet_node_taints     = ""
   no_proxy                = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s    = "${var.tectonic_vanilla_k8s}"
-  http_proxy              = "${var.tectonic_http_proxy_address}"
-  https_proxy             = "${var.tectonic_https_proxy_address}"
-  no_proxy                = "${var.tectonic_no_proxy}"
 }
 
 resource "matchbox_group" "worker" {
@@ -148,7 +140,5 @@ resource "matchbox_group" "worker" {
     ign_profile_env_json                   = "${local.tectonic_http_proxy_enabled ? jsonencode(module.ignition_workers.profile_env_rendered) : ""}"
     ign_systemd_default_env_json           = "${local.tectonic_http_proxy_enabled ? jsonencode(module.ignition_workers.systemd_default_env_rendered) : ""}"
     ign_update_ca_certificates_dropin_json = "${jsonencode(module.ignition_workers.update_ca_certificates_dropin_rendered)}"
-    ign_profile_env_json                   = "${local.tectonic_http_proxy_enabled ? jsonencode(module.ignition_workers.profile_env_rendered) : ""}"
-    ign_systemd_default_env_json           = "${local.tectonic_http_proxy_enabled ? jsonencode(module.ignition_workers.systemd_default_env_rendered) : ""}"
   }
 }

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -164,8 +164,6 @@ EOF
   instance_count                = "${var.tectonic_etcd_count}"
   self_hosted_etcd              = "${var.tectonic_self_hosted_etcd}"
   tls_enabled                   = "${var.tectonic_etcd_tls_enabled}"
-  ign_profile_env_id            = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id    = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "ignition_masters" {
@@ -201,9 +199,6 @@ module "ignition_masters" {
   metadata_provider         = "openstack-metadata"
   no_proxy                  = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
-  http_proxy                = "${var.tectonic_http_proxy_address}"
-  https_proxy               = "${var.tectonic_https_proxy_address}"
-  no_proxy                  = "${var.tectonic_no_proxy}"
 }
 
 module "master_nodes" {
@@ -235,8 +230,6 @@ EOF
   ign_update_ca_certificates_dropin_id = "${module.ignition_masters.update_ca_certificates_dropin_id}"
   instance_count                       = "${var.tectonic_master_count}"
   kubeconfig_content                   = "${module.bootkube.kubeconfig}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_masters.systemd_default_env_id : ""}"
 }
 
 module "ignition_workers" {
@@ -259,9 +252,6 @@ module "ignition_workers" {
   kubelet_node_taints     = ""
   no_proxy                = "${var.tectonic_no_proxy}"
   tectonic_vanilla_k8s    = "${var.tectonic_vanilla_k8s}"
-  http_proxy              = "${var.tectonic_http_proxy_address}"
-  https_proxy             = "${var.tectonic_https_proxy_address}"
-  no_proxy                = "${var.tectonic_no_proxy}"
 }
 
 module "worker_nodes" {
@@ -289,8 +279,6 @@ EOF
   ign_update_ca_certificates_dropin_id = "${module.ignition_workers.update_ca_certificates_dropin_id}"
   instance_count                       = "${var.tectonic_worker_count}"
   kubeconfig_content                   = "${module.bootkube.kubeconfig}"
-  ign_profile_env_id                   = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.profile_env_id : ""}"
-  ign_systemd_default_env_id           = "${local.tectonic_http_proxy_enabled ? module.ignition_workers.systemd_default_env_id : ""}"
 }
 
 module "secrets" {


### PR DESCRIPTION
An old commit got overlaid during a rebase (I think) which caused proxy variables to be duplicated.  This fixes that.

@kalmog 
