### PR TITLE
frontend: Add Analytics events for all docs links, make target="_blank" links easier to maintain

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { compose, validate } from '../validate';
-import { Input, Password, Select, RadioBoolean, Connect } from './ui';
+import { A, Input, Password, Select, RadioBoolean, Connect } from './ui';
 import { Alert } from './alert';
 
 import { getRegions } from '../aws-actions';
@@ -147,10 +147,7 @@ export const AWS_CloudCredentials = connect(stateToProps)(
   ({regionSelections, stsEnabled}) => <div>
     <div className="row form-group">
       <div className="col-xs-12">
-        Enter your Amazon Web Services (AWS) credentials to create and configure the required resources.
-        {/* eslint-disable react/jsx-no-target-blank */}
-        It is strongly suggested that you create a <a href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#privileges" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener" target="_blank">limited access role</a> for Tectonic's communication with your cloud provider.
-        {/* eslint-enable react/jsx-no-target-blank */}
+        Enter your Amazon Web Services (AWS) credentials to create and configure the required resources. It is strongly suggested that you create a <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#privileges" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">limited access role</A> for Tectonic's communication with your cloud provider.
       </div>
     </div>
 
@@ -165,7 +162,7 @@ export const AWS_CloudCredentials = connect(stateToProps)(
               Use a normal access key
             </label>&nbsp;(default)
             <p className="text-muted">
-              Go to the <a href="https://console.aws.amazon.com/iam/home#/users" rel="noopener noreferrer" target="_blank">AWS console user section</a>, select your user name, and the Security Credentials tab.
+              Go to the <A href="https://console.aws.amazon.com/iam/home#/users">AWS console user section</A>, select your user name, and the Security Credentials tab.
             </p>
           </div>
           <div className="wiz-radio-group__body">

--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -3,12 +3,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { compose, validate } from '../validate';
-import { A, Input, Password, Select, RadioBoolean, Connect } from './ui';
+import { A, DocsA, Input, Password, Select, RadioBoolean, Connect } from './ui';
 import { Alert } from './alert';
 
 import { getRegions } from '../aws-actions';
 import { Field, Form } from '../form';
-import { TectonicGA } from '../tectonic-ga';
 
 import {
   AWS_ACCESS_KEY_ID,
@@ -147,7 +146,7 @@ export const AWS_CloudCredentials = connect(stateToProps)(
   ({regionSelections, stsEnabled}) => <div>
     <div className="row form-group">
       <div className="col-xs-12">
-        Enter your Amazon Web Services (AWS) credentials to create and configure the required resources. It is strongly suggested that you create a <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#privileges" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">limited access role</A> for Tectonic's communication with your cloud provider.
+        Enter your Amazon Web Services (AWS) credentials to create and configure the required resources. It is strongly suggested that you create a <DocsA path="/install/aws/requirements.html#privileges">limited access role</DocsA> for Tectonic's communication with your cloud provider.
       </div>
     </div>
 

--- a/installer/frontend/components/aws-domain-validation.jsx
+++ b/installer/frontend/components/aws-domain-validation.jsx
@@ -8,6 +8,7 @@ import { AWS_HOSTED_ZONE_ID, CLUSTER_SUBDOMAIN } from '../cluster-config';
 import { Alert } from './alert';
 import { TectonicGA } from '../tectonic-ga';
 import { toExtraData } from '../utils';
+import { A } from './ui';
 
 const stateToProps = ({aws, clusterConfig}) => {
   const hostedZoneID = clusterConfig[AWS_HOSTED_ZONE_ID];
@@ -82,9 +83,7 @@ class DomainInfo extends React.Component {
       warnings.push(<Alert key="soa">
         <b>{domain}'s SOA TTL is {soaTTL} seconds and its SOA minimum TTL is {minimumTTL} seconds.</b>&nbsp;
         The SOA record TTL and minimum TTL values determine how long to cache NXDOMAIN responses for. Installation cannot complete until {clusterSubdomain}-k8s.{domain} resolves.&nbsp;
-        {/* eslint-disable react/jsx-no-target-blank */}
-        <a href="https://coreos.com/tectonic/docs/latest/install/aws/troubleshooting.html#route53-dns-resolution" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener" target="_blank">Read more here</a>.
-        {/* eslint-enable react/jsx-no-target-blank */}
+        <A href="https://coreos.com/tectonic/docs/latest/install/aws/troubleshooting.html#route53-dns-resolution" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">Read more here</A>.
       </Alert>);
     }
 

--- a/installer/frontend/components/aws-domain-validation.jsx
+++ b/installer/frontend/components/aws-domain-validation.jsx
@@ -6,9 +6,8 @@ import _ from 'lodash';
 import * as awsActions from '../aws-actions';
 import { AWS_HOSTED_ZONE_ID, CLUSTER_SUBDOMAIN } from '../cluster-config';
 import { Alert } from './alert';
-import { TectonicGA } from '../tectonic-ga';
 import { toExtraData } from '../utils';
-import { A } from './ui';
+import { DocsA } from './ui';
 
 const stateToProps = ({aws, clusterConfig}) => {
   const hostedZoneID = clusterConfig[AWS_HOSTED_ZONE_ID];
@@ -83,7 +82,7 @@ class DomainInfo extends React.Component {
       warnings.push(<Alert key="soa">
         <b>{domain}'s SOA TTL is {soaTTL} seconds and its SOA minimum TTL is {minimumTTL} seconds.</b>&nbsp;
         The SOA record TTL and minimum TTL values determine how long to cache NXDOMAIN responses for. Installation cannot complete until {clusterSubdomain}-k8s.{domain} resolves.&nbsp;
-        <A href="https://coreos.com/tectonic/docs/latest/install/aws/troubleshooting.html#route53-dns-resolution" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">Read more here</A>.
+        <DocsA path="/install/aws/troubleshooting.html#route53-dns-resolution">Read more here</DocsA>.
       </Alert>);
     }
 

--- a/installer/frontend/components/aws-submit-keys.jsx
+++ b/installer/frontend/components/aws-submit-keys.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { validate } from '../validate';
-import { Connect, Selector } from './ui';
+import { A, Connect, Selector } from './ui';
 import { Field, Form } from '../form';
 
 import * as awsActions from '../aws-actions';
@@ -35,9 +35,7 @@ const Title = connect(
 export const AWS_SubmitKeys = () => <div>
   <div className="row form-group">
     <div className="col-xs-12">
-      {/* eslint-disable react/jsx-no-target-blank */}
-      <a href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#ssh-key" rel="noopener" target="_blank">Generate a new key</a> if you don't have an existing one in this region.
-      {/* eslint-enable react/jsx-no-target-blank */}
+      <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#ssh-key" rel="noopener">Generate a new key</A> if you don't have an existing one in this region.
     </div>
   </div>
   <div className="row form-group">

--- a/installer/frontend/components/aws-submit-keys.jsx
+++ b/installer/frontend/components/aws-submit-keys.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { validate } from '../validate';
-import { A, Connect, Selector } from './ui';
+import { Connect, DocsA, Selector } from './ui';
 import { Field, Form } from '../form';
 
 import * as awsActions from '../aws-actions';
@@ -35,7 +35,7 @@ const Title = connect(
 export const AWS_SubmitKeys = () => <div>
   <div className="row form-group">
     <div className="col-xs-12">
-      <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#ssh-key" rel="noopener">Generate a new key</A> if you don't have an existing one in this region.
+      <DocsA path="/install/aws/requirements.html#ssh-key">Generate a new key</DocsA> if you don't have an existing one in this region.
     </div>
   </div>
   <div className="row form-group">

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { compose, validate } from '../validate';
 import { getDefaultSubnets, getZones, getVpcs, getVpcSubnets, validateSubnets } from '../aws-actions';
 import {
+  A,
   AsyncSelect,
   Radio,
   Select,
@@ -302,9 +303,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
               Use an existing VPC (Public)
             </label>
             <p className="text-muted wiz-help-text">
-              {/* eslint-disable react/jsx-no-target-blank */}
-              Useful for installing beside existing resources. Your VPC must be <a href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#using-an-existing-vpc" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener" target="_blank">set up correctly</a>.
-              {/* eslint-enable react/jsx-no-target-blank */}
+              Useful for installing beside existing resources. Your VPC must be <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#using-an-existing-vpc" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">set up correctly</A>.
             </p>
           </div>
         </div>
@@ -317,9 +316,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
               Use an existing VPC (Private)
             </label>
             <p className="text-muted wiz-help-text">
-              {/* eslint-disable react/jsx-no-target-blank */}
-              Useful for installing beside existing resources. Your VPC must be <a href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#using-an-existing-vpc" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener" target="_blank">set up correctly</a>.
-              {/* eslint-enable react/jsx-no-target-blank */}
+              Useful for installing beside existing resources. Your VPC must be <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#using-an-existing-vpc" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">set up correctly</A>.
             </p>
           </div>
         </div>
@@ -329,7 +326,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
     <hr />
 
     <p className="text-muted">
-      Please select a Route 53 hosted zone. For more information, see AWS Route 53 docs on <a target="_blank" href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html" rel="noopener noreferrer">Working with Hosted Zones</a>.
+      Please select a Route 53 hosted zone. For more information, see AWS Route 53 docs on <A href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html">Working with Hosted Zones</A>.
     </p>
     <div className="row form-group">
       <div className="col-xs-2">
@@ -359,7 +356,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
             </Select>
           </Connect>
           <p className="text-muted wiz-help-text">
-            See AWS <a href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html" rel="noopener noreferrer" target="_blank">Split-View DNS documentation&nbsp;<i className="fa fa-external-link" /></a>
+            See AWS <A href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html">Split-View DNS documentation&nbsp;<i className="fa fa-external-link" /></A>
           </p>
         </div>
       </div>
@@ -389,7 +386,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
           </Alert>
           <div className="row form-group">
             <div className="col-xs-12">
-              Specify a range of IPv4 addresses for the VPC in the form of a <a href="https://tools.ietf.org/html/rfc4632" rel="noopener noreferrer" target="_blank">CIDR block</a>. Safe defaults have been chosen for you.
+              Specify a range of IPv4 addresses for the VPC in the form of a <A href="https://tools.ietf.org/html/rfc4632">CIDR block</A>. Safe defaults have been chosen for you.
             </div>
           </div>
           <CIDRRow name="CIDR Block" field={AWS_VPC_CIDR} placeholder={DEFAULT_AWS_VPC_CIDR} />

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -7,6 +7,7 @@ import { getDefaultSubnets, getZones, getVpcs, getVpcSubnets, validateSubnets } 
 import {
   A,
   AsyncSelect,
+  DocsA,
   Radio,
   Select,
   Deselect,
@@ -19,7 +20,6 @@ import {
 import { Alert } from './alert';
 import { configActions } from '../actions';
 import { AWS_DomainValidation } from './aws-domain-validation';
-import { TectonicGA } from '../tectonic-ga';
 import { KubernetesCIDRs } from './k8s-cidrs';
 import { CIDRRow } from './cidr';
 import { Field, Form } from '../form';
@@ -303,7 +303,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
               Use an existing VPC (Public)
             </label>
             <p className="text-muted wiz-help-text">
-              Useful for installing beside existing resources. Your VPC must be <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#using-an-existing-vpc" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">set up correctly</A>.
+              Useful for installing beside existing resources. Your VPC must be <DocsA path="/install/aws/requirements.html#using-an-existing-vpc">set up correctly</DocsA>.
             </p>
           </div>
         </div>
@@ -316,7 +316,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
               Use an existing VPC (Private)
             </label>
             <p className="text-muted wiz-help-text">
-              Useful for installing beside existing resources. Your VPC must be <A href="https://coreos.com/tectonic/docs/latest/install/aws/requirements.html#using-an-existing-vpc" onClick={() => TectonicGA.sendDocsEvent('aws-tf')} rel="noopener">set up correctly</A>.
+              Useful for installing beside existing resources. Your VPC must be <DocsA path="/install/aws/requirements.html#using-an-existing-vpc">set up correctly</DocsA>.
             </p>
           </div>
         </div>

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -7,9 +7,8 @@ import { configActions, eventErrorsActionTypes } from '../actions';
 import { Field, Form } from '../form';
 import { compareVersions } from '../utils';
 import { validate } from '../validate';
-import { TectonicGA } from '../tectonic-ga';
 
-import { A, Connect, Input } from './ui';
+import { Connect, DocsA, Input } from './ui';
 import {
   DEFAULT_CLUSTER_CONFIG,
   BM_MATCHBOX_HTTP,
@@ -113,7 +112,7 @@ export const BM_Matchbox = connect(stateToProps, dispatchToProps)(
         <div className="col-sm-12">
           <div className="form-group">Matchbox will provision nodes during network boot. Enter the matchbox endpoints.</div>
           <div className="form-group">
-            To find your matchbox endpoints, follow the instructions in the <A href="https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html" onClick={() => TectonicGA.sendDocsEvent('bare-metal-tf')} rel="noopener">Tectonic Deploy Documentation</A>.
+            To find your matchbox endpoints, follow the instructions in the <DocsA path="/install/bare-metal/index.html">Tectonic Deploy Documentation</DocsA>.
           </div>
           <div className="form-group">
             <div className="row">

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -9,7 +9,7 @@ import { compareVersions } from '../utils';
 import { validate } from '../validate';
 import { TectonicGA } from '../tectonic-ga';
 
-import { Connect, Input } from './ui';
+import { A, Connect, Input } from './ui';
 import {
   DEFAULT_CLUSTER_CONFIG,
   BM_MATCHBOX_HTTP,
@@ -112,12 +112,8 @@ export const BM_Matchbox = connect(stateToProps, dispatchToProps)(
       return <div className="row form-group">
         <div className="col-sm-12">
           <div className="form-group">Matchbox will provision nodes during network boot. Enter the matchbox endpoints.</div>
-          <div className="form-group">To find your matchbox endpoints, follow the instructions in the {' '}
-            {/* eslint-disable react/jsx-no-target-blank */}
-            <a href="https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html" onClick={() => TectonicGA.sendDocsEvent('bare-metal-tf')} rel="noopener" target="_blank">
-              Tectonic Deploy Documentation
-            </a>.
-            {/* eslint-enable react/jsx-no-target-blank */}
+          <div className="form-group">
+            To find your matchbox endpoints, follow the instructions in the <A href="https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html" onClick={() => TectonicGA.sendDocsEvent('bare-metal-tf')} rel="noopener">Tectonic Deploy Documentation</A>.
           </div>
           <div className="form-group">
             <div className="row">

--- a/installer/frontend/components/cluster-info.jsx
+++ b/installer/frontend/components/cluster-info.jsx
@@ -8,10 +8,9 @@ import fields from '../fields';
 import { Field, Form } from '../form';
 
 import { Alert } from './alert';
-import { Connect, FileInput, Input } from './ui';
+import { A, Connect, FileInput, Input } from './ui';
 
-// eslint-disable-next-line react/jsx-no-target-blank
-const accountLink = <a href="https://account.coreos.com" rel="noopener" target="_blank">account.coreos.com</a>;
+const accountLink = <A href="https://account.coreos.com" rel="noopener">account.coreos.com</A>;
 
 const licenseField = new Field(TECTONIC_LICENSE, {
   default: '',

--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { validate } from '../validate';
-import { A, Connect, Select } from './ui';
+import { Connect, DocsA, Select } from './ui';
 import { Field, Form } from '../form';
 import { PLATFORM_TYPE, PLATFORM_FORM } from '../cluster-config';
 import { TectonicGA } from '../tectonic-ga';
@@ -26,16 +26,16 @@ const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PL
         Use the documentation and the Terraform CLI to install a cluster with specific infrastructure use-cases.
         This method is designed for automation and doesn't use the graphical installer.
         <br />
-        <A href={DOCS[platform]} rel="noopener">
+        <DocsA path={DOCS[platform]}>
           <button className="btn btn-primary" style={{marginTop: 8}}>{platformName && platformName.split('(Alpha)')[0]} Docs&nbsp;&nbsp;{icon}</button>
-        </A>
+        </DocsA>
       </p>;
     }
     return <p className="text-muted">
       Use the graphical installer to input cluster details, this is best for demos and your first Tectonic cluster.
       &nbsp;&nbsp;{platform === BARE_METAL_TF
-        ? <span><br />{platformName} <A href="https://coreos.com/tectonic/docs/latest/install/bare-metal/requirements.html" rel="noopener">requirements&nbsp;&nbsp;{icon}</A> and <A href={DOCS[platform]} rel="noopener">install guide&nbsp;&nbsp;{icon}</A>.</span>
-        : <A href={DOCS[platform]} rel="noopener">{platformName} documentation&nbsp;&nbsp;{icon}</A>}
+        ? <span><br />{platformName} <DocsA path="/install/bare-metal/requirements.html">requirements&nbsp;&nbsp;{icon}</DocsA> and <DocsA path={DOCS[platform]}>install guide&nbsp;&nbsp;{icon}</DocsA>.</span>
+        : <DocsA path={DOCS[platform]}>{platformName} documentation&nbsp;&nbsp;{icon}</DocsA>}
     </p>;
   });
 

--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { validate } from '../validate';
-import { Connect, Select } from './ui';
+import { A, Connect, Select } from './ui';
 import { Field, Form } from '../form';
 import { PLATFORM_TYPE, PLATFORM_FORM } from '../cluster-config';
 import { TectonicGA } from '../tectonic-ga';
@@ -26,21 +26,17 @@ const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PL
         Use the documentation and the Terraform CLI to install a cluster with specific infrastructure use-cases.
         This method is designed for automation and doesn't use the graphical installer.
         <br />
-        {/* eslint-disable react/jsx-no-target-blank */}
-        <a href={DOCS[platform]} rel="noopener" target="_blank">
+        <A href={DOCS[platform]} rel="noopener">
           <button className="btn btn-primary" style={{marginTop: 8}}>{platformName && platformName.split('(Alpha)')[0]} Docs&nbsp;&nbsp;{icon}</button>
-        </a>
-        {/* eslint-enable react/jsx-no-target-blank */}
+        </A>
       </p>;
     }
-    /* eslint-disable react/jsx-no-target-blank */
     return <p className="text-muted">
       Use the graphical installer to input cluster details, this is best for demos and your first Tectonic cluster.
       &nbsp;&nbsp;{platform === BARE_METAL_TF
-        ? <span><br />{platformName} <a href="https://coreos.com/tectonic/docs/latest/install/bare-metal/requirements.html" rel="noopener" target="_blank">requirements&nbsp;&nbsp;{icon}</a> and <a href={DOCS[platform]} rel="noopener" target="_blank">install guide&nbsp;&nbsp;{icon}</a>.</span>
-        : <a href={DOCS[platform]} rel="noopener" target="_blank">{platformName} documentation&nbsp;&nbsp;{icon}</a>}
+        ? <span><br />{platformName} <A href="https://coreos.com/tectonic/docs/latest/install/bare-metal/requirements.html" rel="noopener">requirements&nbsp;&nbsp;{icon}</A> and <A href={DOCS[platform]} rel="noopener">install guide&nbsp;&nbsp;{icon}</A>.</span>
+        : <A href={DOCS[platform]} rel="noopener">{platformName} documentation&nbsp;&nbsp;{icon}</A>}
     </p>;
-    /* eslint-enable react/jsx-no-target-blank */
   });
 
 const platformForm = new Form(PLATFORM_FORM, [

--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -1,18 +1,13 @@
 import React from 'react';
 
 import { TectonicGA } from '../tectonic-ga';
+import { A } from './ui';
 
 export const DryRun = () => <div className="row">
   <div className="col-xs-12">
     <div className="form-group">
-      {/* eslint-disable react/jsx-no-target-blank */}
-      Your cluster assets have been created. You can download these <a href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" rel="noopener" target="_blank">assets</a> and customize underlying infrastructure as needed.
-      Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.
-      &nbsp;<a href="https://coreos.com/tectonic/docs/latest/install/aws/manual-boot.html"
-        onClick={TectonicGA.sendDocsEvent} rel="noopener" target="_blank">
-        Read more here.&nbsp;&nbsp;<i className="fa fa-external-link" />
-      </a>
-      {/* eslint-enable react/jsx-no-target-blank */}
+      Your cluster assets have been created. You can download these <A href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" rel="noopener">assets</A> and customize underlying infrastructure as needed.
+      Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.&nbsp; <A href="https://coreos.com/tectonic/docs/latest/install/aws/manual-boot.html" onClick={TectonicGA.sendDocsEvent} rel="noopener">Read more here.&nbsp;&nbsp;<i className="fa fa-external-link" /></A>
     </div>
     <div className="from-group">
       <div className="wiz-giant-button-container">

--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
-import { TectonicGA } from '../tectonic-ga';
-import { A } from './ui';
+import { DocsA } from './ui';
 
 export const DryRun = () => <div className="row">
   <div className="col-xs-12">
     <div className="form-group">
-      Your cluster assets have been created. You can download these <A href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" rel="noopener">assets</A> and customize underlying infrastructure as needed.
-      Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.&nbsp; <A href="https://coreos.com/tectonic/docs/latest/install/aws/manual-boot.html" onClick={TectonicGA.sendDocsEvent} rel="noopener">Read more here.&nbsp;&nbsp;<i className="fa fa-external-link" /></A>
+      Your cluster assets have been created. You can download these <DocsA path="/admin/assets-zip.html">assets</DocsA> and customize underlying infrastructure as needed.
+      Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.&nbsp; <DocsA path="/install/aws/manual-boot.html">Read more here.&nbsp;&nbsp;<i className="fa fa-external-link" /></DocsA>
     </div>
     <div className="from-group">
       <div className="wiz-giant-button-container">

--- a/installer/frontend/components/footer.jsx
+++ b/installer/frontend/components/footer.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-/* eslint-disable react/jsx-no-target-blank */
+import { A } from './ui';
+
 export const Footer = () => <footer className="tectonic-footer">
-  CoreOS collects data about your Tectonic cluster for billing purposes. See the <a href="https://coreos.com/data-policy/tectonic" rel="noopener" target="_blank">data policy</a> for details
+  CoreOS collects data about your Tectonic cluster for billing purposes. See the <A href="https://coreos.com/data-policy/tectonic" rel="noopener">data policy</A> for details
 </footer>;
-/* eslint-enable react/jsx-no-target-blank */

--- a/installer/frontend/components/header.jsx
+++ b/installer/frontend/components/header.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import semver from 'semver';
-import { Dropdown } from './ui';
+import { A, Dropdown } from './ui';
 
 const fetchLatestRelease = () => {
   const opts = {
@@ -120,18 +120,14 @@ export class Header extends React.Component {
             <Dropdown items={openSourceDdItems} header="Open Source" />
           </li>
           <li className="tectonic-dropdown-menu-title">
-            {/* eslint-disable react/jsx-no-target-blank */}
-            <a href="https://coreos.com/tectonic/docs/latest/" rel="noopener" target="_blank" className="tectonic-dropdown-menu-title__link">Tectonic Docs</a>
-            {/* eslint-enable react/jsx-no-target-blank */}
+            <A href="https://coreos.com/tectonic/docs/latest/" className="tectonic-dropdown-menu-title__link" rel="noopener">Tectonic Docs</A>
           </li>
         </ul>
         <div className="co-navbar--right">
           <ul className="co-navbar-nav">
             {latestRelease && hasNewVersion(latestRelease) && <li className="co-navbar-nav-item__version">
               <span className="co-navbar-nav-item__version--new">
-                {/* eslint-disable react/jsx-no-target-blank */}
-                New installer version: <a href="https://coreos.com/tectonic/releases/" rel="noopener" target="_blank">Release notes {latestRelease}</a>
-                {/* eslint-enable react/jsx-no-target-blank */}
+                New installer version: <A href="https://coreos.com/tectonic/releases/" rel="noopener">Release notes {latestRelease}</A>
               </span>
             </li>}
             <li className="co-navbar-nav-item__version">

--- a/installer/frontend/components/header.jsx
+++ b/installer/frontend/components/header.jsx
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 import semver from 'semver';
 
-import { A, DropdownMixin } from './ui';
+import { A, DocsA, DropdownMixin } from './ui';
 
 const fetchLatestRelease = () => {
   const opts = {
@@ -145,7 +145,7 @@ export class Header extends React.Component {
             <MenuDropdown items={openSourceDdItems} header="Open Source" />
           </li>
           <li className="tectonic-dropdown-menu-title">
-            <A href="https://coreos.com/tectonic/docs/latest/" className="tectonic-dropdown-menu-title__link" rel="noopener">Tectonic Docs</A>
+            <DocsA className="tectonic-dropdown-menu-title__link" path="/">Tectonic Docs</DocsA>
           </li>
         </ul>
         <div className="co-navbar--right">

--- a/installer/frontend/components/header.jsx
+++ b/installer/frontend/components/header.jsx
@@ -1,6 +1,8 @@
+import _ from 'lodash';
 import React from 'react';
 import semver from 'semver';
-import { A, Dropdown } from './ui';
+
+import { A, DropdownMixin } from './ui';
 
 const fetchLatestRelease = () => {
   const opts = {
@@ -65,6 +67,29 @@ const hasNewVersion = (latestRelease) => {
   return false;
 };
 
+class MenuDropdown extends DropdownMixin {
+  render () {
+    const {active} = this.state;
+    const {items, header} = this.props;
+
+    const children = _.map(items, (href, title) => {
+      const rel = href.includes('coreos.com') ? 'noopener' : 'noopener noreferrer';
+      return <li className="tectonic-dropdown-menu-item" key={title}>
+        <A className="tectonic-dropdown-menu-item__link" href={href} rel={rel}>{title}</A>
+      </li>;
+    });
+
+    return (
+      <div ref={el => this.dropdownElement = el} className="dropdown" onClick={this.toggle}>
+        <a className="tectonic-dropdown-menu-title">{header}&nbsp;&nbsp;<i className="fa fa-angle-down"></i></a>
+        <ul className="dropdown-menu tectonic-dropdown-menu" style={{display: active ? 'block' : 'none'}}>
+          {children}
+        </ul>
+      </div>
+    );
+  }
+}
+
 export class Header extends React.Component {
   constructor (props) {
     super(props);
@@ -114,10 +139,10 @@ export class Header extends React.Component {
       <div>
         <ul className="co-navbar-nav">
           <li>
-            <Dropdown items={productDdItems} header="Product" />
+            <MenuDropdown items={productDdItems} header="Product" />
           </li>
           <li>
-            <Dropdown items={openSourceDdItems} header="Open Source" />
+            <MenuDropdown items={openSourceDdItems} header="Open Source" />
           </li>
           <li className="tectonic-dropdown-menu-title">
             <A href="https://coreos.com/tectonic/docs/latest/" className="tectonic-dropdown-menu-title__link" rel="noopener">Tectonic Docs</A>

--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -25,7 +25,7 @@ import { AWS_TF } from '../platforms';
 import { toError } from '../utils';
 import { compose, validate } from '../validate';
 import { makeNodeForm, toKey } from './make-node-form';
-import { Connect, Input, NumberInput, Radio, Select } from './ui';
+import { A, Connect, Input, NumberInput, Radio, Select } from './ui';
 
 const Row = ({label, htmlFor, children}) => <div className="row form-group">
   <div className="col-xs-4">
@@ -79,9 +79,7 @@ export const DefineNode = ({type, max, withIamRole = true}) => <div>
       </Select>
     </Connect>
     {type === 'aws_etcds' && <p className="text-muted wiz-help-text">
-      {/* eslint-disable react/jsx-no-target-blank */}
-      Read the <a href="https://coreos.com/etcd/docs/latest/op-guide/hardware.html" rel="noopener" target="_blank">etcd recommended hardware</a> guide for best performance.
-      {/* eslint-enable react/jsx-no-target-blank */}
+      Read the <A href="https://coreos.com/etcd/docs/latest/op-guide/hardware.html" rel="noopener">etcd recommended hardware</A> guide for best performance.
     </p>}
   </Row>
   <Row htmlFor={`${type}--storage-size`} label="Storage Size">

--- a/installer/frontend/components/submit-definition.jsx
+++ b/installer/frontend/components/submit-definition.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { commitToServer } from '../server';
 import { commitPhases } from '../actions';
 import { withNav } from '../nav';
-import { A } from './ui';
+import { DocsA } from './ui';
 
 export const SubmitDefinition = withNav(connect(
   state => ({
@@ -37,7 +37,7 @@ export const SubmitDefinition = withNav(connect(
         Congratulations! Your cluster has been defined and will be submitted to Terraform. After submission, the definition cannot be updated. Go <a onClick={inProgress ? undefined : navPrevious} className={inProgress ? 'disabled' : undefined}>back</a> to update or make changes.
       </p>
       <p>
-        You'll be able to download your <A href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" rel="noopener">assets zip file</A> after the definition is submitted.
+        You'll be able to download your <DocsA path="/admin/assets-zip.html">assets zip file</DocsA> after the definition is submitted.
       </p>
       <br />
       <div className="wiz-giant-button-container">

--- a/installer/frontend/components/submit-definition.jsx
+++ b/installer/frontend/components/submit-definition.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { commitToServer } from '../server';
 import { commitPhases } from '../actions';
 import { withNav } from '../nav';
+import { A } from './ui';
 
 export const SubmitDefinition = withNav(connect(
   state => ({
@@ -36,9 +37,7 @@ export const SubmitDefinition = withNav(connect(
         Congratulations! Your cluster has been defined and will be submitted to Terraform. After submission, the definition cannot be updated. Go <a onClick={inProgress ? undefined : navPrevious} className={inProgress ? 'disabled' : undefined}>back</a> to update or make changes.
       </p>
       <p>
-        {/* eslint-disable react/jsx-no-target-blank */}
-        You'll be able to download your <a href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" rel="noopener" target="_blank">assets zip file</a> after the definition is submitted.
-        {/* eslint-enable react/jsx-no-target-blank */}
+        You'll be able to download your <A href="https://coreos.com/tectonic/docs/latest/admin/assets-zip.html" rel="noopener">assets zip file</A> after the definition is submitted.
       </p>
       <br />
       <div className="wiz-giant-button-container">

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -580,28 +580,6 @@ export class DropdownMixin extends React.PureComponent {
   }
 }
 
-export class Dropdown extends DropdownMixin {
-  render () {
-    const {active} = this.state;
-    const {items, header} = this.props;
-
-    const children = _.map(items, (href, title) => {
-      return <li className="tectonic-dropdown-menu-item" key={title}>
-        <a className="tectonic-dropdown-menu-item__link" href={href} rel="noopener" target="_blank">{title}</a>
-      </li>;
-    });
-
-    return (
-      <div ref={el => this.dropdownElement = el} className="dropdown" onClick={this.toggle}>
-        <a className="tectonic-dropdown-menu-title">{header}&nbsp;&nbsp;<i className="fa fa-angle-down"></i></a>
-        <ul className="dropdown-menu tectonic-dropdown-menu" style={{display: active ? 'block' : 'none'}}>
-          {children}
-        </ul>
-      </div>
-    );
-  }
-}
-
 export class DropdownInline extends DropdownMixin {
   render () {
     const {active} = this.state;

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -7,10 +7,11 @@ import { connect } from 'react-redux';
 import { withNav } from '../nav';
 import { validate } from '../validate';
 import { readFile } from '../readfile';
+import { TectonicGA } from '../tectonic-ga';
 import { toError, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from '../utils';
 
 import { dirtyActions, configActions } from '../actions';
-import { DESELECTED_FIELDS } from '../cluster-config.js';
+import { DESELECTED_FIELDS, PLATFORM_TYPE } from '../cluster-config.js';
 
 import { Alert } from './alert';
 
@@ -60,6 +61,14 @@ const FIELD_PROPS = ImmutableSet([
 
 // Same as an <a> except defaults to rel="noopener noreferrer" and target="_blank"
 export const A = props => <a rel="noopener noreferrer" target="_blank" {...props} />;
+
+export const DocsA = connect(({clusterConfig}) => ({platform: clusterConfig[PLATFORM_TYPE]}))(props => <a
+  {..._.omit(props, ['dispatch', 'path', 'platform'])}
+  href={`https://coreos.com/tectonic/docs/latest${props.path}`}
+  onClick={() => TectonicGA.sendDocsEvent(props.platform)}
+  rel="noopener"
+  target="_blank"
+/>);
 
 export const ErrorComponent = props => {
   const error = props.error;

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -58,6 +58,9 @@ const FIELD_PROPS = ImmutableSet([
   'width',
 ]);
 
+// Same as an <a> except defaults to rel="noopener noreferrer" and target="_blank"
+export const A = props => <a rel="noopener noreferrer" target="_blank" {...props} />;
+
 export const ErrorComponent = props => {
   const error = props.error;
   if (props.ErrorComponent) {

--- a/installer/frontend/platforms.js
+++ b/installer/frontend/platforms.js
@@ -26,10 +26,10 @@ export const optGroups = [
 ];
 
 export const DOCS = {
-  [AWS]: 'https://coreos.com/tectonic/docs/latest/install/aws/aws-terraform.html',
-  [AWS_TF]: 'https://coreos.com/tectonic/docs/latest/install/aws/index.html',
-  [AZURE]: 'https://coreos.com/tectonic/docs/latest/install/azure/azure-terraform.html',
-  [BARE_METAL]: 'https://coreos.com/tectonic/docs/latest/install/bare-metal/metal-terraform.html',
-  [BARE_METAL_TF]: 'https://coreos.com/tectonic/docs/latest/install/bare-metal/index.html',
-  [OPENSTACK]: 'https://coreos.com/tectonic/docs/latest/install/openstack/openstack-terraform.html',
+  [AWS]: '/install/aws/aws-terraform.html',
+  [AWS_TF]: '/install/aws/index.html',
+  [AZURE]: '/install/azure/azure-terraform.html',
+  [BARE_METAL]: '/install/bare-metal/metal-terraform.html',
+  [BARE_METAL_TF]: '/install/bare-metal/index.html',
+  [OPENSTACK]: '/install/openstack/openstack-terraform.html',
 };

--- a/installer/frontend/ui-tests/utils/wizard.js
+++ b/installer/frontend/ui-tests/utils/wizard.js
@@ -27,6 +27,10 @@ const testPage = (page, platform, json, nextInitiallyDisabled = true) => {
     page.expect.element('.wiz-wizard__nav__step--active + .wiz-wizard__nav__step button').to.not.have.attribute('disabled');
   }
 
+  // Links that open in a new tab must set rel="noopener noreferrer", but coreos.com links must set rel="noopener"
+  page.expect.element('a[target=_blank][href*="coreos.com"]:not([rel="noopener"])').not.present;
+  page.expect.element('a[target=_blank]:not([href*="coreos.com"]):not([rel="noopener noreferrer"])').not.present;
+
   page.test(json, platform);
 
   page.expect.element(nextStep).to.have.attribute('class').which.not.contains('disabled');


### PR DESCRIPTION
Create `A` and `DocsA` components to wrap links in order to
- Send Google Analytics docs events for all docs links
- Stop littering the code with `eslint-disable-next-line react/jsx-no-target-blank` comments
- Make the `rel="noopener"` / `rel="noopener noreferrer"` attributes easier to get right

Also adds Nightwatch tests for the `rel` attributes, fixes the `rel` attribute of one header link and renames `Dropdown` to `MenuDropdown` and moves it to `header.jsx` because it is actually specific to the header menus.