### PR TITLE
Inject kubeconfig file from ignition

### DIFF
--- a/modules/aws/master-asg/ignition_s3.tf
+++ b/modules/aws/master-asg/ignition_s3.tf
@@ -18,7 +18,19 @@ data "aws_region" "region" {
 }
 
 data "ignition_config" "s3" {
-  replace {
+  append {
     source = "http://${var.cluster_name}-ncg.${var.base_domain}/ignition?profile=controller"
+  }
+
+  files = ["${data.ignition_file.kubeconfig.id}"]
+}
+
+data "ignition_file" "kubeconfig" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/kubeconfig"
+  mode       = 0644
+
+  content {
+    content = "${var.kubeconfig_content}"
   }
 }

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -147,3 +147,8 @@ variable "dns_server_ip" {
   type    = "string"
   default = ""
 }
+
+variable "kubeconfig_content" {
+  type    = "string"
+  default = ""
+}

--- a/modules/aws/worker-asg/ignition_s3.tf
+++ b/modules/aws/worker-asg/ignition_s3.tf
@@ -1,5 +1,17 @@
 data "ignition_config" "s3" {
-  replace {
+  append {
     source = "${format("http://${var.cluster_name}-ncg.tectonic.kuwit.rocks/%s?profile=worker", "ignition")}"
+  }
+
+  files = ["${data.ignition_file.kubeconfig.id}"]
+}
+
+data "ignition_file" "kubeconfig" {
+  filesystem = "root"
+  path       = "/etc/kubernetes/kubeconfig"
+  mode       = 0644
+
+  content {
+    content = "${var.kubeconfig_content}"
   }
 }

--- a/modules/aws/worker-asg/variables.tf
+++ b/modules/aws/worker-asg/variables.tf
@@ -91,3 +91,8 @@ variable "dns_server_ip" {
   type    = "string"
   default = ""
 }
+
+variable "kubeconfig_content" {
+  type    = "string"
+  default = ""
+}

--- a/modules/ignition/resources/services/kubelet.service
+++ b/modules/ignition/resources/services/kubelet.service
@@ -16,7 +16,6 @@ ExecStartPre=/bin/mkdir -p /srv/kubernetes/manifests
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/checkpoint-secrets
 ExecStartPre=/bin/mkdir -p /etc/kubernetes/cni/net.d
 ExecStartPre=/bin/mkdir -p /var/lib/cni
-${kubeconfig_fetch_cmd}
 ExecStartPre=/usr/bin/bash -c "grep 'certificate-authority-data' /etc/kubernetes/kubeconfig | awk '{print $2}' | base64 -d > /etc/kubernetes/ca.crt"
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
 

--- a/platforms/aws/main.tf
+++ b/platforms/aws/main.tf
@@ -171,6 +171,7 @@ module "masters" {
   s3_bucket                            = "${aws_s3_bucket.tectonic.bucket}"
   ssh_key                              = "${var.tectonic_aws_ssh_key}"
   subnet_ids                           = "${module.vpc.master_subnet_ids}"
+  kubeconfig_content                   = "${module.bootkube.kubeconfig}"
 }
 
 module "ignition_workers" {
@@ -229,6 +230,7 @@ module "workers" {
   subnet_ids                           = "${module.vpc.worker_subnet_ids}"
   vpc_id                               = "${module.vpc.vpc_id}"
   worker_iam_role                      = "${var.tectonic_aws_worker_iam_role_name}"
+  kubeconfig_content                   = "${module.bootkube.kubeconfig}"
 }
 
 module "dns" {


### PR DESCRIPTION
I was pulling the kubeconfig through s3 with a hacked domain into the ncg kubelet service.
Let's do this for now so we can collaborate.
This auth should be handled by TLS bootstrapping and bootstrap tokens eventually
