### PR TITLE
modules/openstack/nodes/ignition: Remove deprecated sshd option

### DIFF
--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -80,7 +80,6 @@ data "ignition_file" "sshd" {
 
   content {
     content = <<EOF
-UsePrivilegeSeparation sandbox
 Subsystem sftp internal-sftp
 
 PermitRootLogin no


### PR DESCRIPTION
@squat I don't have permission to set labels. Tested on OpenStack.