### PR TITLE
*: bump Tectonic Monitoring to v1.9.1

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -95,7 +95,7 @@ variable "tectonic_container_images" {
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.6.2"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.0"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.1"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.5"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
     tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:0.2.1"
@@ -118,6 +118,7 @@ variable "tectonic_container_base_images" {
     prometheus               = "quay.io/prometheus/prometheus"
     alertmanager             = "quay.io/prometheus/alertmanager"
     node_exporter            = "quay.io/prometheus/node-exporter"
+    kube_rbac_proxy          = "quay.io/brancz/kube-rbac-proxy"
   }
 }
 
@@ -128,7 +129,7 @@ variable "tectonic_versions" {
   default = {
     etcd          = "3.1.8"
     kubernetes    = "1.8.4+tectonic.2"
-    monitoring    = "1.9.0"
+    monitoring    = "1.9.1"
     tectonic      = "1.8.4-tectonic.3"
     tectonic-etcd = "0.0.1"
     cluo          = "0.2.5"

--- a/modules/tectonic/assets.tf
+++ b/modules/tectonic/assets.tf
@@ -37,6 +37,7 @@ resource "template_dir" "tectonic" {
     node_exporter_base_image            = "${var.container_base_images["node_exporter"]}"
     grafana_base_image                  = "${var.container_base_images["grafana"]}"
     grafana_watcher_base_image          = "${var.container_base_images["grafana_watcher"]}"
+    kube_rbac_proxy_base_image          = "${var.container_base_images["kube_rbac_proxy"]}"
 
     kubernetes_version             = "${var.versions["kubernetes"]}"
     monitoring_version             = "${var.versions["monitoring"]}"

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -22,3 +22,9 @@ data:
     kubeStateMetrics:
       baseImage: ${kube_state_metrics_base_image}
       addonResizerBaseImage: ${addon_resizer_base_image}
+    grafana:
+      baseImage: ${grafana_base_image}
+      grafanaWatcherBaseImage: ${grafana_watcher_base_image}
+    kubeRbacProxy:
+      baseImage: ${kube_rbac_proxy_base_image}
+


### PR DESCRIPTION
This bumps Tectonic Monitoring to `v1.9.1`.

This is primarily important to land in track-1 for the Lithium release. For track-2 this can be handled next week.

@alexsomesan @sym3tri 

/cc @ant31 @pst @sichvoge 