### PR TITLE
modules: fix ca-certificates mount src

### DIFF
--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-apiserver.yaml
@@ -59,7 +59,7 @@ spec:
       path: /etc/kubernetes/cloud
   - name: ssl-certs-host
     hostPath:
-      path: /usr/share/ca-certificates
+      path: /etc/ssl/certs
   - name: var-lock
     hostPath:
       path: /var/lock

--- a/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
+++ b/modules/bootkube/resources/bootstrap-manifests/bootstrap-controller-manager.yaml
@@ -33,4 +33,4 @@ spec:
       path: /etc/kubernetes
   - name: ssl-host
     hostPath:
-      path: /usr/share/ca-certificates
+      path: /etc/ssl/certs

--- a/modules/bootkube/resources/manifests/kube-apiserver.yaml
+++ b/modules/bootkube/resources/manifests/kube-apiserver.yaml
@@ -92,7 +92,7 @@ spec:
       volumes:
       - name: ssl-certs-host
         hostPath:
-          path: /usr/share/ca-certificates
+          path: /etc/ssl/certs
       - name: secrets
         secret:
           secretName: kube-apiserver

--- a/modules/bootkube/resources/manifests/kube-controller-manager.yaml
+++ b/modules/bootkube/resources/manifests/kube-controller-manager.yaml
@@ -83,5 +83,5 @@ spec:
           secretName: kube-cloud-cfg
       - name: ssl-host
         hostPath:
-          path: /usr/share/ca-certificates
+          path: /etc/ssl/certs
       dnsPolicy: Default # Don't use cluster DNS.

--- a/modules/bootkube/resources/manifests/kube-proxy.yaml
+++ b/modules/bootkube/resources/manifests/kube-proxy.yaml
@@ -53,7 +53,7 @@ spec:
         effect: "NoSchedule"
       volumes:
       - hostPath:
-          path: /usr/share/ca-certificates
+          path: /etc/ssl/certs
         name: ssl-certs-host
       - name: etc-kubernetes
         hostPath:

--- a/modules/ignition/resources/services/k8s-node-bootstrap.service
+++ b/modules/ignition/resources/services/k8s-node-bootstrap.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Bootstrap Kubernetes Node Components
 ConditionPathExists=!/etc/kubernetes/kubelet.env
+Wants=update-ca-certificates.service
+After=update-ca-certificates.service
 Before=kubelet.service
 
 [Service]
@@ -15,7 +17,7 @@ ExecStartPre=/usr/bin/docker run --rm \
             --tmpfs /tmp \
             -v /usr/share:/usr/share:ro \
             -v /usr/lib/os-release:/usr/lib/os-release:ro \
-            -v /usr/share/ca-certificates/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
+            -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
             -v /var/lib/torcx:/var/lib/torcx \
             -v /var/run/dbus:/var/run/dbus \
             -v /run/metadata:/run/metadata:ro \

--- a/modules/tectonic/resources/manifests/console/deployment.yaml
+++ b/modules/tectonic/resources/manifests/console/deployment.yaml
@@ -140,9 +140,6 @@ spec:
         - mountPath: /etc/ssl/certs
           name: ssl-certs-host
           readOnly: true
-        - mountPath: /usr/share/ca-certificates
-          name: ca-certs-host
-          readOnly: true
         - mountPath: /etc/tectonic/licenses
           name: tectonic-license-secret
           readOnly: true
@@ -164,9 +161,6 @@ spec:
       - hostPath:
           path: /etc/ssl/certs
         name: ssl-certs-host
-      - hostPath:
-          path: /usr/share/ca-certificates
-        name: ca-certs-host
       - name: tectonic-license-secret
         secret:
           secretName: tectonic-license-secret

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
@@ -51,4 +51,4 @@ spec:
       volumes:
       - name: certs
         hostPath:
-          path: /usr/share/ca-certificates
+          path: /etc/ssl/certs


### PR DESCRIPTION
This PR changes the ca-certificates mounts for:

* k8s-node-bootstrap.service; and
* tectonic-channel-operator.yaml

Rather than rely on /usr/share/ca-certificates/ca-certificates.crt they
should be using /etc/ssl/certs/ca-certificates.crt since this will
actually include admin-installed certs.

Fixes: INST-886

cc @brianredbeard @coresolve @alexsomesan