### PR TITLE
move dns api key to a variable

### DIFF
--- a/Documentation/variables/govcloud.md
+++ b/Documentation/variables/govcloud.md
@@ -12,7 +12,7 @@ This document gives an overview of variables used in the GovCloud AWS platform o
 | tectonic_govcloud_config_version | (internal) This declares the version of the AWS configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
 | tectonic_govcloud_dns_server_api_key | The api key of the dns server to create the records. | string | - |
 | tectonic_govcloud_dns_server_api_url | The address of the dns server api to create the records. | string | - |
-| tectonic_govcloud_dns_server_ip | The resolver api of the dns server. | string | - |
+| tectonic_govcloud_dns_server_ip | The resolver ip of the dns server. | string | - |
 | tectonic_govcloud_etcd_ec2_type | Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance | string | `t2.medium` |
 | tectonic_govcloud_etcd_extra_sg_ids | (optional) List of additional security group IDs for etcd nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_govcloud_etcd_root_volume_iops | The amount of provisioned IOPS for the root block device of etcd nodes. Ignored if the volume type is not io1. | string | `100` |

--- a/Documentation/variables/govcloud.md
+++ b/Documentation/variables/govcloud.md
@@ -10,7 +10,9 @@ This document gives an overview of variables used in the GovCloud AWS platform o
 | tectonic_dns_name | (optional) DNS prefix used to construct the console and API server endpoints. | string | `` |
 | tectonic_govcloud_assets_s3_bucket_name | (optional) Unique name under which the Amazon S3 bucket will be created. Bucket name must start with a lower case name and is limited to 63 characters. The Tectonic Installer uses the bucket to store tectonic assets and kubeconfig. If name is not provided the installer will construct the name using "tectonic_cluster_name", current AWS region and "tectonic_base_domain" | string | `` |
 | tectonic_govcloud_config_version | (internal) This declares the version of the AWS configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
-| tectonic_govcloud_dns_server_ip |  | string | - |
+| tectonic_govcloud_dns_server_api_key | The api key of the dns server to create the records. | string | - |
+| tectonic_govcloud_dns_server_api_url | The address of the dns server api to create the records. | string | - |
+| tectonic_govcloud_dns_server_ip | The resolver api of the dns server. | string | - |
 | tectonic_govcloud_etcd_ec2_type | Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance | string | `t2.medium` |
 | tectonic_govcloud_etcd_extra_sg_ids | (optional) List of additional security group IDs for etcd nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_govcloud_etcd_root_volume_iops | The amount of provisioned IOPS for the root block device of etcd nodes. Ignored if the volume type is not io1. | string | `100` |
@@ -28,9 +30,7 @@ This document gives an overview of variables used in the GovCloud AWS platform o
 | tectonic_govcloud_master_root_volume_iops | The amount of provisioned IOPS for the root block device of master nodes. Ignored if the volume type is not io1. | string | `100` |
 | tectonic_govcloud_master_root_volume_size | The size of the volume in gigabytes for the root block device of master nodes. | string | `30` |
 | tectonic_govcloud_master_root_volume_type | The type of volume for the root block device of master nodes. | string | `gp2` |
-| tectonic_govcloud_private_endpoints | (optional) If set to true, create private-facing ingress resources (ELB, A-records). If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone. | string | `true` |
 | tectonic_govcloud_profile | (optional) This declares the AWS credentials profile to use. | string | `default` |
-| tectonic_govcloud_public_endpoints | (optional) If set to true, create public-facing ingress resources (ELB, A-records). If set to false, no public-facing ingress resources will be created. | string | `false` |
 | tectonic_govcloud_ssh_key | Name of an SSH key located within the AWS region. Example: coreos-user. | string | - |
 | tectonic_govcloud_vpc_cidr_block | Block of IP addresses used by the VPC. This should not overlap with any other networks, such as a private datacenter connected via Direct Connect. | string | `10.0.0.0/16` |
 | tectonic_govcloud_worker_custom_subnets | (optional) This configures worker availability zones and their corresponding subnet CIDRs directly.<br><br>Example: `{ eu-west-1a = "10.0.64.0/20", eu-west-1b = "10.0.80.0/20" }` | map | `<map>` |

--- a/contrib/govcloud/vars.tf
+++ b/contrib/govcloud/vars.tf
@@ -58,8 +58,12 @@ output "vpc_id" {
   value = "${aws_vpc.vpc.id}"
 }
 
