### PR TITLE
frontend: Fix style of nodes form error

### DIFF
--- a/installer/frontend/components/make-node-form.jsx
+++ b/installer/frontend/components/make-node-form.jsx
@@ -15,7 +15,7 @@ import {
 import { Field, Form } from '../form';
 import { validate } from '../validate';
 
-export const toKey = (name, field) => `${name}-${field}`;
+export const toId = (name, field) => `${name}-${field}`;
 
 // Use this single dummy form / field to trigger loading the IAM roles list. Then IAM role fields can set this as their
 // dependency, which avoids triggering a separate API request for each field.
@@ -29,41 +29,41 @@ new Form('DUMMY_NODE_FORM', [
 ]);
 
 export const makeNodeForm = (name, instanceValidator, withIamRole = true, opts) => {
-  const storageType = toKey(name, STORAGE_TYPE);
+  const storageTypeId = toId(name, STORAGE_TYPE);
 
   // all fields must have a unique name!
   const fields = [
-    new Field(toKey(name, NUMBER_OF_INSTANCES), {
+    new Field(toId(name, NUMBER_OF_INSTANCES), {
       validator: instanceValidator,
       default: 3,
       name: NUMBER_OF_INSTANCES,
     }),
-    new Field(toKey(name, INSTANCE_TYPE), {
+    new Field(toId(name, INSTANCE_TYPE), {
       validator: validate.nonEmpty,
       default: 't2.medium',
       name: INSTANCE_TYPE,
     }),
-    new Field(toKey(name, STORAGE_SIZE_IN_GIB), {
+    new Field(toId(name, STORAGE_SIZE_IN_GIB), {
       validator: validate.int({min: 30, max: 15999}),
       default: 30,
       name: STORAGE_SIZE_IN_GIB,
     }),
-    new Field(storageType, {
+    new Field(storageTypeId, {
       validator: validate.nonEmpty,
       default: 'gp2',
       name: STORAGE_TYPE,
     }),
-    new Field(toKey(name, STORAGE_IOPS), {
+    new Field(toId(name, STORAGE_IOPS), {
       validator: validate.int({min: 100, max: 20000}),
       default: 1000,
       name: STORAGE_IOPS,
-      dependencies: [storageType],
-      ignoreWhen: cc => cc[storageType] !== 'io1',
+      dependencies: [storageTypeId],
+      ignoreWhen: cc => cc[storageTypeId] !== 'io1',
     }),
   ];
 
   if (withIamRole) {
-    fields.unshift(new Field(toKey(name, IAM_ROLE), {
+    fields.unshift(new Field(toId(name, IAM_ROLE), {
       default: IAM_ROLE_CREATE_OPTION,
       name: IAM_ROLE,
       dependencies: [IAM_ROLE],
@@ -72,11 +72,11 @@ export const makeNodeForm = (name, instanceValidator, withIamRole = true, opts) 
 
   const validator = (data) => {
     const type = data[STORAGE_TYPE];
-    const size = data[STORAGE_SIZE_IN_GIB];
+    const maxIops = 50 * data[STORAGE_SIZE_IN_GIB];
     const ops = data[STORAGE_IOPS];
 
-    if (type === 'io1' && ops > size * 50) {
-      return `IOPS can't be larger than ${size * 50} (50 IOPS/GiB)`;
+    if (type === 'io1' && ops > maxIops) {
+      return `IOPS can't be larger than ${maxIops} (50 IOPS/GiB)`;
     }
   };
 

--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -24,7 +24,7 @@ import { Field, Form } from '../form';
 import { AWS_TF } from '../platforms';
 import { toError } from '../utils';
 import { compose, validate } from '../validate';
-import { makeNodeForm, toKey } from './make-node-form';
+import { makeNodeForm, toId } from './make-node-form';
 import { A, Connect, Input, NumberInput, Radio, Select } from './ui';
 
 const Row = ({label, htmlFor, children}) => <div className="row form-group">
@@ -37,10 +37,10 @@ const Row = ({label, htmlFor, children}) => <div className="row form-group">
 </div>;
 
 const IOPs = connect(
-  ({clusterConfig}, {fieldName}) => ({type: clusterConfig[toKey(fieldName, STORAGE_TYPE)]})
+  ({clusterConfig}, {fieldName}) => ({type: clusterConfig[toId(fieldName, STORAGE_TYPE)]})
 )(
   ({type, fieldName}) => type !== 'io1' ? null : <Row htmlFor={`${fieldName}--storage-iops`} label="Storage Speed">
-    <Connect field={toKey(fieldName, STORAGE_IOPS)}>
+    <Connect field={toId(fieldName, STORAGE_IOPS)}>
       <NumberInput id={`${fieldName}--storage-iops`} className="wiz-super-short-input" suffix="&nbsp;&nbsp;IOPS" />
     </Connect>
   </Row>
@@ -50,7 +50,7 @@ const IamRoles = connect(
   ({clusterConfig}) => ({roles: _.get(clusterConfig, ['extra', IAM_ROLE], [])})
 )(
   ({roles, type}) => <Row htmlFor={`${type}--iam-role`} label="IAM Role">
-    <Connect field={toKey(type, IAM_ROLE)}>
+    <Connect field={toId(type, IAM_ROLE)}>
       <Select id={`${type}--iam-role`}>
         <option value={IAM_ROLE_CREATE_OPTION}>Create an IAM role for me (default)</option>
         {_.isArray(roles) && roles.map(r => <option value={r} key={r}>{r}</option>)}
@@ -67,12 +67,12 @@ const Errors = connect(
 export const DefineNode = ({type, max, withIamRole = true}) => <div>
   {withIamRole && <IamRoles type={type} />}
   <Row htmlFor={`${type}--number`} label="Instances">
-    <Connect field={toKey(type, NUMBER_OF_INSTANCES)}>
+    <Connect field={toId(type, NUMBER_OF_INSTANCES)}>
       <NumberInput className="wiz-super-short-input" id={`${type}--number`} min="1" max={max} />
     </Connect>
   </Row>
   <Row htmlFor={`${type}--instance`} label="Instance Type">
-    <Connect field={toKey(type, INSTANCE_TYPE)}>
+    <Connect field={toId(type, INSTANCE_TYPE)}>
       <Select id={`${type}--instance`}>
         <option value="" disabled>Please select AWS EC2 instance type</option>
         {AWS_INSTANCE_TYPES.map(({value, label}) => <option value={value} key={value}>{label}</option>)}
@@ -83,12 +83,12 @@ export const DefineNode = ({type, max, withIamRole = true}) => <div>
     </p>}
   </Row>
   <Row htmlFor={`${type}--storage-size`} label="Storage Size">
-    <Connect field={toKey(type, STORAGE_SIZE_IN_GIB)}>
+    <Connect field={toId(type, STORAGE_SIZE_IN_GIB)}>
       <NumberInput id={`${type}--storage-size`} className="wiz-super-short-input" suffix="&nbsp;&nbsp;GiB" />
     </Connect>
   </Row>
   <Row htmlFor={`${type}--storage-type`} label="Storage Type">
-    <Connect field={toKey(type, STORAGE_TYPE)}>
+    <Connect field={toId(type, STORAGE_TYPE)}>
       <Select id={`${type}--storage-type`}>
         <option value="" disabled>Please select storage type</option>
         <option value="gp2" key="gp2">General Purpose SSD (GP2)</option>


### PR DESCRIPTION
Fix nodes form error (currently just the `IOPS can't be larger than ### (50 IOPS/GiB)`) to use the form error style (`Alert`) instead of the field error style.

Also rename `toKey()` to `toId()` because we use "id" to refer to field IDs everywhere else and rename a couple of variables too.