### PR TITLE
frontend: Rename REMOVE_AT action to REMOVE_FIELD_LIST_ROW and simplify

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -9,7 +9,7 @@ export const awsActionTypes = {
 export const configActionTypes = {
   ADD_IN: 'CONFIG_ACTION_ADD_IN',
   APPEND: 'CONFIG_ACTION_APPEND',
-  REMOVE_AT: 'CONFIG_ACTION_REMOVE_AT',
+  REMOVE_FIELD_LIST_ROW: 'CONFIG_ACTION_REMOVE_FIELD_LIST_ROW',
   SET: 'CONFIG_ACTION_SIMPLE_SET',
   SET_IN: 'CONFIG_ACTION_SET_IN',
   BATCH_SET_IN: 'CONFIG_ACTION_BATCH_SET_IN',
@@ -89,7 +89,7 @@ export const configActions = {
   // TODO: (kans) move below to form actions...
   removeField: (fieldListId, index) => (dispatch, getState) => {
     const fieldList = getField(fieldListId);
-    dispatch({payload: {path: fieldListId, index}, type: configActionTypes.REMOVE_AT});
+    dispatch({payload: {fieldListId, index}, type: configActionTypes.REMOVE_FIELD_LIST_ROW});
     fieldList.validate(dispatch, getState);
   },
   appendField: fieldListId => (dispatch, getState) => {

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -145,21 +145,9 @@ const reducersTogether = combineReducers({
       return setIn(state, path, action.payload.value);
     }
 
-    case configActionTypes.REMOVE_AT: {
-      const {path, index} = action.payload;
-      const array = _.isString(path) ? path.split('.') : path;
-      array.push(index.toString());
-      // TODO: (kans) delete all the other stuff too
-      const invalidArray = ['error'].concat(array);
-      const arrays = [array, invalidArray];
-      return fromJS(state).withMutations(map => {
-        arrays.forEach(a => {
-          if (map.getIn(a)) {
-            map = map.deleteIn(a);
-          }
-          return map;
-        });
-      }).toJS();
+    case configActionTypes.REMOVE_FIELD_LIST_ROW: {
+      const {fieldListId, index} = action.payload;
+      return fromJS(state).deleteIn([fieldListId, index]).toJS();
     }
     default:
       return state;
@@ -253,11 +241,9 @@ const reducersTogether = combineReducers({
     }
 
     switch (action.type) {
-    case configActionTypes.REMOVE_AT: {
-      const {path, index} = action.payload;
-      const array = _.isString(path) ? path.split('.') : path;
-      array.push(index.toString());
-      return fromJS(state).deleteIn(array).toJS();
+    case configActionTypes.REMOVE_FIELD_LIST_ROW: {
+      const {fieldListId, index} = action.payload;
+      return fromJS(state).deleteIn([fieldListId, index]).toJS();
     }
     case dirtyActionTypes.ADD: {
       // {awsTags: [{key: true}]


### PR DESCRIPTION
This Redux action is now specifically for removing a row from a field
list, so rename it to make that clear.

Simplify the reducers by assuming they take a field list id and an
index, not an arbitrary path. Also stop clearing any associated error
data, since a `REMOVE_FIELD_LIST_ROW` action will need to trigger a
re-validation of the field list anyway.