### PR TITLE
frontend: Small Platform field clean up

### DIFF
--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -7,15 +7,7 @@ import { Connect, Select } from './ui';
 import { Field, Form } from '../form';
 import { PLATFORM_TYPE, PLATFORM_FORM } from '../cluster-config';
 import { TectonicGA } from '../tectonic-ga';
-import {
-  AWS_TF,
-  BARE_METAL_TF,
-  DOCS,
-  PLATFORM_NAMES,
-  isEnabled,
-  isSupported,
-  optGroups,
-} from '../platforms';
+import { AWS_TF, BARE_METAL_TF, DOCS, PLATFORM_NAMES, isSupported, optGroups } from '../platforms';
 
 const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PLATFORM_TYPE]}))(
   ({error, platform}) => {
@@ -43,6 +35,8 @@ const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PL
     /* eslint-enable react/jsx-no-target-blank */
   });
 
+const isEnabled = platform => _.get(window.config, 'platforms', []).includes(platform);
+
 const platformForm = new Form(PLATFORM_FORM, [
   new Field(PLATFORM_TYPE, {
     default: _.find([AWS_TF, BARE_METAL_TF], isEnabled) || AWS_TF,
@@ -59,7 +53,7 @@ const platformForm = new Form(PLATFORM_FORM, [
 const platformOptions = [];
 _.each(optGroups, optgroup => {
   const [name, ...group] = optgroup;
-  const platforms = _.filter(group, p => isEnabled(p));
+  const platforms = _.filter(group, isEnabled);
   if (platforms.length) {
     platformOptions.push(<optgroup label={name} key={name}>{
       platforms.map(p => <option value={p} key={p}>{PLATFORM_NAMES[p]}</option>)

--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -50,9 +50,8 @@ const platformForm = new Form(PLATFORM_FORM, [
   }),
 ], {
   validator: (data, cc) => {
-    const platform = cc[PLATFORM_TYPE];
-    if (!isSupported(platform)) {
-      return `${PLATFORM_NAMES[platform]} not supported for GUI`;
+    if (!isSupported(cc[PLATFORM_TYPE])) {
+      return 'unused';
     }
   },
 });

--- a/installer/frontend/platforms.js
+++ b/installer/frontend/platforms.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 export const AWS = 'aws';
 export const AWS_TF = 'aws-tf';
 export const AZURE = 'azure';
@@ -8,8 +6,6 @@ export const BARE_METAL_TF = 'bare-metal-tf';
 export const OPENSTACK = 'openstack';
 
 export const isSupported = platform => [AWS_TF, BARE_METAL_TF].includes(platform);
-
-export const isEnabled = platform => _.get(window.config, 'platforms', []).includes(platform);
 
 export const PLATFORM_NAMES = {
   [AWS]: 'Amazon Web Services',


### PR DESCRIPTION
Change `platformForm`'s validator error message to `'unused'` to make it more obvious that the message is not actually displayed.

Move `isEnabled` to `cluster-type.jsx`.