-output "vpc_dns" {
+output "vpc_dns_ip" {
   value = "${aws_instance.bastion.private_ip}"
+}
+
+output "dns_api_url" {
+  value = "http://${aws_instance.bastion.private_ip}:8081"
 }
 
 output "subnets" {

--- a/examples/terraform.tfvars.govcloud
+++ b/examples/terraform.tfvars.govcloud
@@ -115,7 +115,13 @@ tectonic_etcd_count = "0"
 // If name is not provided the installer will construct the name using "tectonic_cluster_name", current AWS region and "tectonic_base_domain"
 // tectonic_govcloud_assets_s3_bucket_name = ""
 
-// 
+// The api key of the dns server to create the records.
+tectonic_govcloud_dns_server_api_key = ""
+
+// The address of the dns server api to create the records.
+tectonic_govcloud_dns_server_api_url = ""
+
+// The resolver api of the dns server.
 tectonic_govcloud_dns_server_ip = ""
 
 // Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance
@@ -196,16 +202,8 @@ tectonic_govcloud_master_root_volume_size = "30"
 // The type of volume for the root block device of master nodes.
 tectonic_govcloud_master_root_volume_type = "gp2"
 
-// (optional) If set to true, create private-facing ingress resources (ELB, A-records).
-// If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
-// tectonic_govcloud_private_endpoints = true
-
 // (optional) This declares the AWS credentials profile to use.
 // tectonic_govcloud_profile = "default"
-
-// (optional) If set to true, create public-facing ingress resources (ELB, A-records).
-// If set to false, no public-facing ingress resources will be created.
-// tectonic_govcloud_public_endpoints = false
 
 // Name of an SSH key located within the AWS region. Example: coreos-user.
 tectonic_govcloud_ssh_key = ""

--- a/examples/terraform.tfvars.govcloud
+++ b/examples/terraform.tfvars.govcloud
@@ -121,7 +121,7 @@ tectonic_govcloud_dns_server_api_key = ""
 // The address of the dns server api to create the records.
 tectonic_govcloud_dns_server_api_url = ""
 
-// The resolver api of the dns server.
+// The resolver ip of the dns server.
 tectonic_govcloud_dns_server_ip = ""
 
 // Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance

--- a/modules/dns/powerdns/records.tf
+++ b/modules/dns/powerdns/records.tf
@@ -1,7 +1,7 @@
 provider "powerdns" {
   version    = "0.1.0"
-  api_key    = "tectonicgov"
-  server_url = "${var.nameserver_url}"
+  api_key    = "${var.api_key}"
+  server_url = "${var.api_url}"
 }
 
 resource "powerdns_record" "api_internal" {

--- a/modules/dns/powerdns/variables.tf
+++ b/modules/dns/powerdns/variables.tf
@@ -166,6 +166,10 @@ variable "console_elb_zone_id" {
   type        = "string"
 }
 
-variable "nameserver_url" {
+variable "api_url" {
+  type = "string"
+}
+
+variable "api_key" {
   type = "string"
 }

--- a/platforms/govcloud/main.tf
+++ b/platforms/govcloud/main.tf
@@ -6,11 +6,6 @@ provider "aws" {
 
 data "aws_availability_zones" "azs" {}
 
-locals {
-  tectonic_govcloud_private_endpoints = true
-  tectonic_govcloud_public_endpoints  = false
-}
-
 module "container_linux" {
   source = "../../modules/container_linux"
 
@@ -31,8 +26,8 @@ module "vpc" {
   external_vpc_id          = "${var.tectonic_govcloud_external_vpc_id}"
   external_worker_subnets  = "${compact(var.tectonic_govcloud_external_worker_subnet_ids)}"
   extra_tags               = "${var.tectonic_govcloud_extra_tags}"
-  private_master_endpoints = "${local.tectonic_govcloud_private_endpoints}"
-  public_master_endpoints  = "${local.tectonic_govcloud_public_endpoints}"
+  private_master_endpoints = true
+  public_master_endpoints  = false
 
   # VPC layout settings.
   #
@@ -166,8 +161,8 @@ module "masters" {
   instance_count                       = "${var.tectonic_master_count}"
   master_iam_role                      = "${var.tectonic_govcloud_master_iam_role_name}"
   master_sg_ids                        = "${concat(var.tectonic_govcloud_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
-  private_endpoints                    = "${local.tectonic_govcloud_private_endpoints}"
-  public_endpoints                     = "${local.tectonic_govcloud_public_endpoints}"
+  private_endpoints                    = true
+  public_endpoints                     = false
   root_volume_iops                     = "${var.tectonic_govcloud_master_root_volume_iops}"
   root_volume_size                     = "${var.tectonic_govcloud_master_root_volume_size}"
   root_volume_type                     = "${var.tectonic_govcloud_master_root_volume_type}"
@@ -258,7 +253,7 @@ module "dns" {
   tectonic_external_private_zone = "${var.tectonic_govcloud_external_private_zone}"
   tectonic_external_vpc_id       = "${module.vpc.vpc_id}"
   tectonic_extra_tags            = "${var.tectonic_govcloud_extra_tags}"
-  tectonic_private_endpoints     = "${local.tectonic_govcloud_private_endpoints}"
-  tectonic_public_endpoints      = "${local.tectonic_govcloud_public_endpoints}"
+  tectonic_private_endpoints     = true
+  tectonic_public_endpoints      = false
   api_key                        = "${var.tectonic_govcloud_dns_server_api_key}"
 }

--- a/platforms/govcloud/main.tf
+++ b/platforms/govcloud/main.tf
@@ -6,6 +6,11 @@ provider "aws" {
 
 data "aws_availability_zones" "azs" {}
 
+locals {
+  tectonic_govcloud_private_endpoints = true
+  tectonic_govcloud_public_endpoints  = false
+}
+
 module "container_linux" {
   source = "../../modules/container_linux"
 
@@ -26,8 +31,8 @@ module "vpc" {
   external_vpc_id          = "${var.tectonic_govcloud_external_vpc_id}"
   external_worker_subnets  = "${compact(var.tectonic_govcloud_external_worker_subnet_ids)}"
   extra_tags               = "${var.tectonic_govcloud_extra_tags}"
-  private_master_endpoints = "${var.tectonic_govcloud_private_endpoints}"
-  public_master_endpoints  = "${var.tectonic_govcloud_public_endpoints}"
+  private_master_endpoints = "${local.tectonic_govcloud_private_endpoints}"
+  public_master_endpoints  = "${local.tectonic_govcloud_public_endpoints}"
 
   # VPC layout settings.
   #
@@ -161,8 +166,8 @@ module "masters" {
   instance_count                       = "${var.tectonic_master_count}"
   master_iam_role                      = "${var.tectonic_govcloud_master_iam_role_name}"
   master_sg_ids                        = "${concat(var.tectonic_govcloud_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
-  private_endpoints                    = "${var.tectonic_govcloud_private_endpoints}"
-  public_endpoints                     = "${var.tectonic_govcloud_public_endpoints}"
+  private_endpoints                    = "${local.tectonic_govcloud_private_endpoints}"
+  public_endpoints                     = "${local.tectonic_govcloud_public_endpoints}"
   root_volume_iops                     = "${var.tectonic_govcloud_master_root_volume_iops}"
   root_volume_size                     = "${var.tectonic_govcloud_master_root_volume_size}"
   root_volume_type                     = "${var.tectonic_govcloud_master_root_volume_type}"
@@ -233,7 +238,7 @@ module "workers" {
 
 module "dns" {
   source                         = "../../modules/dns/powerdns"
-  nameserver_url                 = "http://${var.tectonic_govcloud_dns_server_ip}:8081"
+  api_url                        = "${var.tectonic_govcloud_dns_server_api_url}"
   api_external_elb_dns_name      = "${module.vpc.aws_api_external_dns_name}"
   api_external_elb_zone_id       = "${module.vpc.aws_elb_api_external_zone_id}"
   api_internal_elb_dns_name      = "${module.vpc.aws_api_internal_dns_name}"
@@ -253,6 +258,7 @@ module "dns" {
   tectonic_external_private_zone = "${var.tectonic_govcloud_external_private_zone}"
   tectonic_external_vpc_id       = "${module.vpc.vpc_id}"
   tectonic_extra_tags            = "${var.tectonic_govcloud_extra_tags}"
-  tectonic_private_endpoints     = "${var.tectonic_govcloud_private_endpoints}"
-  tectonic_public_endpoints      = "${var.tectonic_govcloud_public_endpoints}"
+  tectonic_private_endpoints     = "${local.tectonic_govcloud_private_endpoints}"
+  tectonic_public_endpoints      = "${local.tectonic_govcloud_public_endpoints}"
+  api_key                        = "${var.tectonic_govcloud_dns_server_api_key}"
 }

--- a/platforms/govcloud/tectonic.tf
+++ b/platforms/govcloud/tectonic.tf
@@ -9,8 +9,8 @@ module "bootkube" {
 
   cluster_name = "${var.tectonic_cluster_name}"
 
-  kube_apiserver_url = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
-  oidc_issuer_url    = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}/identity"
+  kube_apiserver_url = "https://${module.dns.api_internal_fqdn}:443"
+  oidc_issuer_url    = "https://${module.dns.ingress_internal_fqdn}/identity"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -54,8 +54,8 @@ module "tectonic" {
 
   cluster_name = "${var.tectonic_cluster_name}"
 
-  base_address       = "${local.tectonic_govcloud_private_endpoints  ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
-  kube_apiserver_url = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
+  base_address       = "${module.dns.ingress_internal_fqdn}"
+  kube_apiserver_url = "https://${module.dns.api_internal_fqdn}:443"
   service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.

--- a/platforms/govcloud/tectonic.tf
+++ b/platforms/govcloud/tectonic.tf
@@ -9,8 +9,8 @@ module "bootkube" {
 
   cluster_name = "${var.tectonic_cluster_name}"
 
-  kube_apiserver_url = "https://${var.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
-  oidc_issuer_url    = "https://${var.tectonic_govcloud_private_endpoints  ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}/identity"
+  kube_apiserver_url = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
+  oidc_issuer_url    = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}/identity"
 
   # Platform-independent variables wiring, do not modify.
   container_images = "${var.tectonic_container_images}"
@@ -54,8 +54,8 @@ module "tectonic" {
 
   cluster_name = "${var.tectonic_cluster_name}"
 
-  base_address       = "${var.tectonic_govcloud_private_endpoints  ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
-  kube_apiserver_url = "https://${var.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
+  base_address       = "${local.tectonic_govcloud_private_endpoints  ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
+  kube_apiserver_url = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
   service_cidr       = "${var.tectonic_service_cidr}"
 
   # Platform-independent variables wiring, do not modify.

--- a/platforms/govcloud/tls.tf
+++ b/platforms/govcloud/tls.tf
@@ -4,7 +4,7 @@ module "kube_certs" {
   ca_cert_pem        = "${var.tectonic_ca_cert}"
   ca_key_alg         = "${var.tectonic_ca_key_alg}"
   ca_key_pem         = "${var.tectonic_ca_key}"
-  kube_apiserver_url = "https://${var.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
+  kube_apiserver_url = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
   service_cidr       = "${var.tectonic_service_cidr}"
   validity_period    = "${var.tectonic_tls_validity_period}"
 }
@@ -23,7 +23,7 @@ module "etcd_certs" {
 module "ingress_certs" {
   source = "../../modules/tls/ingress/self-signed"
 
-  base_address    = "${var.tectonic_govcloud_private_endpoints ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
+  base_address    = "${local.tectonic_govcloud_private_endpoints ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
   ca_cert_pem     = "${module.kube_certs.ca_cert_pem}"
   ca_key_alg      = "${module.kube_certs.ca_key_alg}"
   ca_key_pem      = "${module.kube_certs.ca_key_pem}"

--- a/platforms/govcloud/tls.tf
+++ b/platforms/govcloud/tls.tf
@@ -4,7 +4,7 @@ module "kube_certs" {
   ca_cert_pem        = "${var.tectonic_ca_cert}"
   ca_key_alg         = "${var.tectonic_ca_key_alg}"
   ca_key_pem         = "${var.tectonic_ca_key}"
-  kube_apiserver_url = "https://${local.tectonic_govcloud_private_endpoints  ? module.dns.api_internal_fqdn : module.dns.api_external_fqdn}:443"
+  kube_apiserver_url = "https://${module.dns.api_internal_fqdn}:443"
   service_cidr       = "${var.tectonic_service_cidr}"
   validity_period    = "${var.tectonic_tls_validity_period}"
 }
@@ -23,7 +23,7 @@ module "etcd_certs" {
 module "ingress_certs" {
   source = "../../modules/tls/ingress/self-signed"
 
-  base_address    = "${local.tectonic_govcloud_private_endpoints ? module.dns.ingress_internal_fqdn : module.dns.ingress_external_fqdn}"
+  base_address    = "${module.dns.ingress_internal_fqdn}"
   ca_cert_pem     = "${module.kube_certs.ca_cert_pem}"
   ca_key_alg      = "${module.kube_certs.ca_key_alg}"
   ca_key_pem      = "${module.kube_certs.ca_key_pem}"

--- a/platforms/govcloud/variables.tf
+++ b/platforms/govcloud/variables.tf
@@ -303,7 +303,7 @@ EOF
 }
 
 variable "tectonic_govcloud_dns_server_ip" {
-  description = "The resolver api of the dns server."
+  description = "The resolver ip of the dns server."
   type        = "string"
 }
 

--- a/platforms/govcloud/variables.tf
+++ b/platforms/govcloud/variables.tf
@@ -110,24 +110,6 @@ EOF
   default = ""
 }
 
-variable "tectonic_govcloud_private_endpoints" {
-  default = true
-
-  description = <<EOF
-(optional) If set to true, create private-facing ingress resources (ELB, A-records).
-If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
-EOF
-}
-
-variable "tectonic_govcloud_public_endpoints" {
-  default = false
-
-  description = <<EOF
-(optional) If set to true, create public-facing ingress resources (ELB, A-records).
-If set to false, no public-facing ingress resources will be created.
-EOF
-}
-
 variable "tectonic_govcloud_external_private_zone" {
   default = ""
 
@@ -321,5 +303,16 @@ EOF
 }
 
 variable "tectonic_govcloud_dns_server_ip" {
-  type = "string"
+  description = "The resolver api of the dns server."
+  type        = "string"
+}
+
+variable "tectonic_govcloud_dns_server_api_url" {
+  description = "The address of the dns server api to create the records."
+  type        = "string"
+}
+
+variable "tectonic_govcloud_dns_server_api_key" {
+  description = "The api key of the dns server to create the records."
+  type        = "string"
 }

--- a/tests/rspec/lib/govcloud_vpc.rb
+++ b/tests/rspec/lib/govcloud_vpc.rb
@@ -37,7 +37,7 @@ class GovcloudVPC
       'TF_VAR_tectonic_govcloud_external_worker_subnet_ids' => @worker_subnet_ids,
       'TF_VAR_tectonic_govcloud_dns_server_ip' => @vpc_dns,
       'TF_VAR_tectonic_govcloud_dns_server_api_url' => @dns_api_url,
-      'TF_VAT_tectonic_govcloud_dns_server_api_key' => 'tectonicgov'
+      'TF_VAR_tectonic_govcloud_dns_server_api_key' => 'tectonicgov'
     }
     vars.each do |key, value|
       ENV[key] = value

--- a/tests/rspec/lib/govcloud_vpc.rb
+++ b/tests/rspec/lib/govcloud_vpc.rb
@@ -35,7 +35,9 @@ class GovcloudVPC
       'TF_VAR_tectonic_govcloud_external_vpc_id' => @vpc_id,
       'TF_VAR_tectonic_govcloud_external_master_subnet_ids' => @master_subnet_ids,
       'TF_VAR_tectonic_govcloud_external_worker_subnet_ids' => @worker_subnet_ids,
-      'TF_VAR_tectonic_govcloud_dns_server_ip' => @vpc_dns
+      'TF_VAR_tectonic_govcloud_dns_server_ip' => @vpc_dns,
+      'TF_VAR_tectonic_govcloud_dns_server_api_url' => @dns_api_url,
+      'TF_VAT_tectonic_govcloud_dns_server_api_key' => 'tectonicgov'
     }
     vars.each do |key, value|
       ENV[key] = value
@@ -64,8 +66,9 @@ class GovcloudVPC
   def parse_terraform_output
     tf_out = JSON.parse(`terraform output -json`)
     @vpn_url = tf_out['ovpn_url']['value']
-    @vpc_dns = tf_out['vpc_dns']['value']
+    @vpc_dns = tf_out['vpc_dns_ip']['value']
     @vpc_id = tf_out['vpc_id']['value']
+    @dns_api_url = tf_out['dns_api_url']['value']
     parse_subnets(tf_out)
   end
 


### PR DESCRIPTION
Move dns api key to a variable for govcloud https://github.com/coreos/tectonic-installer/pull/2834
Remove unnecessary ternaries https://github.com/coreos/tectonic-installer/pull/2838