### PR TITLE
config.tf: Update tectonic-alm-operator to v0.3.0

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -98,7 +98,7 @@ variable "tectonic_container_images" {
     tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.1"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.2.5"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
-    tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:0.2.1"
+    tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:v0.3.0"
   }
 }
 
@@ -133,7 +133,7 @@ variable "tectonic_versions" {
     tectonic      = "1.8.7-tectonic.1"
     tectonic-etcd = "0.0.1"
     cluo          = "0.2.5"
-    alm           = "0.2.1"
+    alm           = "0.3.0"
   }
 }
 

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -28,7 +28,8 @@ spec:
       - name: tectonic-alm-operator
         image: ${tectonic_alm_operator_image}
         command:
-        - /tectonic-x-operator
-        - --operator-name=tectonic-alm-operator
-        - --appversion-name=tectonic-alm-operator
-        - --v=2
+        - /app/x-operator/cmd/xoperator/tectonic-x-operator.binary
+        - '--operator-name=tectonic-alm-operator'
+        - '--appversion-name=tectonic-alm-operator'
+        - '--v=2'
+        - '-manifest-dir=/manifests'


### PR DESCRIPTION
This release includes subscriptions (OCS Updating) and chargeback, as well as the latest versions of Vault, Etcd, and Prometheus OCS.