### PR TITLE
frontend: Remove non-TLS etcd support from GUI

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -572,12 +572,13 @@ input.wiz-inline-field {
 }
 
 input.wiz-inline-field.wiz-inline-field--prefix {
-  border-radius: 0 4px 4px 0;
-  margin-right: 5px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 input.wiz-inline-field.wiz-inline-field--suffix {
-  border-radius: 4px 0 0 4px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .input__prefix, .input__suffix {

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -188,7 +188,7 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
   };
 
   if (cc[ETCD_OPTION] === EXTERNAL) {
-    ret.variables.tectonic_etcd_servers = [cc[EXTERNAL_ETCD_CLIENT].replace(/^https?:\/\//, '')];
+    ret.variables.tectonic_etcd_servers = [cc[EXTERNAL_ETCD_CLIENT]];
   } else if (cc[ETCD_OPTION] === PROVISIONED) {
     ret.variables.tectonic_aws_etcd_ec2_type = etcds[INSTANCE_TYPE];
     ret.variables.tectonic_aws_etcd_root_volume_iops = etcds[STORAGE_TYPE] === 'io1' ? etcds[STORAGE_IOPS] : undefined;
@@ -271,7 +271,7 @@ export const toBaremetal_TF = ({clusterConfig: cc}, FORMS) => {
   };
 
   if (cc[ETCD_OPTION] === EXTERNAL) {
-    ret.variables.tectonic_etcd_servers = [cc[EXTERNAL_ETCD_CLIENT].replace(/^https?:\/\//, '')];
+    ret.variables.tectonic_etcd_servers = [cc[EXTERNAL_ETCD_CLIENT]];
   }
 
   if (cc[CA_TYPE] === CA_TYPES.OWNED) {

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -132,6 +132,7 @@ export const BM_Matchbox = connect(stateToProps, dispatchToProps)(
                   placeholder="matchbox.example.com:8080"
                   forceDirty={!!osError}
                   invalid={osError || httpError}
+                  style={{marginRight: 5}}
                   value={http}
                   onValue={v => this.onBootCfg(v)}>
                   <button className="btn btn-default" disabled={!!httpError} onClick={() => this.onBootCfg(http, 0)}>

--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -175,31 +175,31 @@ export const Etcd = connect(({clusterConfig}) => ({
         <etcdForm.Errors />
       </div>
     </div>
-    {etcdOption === ETCD_OPTIONS.EXTERNAL && <hr />}
-    {etcdOption === ETCD_OPTIONS.EXTERNAL &&
-      <div className="form-group">
-        <div className="row">
-          <div className="col-xs-3">
-            <label htmlFor={EXTERNAL_ETCD_CLIENT}>Client Address</label>
-          </div>
-          <div className="col-xs-8">
-            <Connect field={EXTERNAL_ETCD_CLIENT}>
-              <Input id={EXTERNAL_ETCD_CLIENT}
-                autoFocus={true}
-                className="wiz-inline-field wiz-inline-field--suffix"
-                suffix={<span className="input__suffix">:2379</span>}
-                placeholder="https://etcd.example.com" />
-            </Connect>
-            <p className="text-muted">Address of etcd client endpoint</p>
-          </div>
+    {etcdOption === ETCD_OPTIONS.EXTERNAL && <div>
+      <hr />
+      <div className="row form-group">
+        <div className="col-xs-3">
+          <label htmlFor={EXTERNAL_ETCD_CLIENT}>Client Address</label>
+        </div>
+        <div className="col-xs-8">
+          <Connect field={EXTERNAL_ETCD_CLIENT}>
+            <Input id={EXTERNAL_ETCD_CLIENT}
+              autoFocus={true}
+              className="wiz-inline-field wiz-inline-field--suffix"
+              suffix={<span className="input__suffix">:2379</span>}
+              placeholder="https://etcd.example.com" />
+          </Connect>
+          <p className="text-muted">Address of etcd client endpoint</p>
         </div>
       </div>
+    </div>
     }
-    {isAWS && etcdOption === ETCD_OPTIONS.PROVISIONED && <hr />}
-    {isAWS && etcdOption === ETCD_OPTIONS.PROVISIONED &&
+    {isAWS && etcdOption === ETCD_OPTIONS.PROVISIONED && <div>
+      <hr />
       <div className="row form-group col-xs-12">
         <DefineNode type={AWS_ETCDS} max={9} withIamRole={false} />
       </div>
+    </div>
     }
   </div>
 );

--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -116,7 +116,7 @@ const etcdForm = new Form('etcdForm', [
   }),
   new Field(EXTERNAL_ETCD_CLIENT, {
     default: '',
-    validator: validate.url,
+    validator: compose(validate.nonEmpty, validate.host),
     dependencies: [ETCD_OPTION],
     ignoreWhen: cc => cc[ETCD_OPTION] !== ETCD_OPTIONS.EXTERNAL,
   }),
@@ -181,13 +181,14 @@ export const Etcd = connect(({clusterConfig}) => ({
         <div className="col-xs-3">
           <label htmlFor={EXTERNAL_ETCD_CLIENT}>Client Address</label>
         </div>
-        <div className="col-xs-8">
+        <div className="col-xs-9">
           <Connect field={EXTERNAL_ETCD_CLIENT}>
             <Input id={EXTERNAL_ETCD_CLIENT}
               autoFocus={true}
-              className="wiz-inline-field wiz-inline-field--suffix"
+              className="wiz-inline-field wiz-inline-field--prefix wiz-inline-field--suffix"
+              prefix={<span className="input__prefix">https://</span>}
               suffix={<span className="input__suffix">:2379</span>}
-              placeholder="https://etcd.example.com" />
+              placeholder="etcd.example.com" />
           </Connect>
           <p className="text-muted">Address of etcd client endpoint</p>
         </div>

--- a/installer/frontend/ui-tests/pages/etcdConnectionPage.js
+++ b/installer/frontend/ui-tests/pages/etcdConnectionPage.js
@@ -5,13 +5,11 @@ const pageCommands = {
 
     this
       .selectOption('@optionExternal')
-      .setField('@address', 'example.com')
-      .expectValidationErrorContains('Invalid format')
-      .setField('@address', 'https://example.com:1234')
-      .expectValidationErrorContains('Invalid format')
-      .setField('@address', 'http://example.com')
-      .expectNoValidationError()
       .setField('@address', 'https://example.com')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@address', 'example.com:1234')
+      .expectValidationErrorContains('Invalid format')
+      .setField('@address', 'example.com')
       .expectNoValidationError();
 
     this.selectOption('@optionProvisioned');

--- a/installer/frontend/ui-tests/pages/etcdConnectionPage.js
+++ b/installer/frontend/ui-tests/pages/etcdConnectionPage.js
@@ -1,27 +1,31 @@
+const testExternalEtcd = page => {
+  const address = 'input[type=text]#externalETCDClient';
+  const optionExternal = 'input[type=radio]#external';
+  const optionProvisioned = 'input[type=radio]#provisioned';
+
+  page.expect.element(optionProvisioned).to.be.selected;
+  page.expect.element(address).to.not.be.present;
+
+  page
+    .selectOption(optionExternal)
+    .setField(address, 'https://example.com')
+    .expectValidationErrorContains('Invalid format')
+    .setField(address, 'example.com:1234')
+    .expectValidationErrorContains('Invalid format')
+    .setField(address, 'example.com')
+    .expectNoValidationError()
+    .selectOption(optionProvisioned)
+    .expect.element(address).to.not.be.present;
+};
+
 const pageCommands = {
   test () {
-    this.expect.element('@optionProvisioned').to.be.selected;
-    this.expect.element('@address').to.not.be.present;
-
-    this
-      .selectOption('@optionExternal')
-      .setField('@address', 'https://example.com')
-      .expectValidationErrorContains('Invalid format')
-      .setField('@address', 'example.com:1234')
-      .expectValidationErrorContains('Invalid format')
-      .setField('@address', 'example.com')
-      .expectNoValidationError();
-
-    this.selectOption('@optionProvisioned');
-    this.expect.element('@address').to.not.be.present;
+    testExternalEtcd(this);
   },
 };
 
 module.exports = {
   commands: [pageCommands],
-  elements: {
-    address: 'input[type=text]#externalETCDClient',
-    optionProvisioned: 'input[type=radio]#provisioned',
-    optionExternal: 'input[type=radio]#external',
-  },
+  elements: {},
+  testExternalEtcd,
 };

--- a/installer/frontend/ui-tests/pages/nodesPage.js
+++ b/installer/frontend/ui-tests/pages/nodesPage.js
@@ -1,3 +1,5 @@
+const {testExternalEtcd} = require('./etcdConnectionPage');
+
 const nodesPageCommands = {
   test (json) {
     this.selectOption('input[type=radio]#external');
@@ -33,6 +35,8 @@ const nodesPageCommands = {
       .setField('[id=aws_workers--storage-size]', json['aws_workers-storageSizeInGiB'])
       .selectOption(`[id=aws_etcds--instance] [value="${json['aws_etcds-instanceType']}"]`)
       .setField('[id=aws_etcds--storage-size]', json['aws_etcds-storageSizeInGiB']);
+
+    testExternalEtcd(this);
   },
 };
 


### PR DESCRIPTION
Changes the etcd address input to assume a `https://` prefix and to just store the host address without a protocol in Redux.

Also changes the external etcd GUI tests to run for both AWS and metal (was just being run for metal).

![screenshot-1](https://user-images.githubusercontent.com/460802/35265354-401ec336-0063-11e8-9908-c64d96c59577.png)
--
![screenshot-1](https://user-images.githubusercontent.com/460802/35265782-78862452-0064-11e8-91ae-91ff90704256.png)

cc: @sym3tri 