### PR TITLE
frontend: Output custom subnet tfvars if Advanced Networking is opened

### DIFF
--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -17,6 +17,7 @@ export const AWS_SESSION_TOKEN = 'awsSessionToken';
 export const AWS_SSH = 'aws_ssh';
 export const AWS_TAGS = 'awsTags';
 
+export const AWS_ADVANCED_NETWORKING = 'awsAdvancedNetworking';
 export const AWS_CREATE_VPC = 'awsCreateVpc';
 export const AWS_VPC_CIDR = 'awsVpcCIDR';
 export const AWS_VPC_ID = 'awsVpcId';
@@ -208,8 +209,9 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
   if (cc[AWS_CREATE_VPC] === VPC_CREATE) {
     ret.variables.tectonic_aws_vpc_cidr_block = cc[AWS_VPC_CIDR];
 
-    // If the subnets have not been edited, omit these variables so that sensible default subnets will be created
-    if (dirty[AWS_CONTROLLER_SUBNETS] || dirty[AWS_WORKER_SUBNETS]) {
+    // If the AWS Advanced Networking section was never opened, omit these variables so that sensible default subnets
+    // will be created
+    if (dirty[AWS_ADVANCED_NETWORKING]) {
       ret.variables.tectonic_aws_master_custom_subnets = selectedSubnets(cc, cc[AWS_CONTROLLER_SUBNETS]);
       ret.variables.tectonic_aws_worker_custom_subnets = selectedSubnets(cc, cc[AWS_WORKER_SUBNETS]);
     }

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -25,6 +25,7 @@ import { Field, Form } from '../form';
 import { toError } from '../utils';
 
 import {
+  AWS_ADVANCED_NETWORKING,
   AWS_CONTROLLER_SUBNETS,
   AWS_CONTROLLER_SUBNET_IDS,
   AWS_CREATE_VPC,
@@ -52,7 +53,6 @@ import {
   selectedSubnets,
 } from '../cluster-config';
 
-const AWS_ADVANCED_NETWORKING = 'awsAdvancedNetworking';
 const DEFAULT_AWS_VPC_CIDR = '10.0.0.0/16';
 
 const {setIn} = configActions;

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -181,10 +181,16 @@ export const Radio = props => {
 
 export const CheckBox = makeBooleanField('checkbox');
 
-export const ToggleButton = props => <button className={props.className} style={props.style} onClick={() => props.onValue(!props.value)}>
-  {props.value ? 'Hide' : 'Show'}&nbsp;{props.children}
-  <i style={{marginLeft: 7}} className={classNames('fa', {'fa-chevron-up': props.value, 'fa-chevron-down': !props.value})}></i>
-</button>;
+export const ToggleButton = connect(
+  null,
+  (dispatch, {id, onValue, value}) => ({onClick: () => {
+    onValue(!value);
+    dispatch(dirtyActions.add(id));
+  }}),
+)(({children, className, onClick, value}) => <button className={className} onClick={onClick}>
+  {value ? 'Hide' : 'Show'}&nbsp;{children}
+  <i style={{marginLeft: 7}} className={classNames('fa', {'fa-chevron-up': value, 'fa-chevron-down': !value})}></i>
+</button>);
 
 export const FileInput = connect(
   null,


### PR DESCRIPTION
It used to be that `AWS_CONTROLLER_SUBNETS` and `AWS_WORKER_SUBNETS` were
marked as dirty as soon as the Advanced Networking section was opened,
but that stopped being the case due to AWS VPC and forms changes. We
should therefore track the dirtiness of `AWS_ADVANCED_NETWORKING` itself
and use that to decide whether to output master and worker custom
subnet tfvars.