### PR TITLE
platforms/metal: unbundle custom certs

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -37,7 +37,7 @@ provider "tls" {
 locals {
   // The total amount of public CA certificates present in Tectonic.
   // That is all custom CAs + kube CA + etcd CA + ingress CA
-  // This is a local constant, which needs to be dependency inject because TF cannot handle length() on computed values,
+  // This is a local constant, which needs to be dependency injected because TF cannot handle length() on computed values,
   // see https://github.com/hashicorp/terraform/issues/10857#issuecomment-268289775.
   tectonic_ca_count = "${length(var.tectonic_custom_ca_pem_list) + 3}"
 

--- a/modules/ignition/ca_certs.tf
+++ b/modules/ignition/ca_certs.tf
@@ -17,7 +17,7 @@ data "ignition_systemd_unit" "update_ca_certificates_dropin" {
 data "ignition_file" "kube_ca_cert_pem" {
   filesystem = "root"
   path       = "/etc/ssl/certs/kube_ca.pem"
-  mode       = 0400
+  mode       = 0444
   uid        = 0
   gid        = 0
 
@@ -29,7 +29,7 @@ data "ignition_file" "kube_ca_cert_pem" {
 data "ignition_file" "etcd_ca_cert_pem" {
   filesystem = "root"
   path       = "/etc/ssl/certs/etcd_ca.pem"
-  mode       = 0400
+  mode       = 0444
   uid        = 0
   gid        = 0
 
@@ -41,7 +41,7 @@ data "ignition_file" "etcd_ca_cert_pem" {
 data "ignition_file" "ingress_ca_cert_pem" {
   filesystem = "root"
   path       = "/etc/ssl/certs/ingress_ca.pem"
-  mode       = 0400
+  mode       = 0444
   uid        = 0
   gid        = 0
 
@@ -55,7 +55,7 @@ data "ignition_file" "custom_ca_cert_pem" {
 
   filesystem = "root"
   path       = "/etc/ssl/certs/custom_ca_${count.index}.pem"
-  mode       = 0400
+  mode       = 0444
   uid        = 0
   gid        = 0
 

--- a/platforms/metal/cl/bootkube-controller.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-controller.yaml.tmpl
@@ -76,11 +76,7 @@ storage:
       mode: 0644
       contents:
         inline: {{.ign_installer_runtime_mappings_json}}
-    - path: /etc/ssl/certs/custom_ca_certs.pem
-      filesystem: root
-      mode: 0400
-      contents:
-        inline: {{.ign_custom_ca_certs_json}}
+${ign_custom_ca_certs}
     - path: /etc/profile.env
       filesystem: root
       mode: 0644

--- a/platforms/metal/cl/bootkube-worker.yaml.tmpl
+++ b/platforms/metal/cl/bootkube-worker.yaml.tmpl
@@ -37,16 +37,6 @@ systemd:
 
 storage:
   files:
-    - path: /etc/kubernetes/installer/kubelet.env
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: {{.ign_installer_kubelet_env_json}}
-    - path: /etc/kubernetes/installer/runtime-mappings.yaml
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: {{.ign_installer_runtime_mappings_json}}
     - path: /etc/hostname
       filesystem: root
       mode: 0644
@@ -58,11 +48,17 @@ storage:
       mode: 0644
       contents:
         inline: {{.ign_max_user_watches_json}}
-    - path: /etc/ssl/certs/custom_ca_certs.pem
+    - path: /etc/kubernetes/installer/kubelet.env
       filesystem: root
-      mode: 0400
+      mode: 0644
       contents:
-        inline: {{.ign_custom_ca_certs_json}}
+        inline: {{.ign_installer_kubelet_env_json}}
+    - path: /etc/kubernetes/installer/runtime-mappings.yaml
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: {{.ign_installer_runtime_mappings_json}}
+${ign_custom_ca_certs}
     - path: /etc/profile.env
       filesystem: root
       mode: 0644

--- a/platforms/metal/cl/custom-ca.yaml.tmpl
+++ b/platforms/metal/cl/custom-ca.yaml.tmpl
@@ -1,0 +1,5 @@
+    - path: /etc/ssl/certs/${filename}
+      filesystem: root
+      mode: 0444
+      contents:
+        inline: "${pem}"

--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -74,7 +74,6 @@ resource "matchbox_group" "controller" {
 
     ign_bootkube_path_unit_json            = "${jsonencode(module.bootkube.systemd_path_unit_rendered)}"
     ign_bootkube_service_json              = "${jsonencode(module.bootkube.systemd_service_rendered)}"
-    ign_custom_ca_certs_json               = "${jsonencode(join("\n", module.ignition_masters.ca_cert_pem_list))}"
     ign_docker_dropin_json                 = "${jsonencode(module.ignition_masters.docker_dropin_rendered)}"
     ign_etcd_dropin_json                   = "${jsonencode(module.ignition_masters.etcd_dropin_rendered_list[count.index])}"
     ign_installer_kubelet_env_json         = "${jsonencode(module.ignition_masters.installer_kubelet_env_rendered)}"
@@ -135,7 +134,6 @@ resource "matchbox_group" "worker" {
     kubelet_image_tag  = "${replace(var.tectonic_container_images["hyperkube"],var.tectonic_image_re,"$2")}"
     kube_version_image = "${var.tectonic_container_images["kube_version"]}"
 
-    ign_custom_ca_certs_json               = "${jsonencode(join("\n", module.ignition_workers.ca_cert_pem_list))}"
     ign_docker_dropin_json                 = "${jsonencode(module.ignition_workers.docker_dropin_rendered)}"
     ign_installer_kubelet_env_json         = "${jsonencode(module.ignition_workers.installer_kubelet_env_rendered)}"
     ign_installer_runtime_mappings_json    = "${jsonencode(module.ignition_workers.installer_runtime_mappings_rendered)}"

--- a/platforms/metal/profiles.tf
+++ b/platforms/metal/profiles.tf
@@ -18,14 +18,40 @@ resource "matchbox_profile" "coreos_install" {
   container_linux_config = "${file("${path.module}/cl/coreos-install.yaml.tmpl")}"
 }
 
+data "template_file" "ign_custom_ca_certs" {
+  count    = "${local.tectonic_ca_count}"
+  template = "${file("${path.module}/cl/custom-ca.yaml.tmpl")}"
+
+  vars {
+    filename = "custom_ca_${count.index}.pem"
+    pem      = "${replace(module.ignition_masters.ca_cert_pem_list[count.index], "\n", "\n\n")}"
+  }
+}
+
+data "template_file" "bootkube_controller_profile" {
+  template = "${file("${path.module}/cl/bootkube-controller.yaml.tmpl")}"
+
+  vars {
+    ign_custom_ca_certs = "${join("", data.template_file.ign_custom_ca_certs.*.rendered)}"
+  }
+}
+
+data "template_file" "bootkube_worker_profile" {
+  template = "${file("${path.module}/cl/bootkube-worker.yaml.tmpl")}"
+
+  vars {
+    ign_custom_ca_certs = "${join("", data.template_file.ign_custom_ca_certs.*.rendered)}"
+  }
+}
+
 // Self-hosted Kubernetes Controller profile
 resource "matchbox_profile" "tectonic_controller" {
   name                   = "tectonic-controller"
-  container_linux_config = "${file("${path.module}/cl/bootkube-controller.yaml.tmpl")}"
+  container_linux_config = "${data.template_file.bootkube_controller_profile.rendered}"
 }
 
 // Self-hosted Kubernetes Worker profile
 resource "matchbox_profile" "tectonic_worker" {
   name                   = "tectonic-worker"
-  container_linux_config = "${file("${path.module}/cl/bootkube-worker.yaml.tmpl")}"
+  container_linux_config = "${data.template_file.bootkube_worker_profile.rendered}"
 }


### PR DESCRIPTION
This commit un-bundles the custom CA certificates that are passed to the
Tectonic Installer. This is needed for OpenSSL certificate hashing to
work. Without this, CAs cannot be anchored. This commit adds an
intermediate templating step to the Matchbox profile generation where
custom CA certs are inserted. Because of the fact that the Tectonic
Installer modifies the `update-ca-certificates.service` unit via a
drop-in, certificates are rehashed on every reboot so the custom CA
certs are rehashed automatically and are avaiable on the first boot to
programs compiled against OpenSSL.

Fixes: INST-885

cc @brianredbeard @coresolve @alexsomesan @sym3tri 

Related: https://github.com/coreos/tectonic-installer/pull/2813, https://github.com/coreos/tectonic-installer/pull/2814
