### PR TITLE
Explicitly set `kubelet-preferred-address-types` flag for apiserver

### DIFF
--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -28,6 +28,7 @@ spec:
     - --advertise-address=${advertise_address}
     - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
     - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+    - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
     - --runtime-config=""
     - --secure-port=443
     - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -51,7 +51,7 @@ spec:
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
-        - --kubelet-preferred-address-types=InternalIP
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --authorization-mode=RBAC

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -51,6 +51,7 @@ spec:
         - --tls-private-key-file=/etc/kubernetes/secrets/apiserver.key
         - --kubelet-client-certificate=/etc/kubernetes/secrets/apiserver.crt
         - --kubelet-client-key=/etc/kubernetes/secrets/apiserver.key
+        - --kubelet-preferred-address-types=InternalIP
         - --service-account-key-file=/etc/kubernetes/secrets/service-account.pub
         - --client-ca-file=/etc/kubernetes/secrets/ca.crt
         - --authorization-mode=RBAC


### PR DESCRIPTION
Explicitly sets `--kubelet-preferred-address-types=InternalDNS,InternalIP,Hostname,ExternalDNS,ExternalIP` on the apiserver.

This allows API --> kubelet communication to succeed in instances where a DNS search domain is not present in `/etc/resolv.conf`

Fixes: https://jira.coreos.com/browse/TECREL-150