### PR TITLE
bump tls provider to 1.0.1 to fix ca cert subject

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -31,7 +31,7 @@ provider "template" {
 }
 
 provider "tls" {
-  version = "1.0.0"
+  version = "1.0.1"
 }
 
 locals {


### PR DESCRIPTION
module/tls creates certificates with invalid distinguishedName attributes for Subject and Issuer causing certificate validation issues.

Upstream Fix: terraform-provider-tls [#10](https://github.com/terraform-providers/terraform-provider-tls/pull/10)
Fixes: #2189

Verified Fix 2018-01-26
* Tectonic: 1.8.4-tectonic.2
* Terraform: v0.11.1
* Platforms: AWS, DigitalOcean

Thanks to @seslattery for helping debug, @SpencerBrown for the upstream
fix.