### PR TITLE
tests: add logic to not fail when trying to send the logs to s3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
   agent none
   environment {
     KUBE_CONFORMANCE_IMAGE = 'quay.io/coreos/kube-conformance:v1.8.4_coreos.0'
+    LOGSTASH_BUCKET= "log-analyzer-tectonic-installer"
   }
   options {
     // Individual steps have stricter timeouts. 360 minutes should be never reached.
@@ -302,7 +303,6 @@ pipeline {
         TF_VAR_tectonic_container_images = "${params.hyperkube_image}"
         TF_VAR_tectonic_kubelet_debug_config = "--minimum-container-ttl-duration=8h --maximum-dead-containers-per-container=9999 --maximum-dead-containers=9999"
         GOOGLE_PROJECT = "tectonic-installer"
-        LOGSTASH_BUCKET= "log-analyzer-tectonic-installer"
       }
       steps {
         script {
@@ -416,7 +416,6 @@ pipeline {
             script {
               try {
                 sh """#!/bin/bash -xe
-                export LOGSTASH_BUCKET='log-analyzer-tectonic-installer'
                 export BUILD_RESULT=${currentBuild.currentResult}
                 ./tests/jenkins-jobs/scripts/log-analyzer-copy.sh jenkins-logs
                 """

--- a/tests/rspec/lib/name_generator.rb
+++ b/tests/rspec/lib/name_generator.rb
@@ -42,6 +42,6 @@ module NameGenerator
   end
 
   def self.generate_short_name
-    "rspec-#{Faker::Internet.user_name(5..8)}-#{Time.now.to_i}"
+    "rspec-#{Faker::Internet.user_name(5..8)}-#{SecureRandom.hex[0...RANDOM_HASH_LENGTH]}"
   end
 end


### PR DESCRIPTION
followup of: https://github.com/coreos/tectonic-installer/pull/2816

master will fail now because the env variable is not defined. was my fault. I thought we send logs only in the end. this fixes the issue.