### PR TITLE
frontend: Fix default platform when all supported platforms are disabled

### DIFF
--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -45,7 +45,7 @@ const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PL
 
 const platformForm = new Form(PLATFORM_FORM, [
   new Field(PLATFORM_TYPE, {
-    default: _.find([AWS_TF, BARE_METAL_TF], isEnabled) || AWS_TF,
+    default: _.find([AWS_TF, BARE_METAL_TF], isEnabled) || _.get(window.config, 'platforms[0]'),
     validator: validate.nonEmpty,
   }),
 ], {


### PR DESCRIPTION
When all supported platforms are disabled, default to the first enabled
(unsupported) platform. This fixes a bug where the Next button was
enabled even if both AWS and bare metal platforms were disabled.