### PR TITLE
frontend: Remove 3 unnecessary comments

### DIFF
--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -181,7 +181,6 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
       tectonic_master_count: controllers[NUMBER_OF_INSTANCES],
       tectonic_service_cidr: cc[SERVICE_CIDR],
       tectonic_worker_count: workers[NUMBER_OF_INSTANCES],
-      // TODO: shouldn't hostedZoneID be specified somewhere?
       tectonic_dns_name: cc[CLUSTER_SUBDOMAIN],
     },
   };

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -161,7 +161,6 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
       AWSSecretAccessKey: cc[AWS_SECRET_ACCESS_KEY],
     },
     variables: {
-      // eslint-disable-next-line no-sync
       tectonic_admin_password: cc[ADMIN_PASSWORD],
       tectonic_aws_region: cc[AWS_REGION],
       tectonic_admin_email: cc[ADMIN_EMAIL],
@@ -245,7 +244,6 @@ export const toBaremetal_TF = ({clusterConfig: cc}, FORMS) => {
     pullSecret: cc[PULL_SECRET],
     retry: cc[RETRY],
     variables: {
-      // eslint-disable-next-line no-sync
       tectonic_admin_password: cc[ADMIN_PASSWORD],
       tectonic_cluster_name: cc[CLUSTER_NAME],
       tectonic_admin_email: cc[ADMIN_EMAIL],


### PR DESCRIPTION
The TODO is unnecessary because `hostedZoneID` is actually included in the value of `tectonic_base_domain`.