### PR TITLE
frontend: Remove old AsyncSelect component

### DIFF
--- a/Documentation/dev/frontend.md
+++ b/Documentation/dev/frontend.md
@@ -82,10 +82,8 @@ Various input field components are defined in `components/ui.jsx`, including
   * For inputs than can optionally be deselected. `Deselect` is the checkbox that controls whether the field is deselected. `DeselectField` wraps the field that should be deselected.
 * `Select`
   * A dropdown input.
-* `Selector`
-  * `Select` with an associated Redux `extraData` entry and optionally with a refresh button that triggers reloading the dropdown options.
 * `AsyncSelect`
-  * Similar to `Selector`, so merging these two components would be a good area for refactoring.
+  * `Select` with an associated Redux `extraData` entry and optionally with a refresh button that triggers reloading the dropdown options.
 * `FileArea`
   * A combined file input and textarea for either uploading a file or entering the text directly.
 * `ConnectedFieldList`

--- a/installer/frontend/components/aws-submit-keys.jsx
+++ b/installer/frontend/components/aws-submit-keys.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { validate } from '../validate';
-import { Connect, DocsA, Selector } from './ui';
+import { AsyncSelect, Connect, DocsA } from './ui';
 import { Field, Form } from '../form';
 
 import * as awsActions from '../aws-actions';
@@ -42,7 +42,7 @@ export const AWS_SubmitKeys = () => <div>
     <div className="col-xs-12">
       <Title />
       <Connect field={AWS_SSH}>
-        <Selector refreshBtn={true} disabledValue="Please select a SSH Key Pair from this region." />
+        <AsyncSelect refreshBtn={true} disabledValue="Please select a SSH Key Pair from this region." />
       </Connect>
       <awsSshForm.Errors />
     </div>

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -280,7 +280,7 @@ export const Select = ({id, children, value, onValue, invalid, isDirty, makeDirt
   );
 };
 
-export const Selector = props => {
+export const AsyncSelect = props => {
   const value = props.value;
   const options = _.get(props, 'extraData.options', []);
 
@@ -364,7 +364,7 @@ class Connect_ extends React.Component {
       props.checked = child.props.value === value;
       break;
     case Select:
-    case Selector:
+    case AsyncSelect:
       props.value = value || '';
       break;
     default:
@@ -428,81 +428,6 @@ export const PrivateKeyArea = (props) => <FileArea
   invalid={validate.privateKey(props.value)}
   placeholder={privateKeyPlaceholder}
 />;
-
-export class AsyncSelect extends React.Component {
-  componentDidMount () {
-    const { onChange, onRefresh, value } = this.props;
-    onRefresh && onRefresh();
-    value && onChange && onChange(value);
-  }
-
-  render () {
-    const {id, availableValues, disabledValue, value, onChange, onRefresh} = this.props;
-    const iClassNames = classNames('fa', 'fa-refresh', {
-      'fa-spin': availableValues.inFly,
-    });
-
-    let options = availableValues.value;
-    if (value && !options.map(r => r.value).includes(value)) {
-      options = [{label: value, value}].concat(options);
-    }
-    const style = {};
-    if (!onRefresh) {
-      style.marginRight = 0;
-    }
-
-    const optionElems = [];
-    const optgroups = new Map();
-
-    _.each(options, o => {
-      const elem = <option key={o.value} value={o.value}>{o.label}</option>;
-      if (!o.optgroup) {
-        optionElems.push(elem);
-        return;
-      }
-
-      if (!optgroups.get(o.optgroup)) {
-        optgroups.set(o.optgroup, []);
-      }
-      optgroups.get(o.optgroup).push(elem);
-    });
-
-    optgroups.forEach((children, label) => optionElems.push(<optgroup key={label} label={label}>{children}</optgroup>));
-
-    const props = this.props;
-
-    return (
-      <div>
-        <div className={classNames('async-select', props.className)} style={props.style}>
-          {props.children}
-          <select style={style}
-            id={id}
-            className="async-select--select"
-            value={value}
-            disabled={availableValues.inFly}
-            onChange={e => {
-              const v = e.target.value;
-              props.onValue && props.onValue(v);
-              onChange && onChange(v);
-            }}>
-            {disabledValue && <option value="" disabled>{disabledValue}</option>}
-            {optionElems}
-          </select>
-          {onRefresh &&
-            <button className="btn btn-default" disabled={availableValues.inFly} onClick={onRefresh} title="Refresh">
-              <i className={iClassNames}></i>
-            </button>
-          }
-        </div>
-        {props.invalid &&
-          <div className="wiz-error-message">
-            {props.invalid}
-          </div>
-        }
-      </div>
-    );
-  }
-}
 
 export const FieldRowList = connect(
   ({clusterConfig}, {id}) => ({

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -38,7 +38,7 @@ class Node {
     const inFlyPath = toExtraDataInFly(this.id);
     setIn(inFlyPath, true, dispatch);
 
-    return this.getExtraStuff_(dispatch, isNow).then(data => {
+    return this.getExtraStuff_(dispatch, isNow, cc).then(data => {
       if (!isNow()) {
         return;
       }


### PR DESCRIPTION
Switch single use of the old `AsyncSelect` to use `Selector` instead. Then rename `Selector` to `AsyncSelect`.