### PR TITLE
frontend: Remove unused clusterKind option

### DIFF
--- a/installer/frontend/__tests__/examples/aws-custom-vpc-out.json
+++ b/installer/frontend/__tests__/examples/aws-custom-vpc-out.json
@@ -1,5 +1,4 @@
 {
-  "clusterKind": "tectonic-aws-tf",
   "credentials": {
     "AWSAccessKeyID": "awsAccessKeyId",
     "AWSSecretAccessKey": "awsSecretAccessKey"

--- a/installer/frontend/__tests__/examples/aws-existing-vpc-out.json
+++ b/installer/frontend/__tests__/examples/aws-existing-vpc-out.json
@@ -1,5 +1,4 @@
 {
-  "clusterKind": "tectonic-aws-tf",
   "credentials": {
     "AWSAccessKeyID": "awsAccessKeyId",
     "AWSSecretAccessKey": "awsSecretAccessKey",

--- a/installer/frontend/__tests__/examples/metal-out.json
+++ b/installer/frontend/__tests__/examples/metal-out.json
@@ -1,5 +1,4 @@
 {
-  "clusterKind": "tectonic-metal",
   "dryRun": false,
   "license": "<TECTONIC_LICENSE>",
   "platform": "metal",

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -151,7 +151,6 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
   });
 
   const ret = {
-    clusterKind: 'tectonic-aws-tf',
     dryRun: cc[DRY_RUN],
     platform: 'aws',
     license: cc[TECTONIC_LICENSE],
@@ -238,7 +237,6 @@ export const toBaremetal_TF = ({clusterConfig: cc}, FORMS) => {
   const workers = cc[BM_WORKERS];
 
   const ret = {
-    clusterKind: 'tectonic-metal',
     dryRun: cc[DRY_RUN],
     platform: 'metal',
     license: cc[TECTONIC_LICENSE],


### PR DESCRIPTION
`clusterKind` was passed from the frontend to the backend, but the backend doesn't actually use it.