### PR TITLE
Support multiple clusters per Matchbox

### DIFF
--- a/platforms/metal/matchers.tf
+++ b/platforms/metal/matchers.tf
@@ -8,7 +8,7 @@ module "container_linux" {
 // Install CoreOS to disk
 resource "matchbox_group" "coreos_install" {
   count   = "${length(var.tectonic_metal_controller_names) + length(var.tectonic_metal_worker_names)}"
-  name    = "${format("coreos-install-%s", element(concat(var.tectonic_metal_controller_names, var.tectonic_metal_worker_names), count.index))}"
+  name    = "${format("%s-coreos-install-%s", var.tectonic_cluster_name, element(concat(var.tectonic_metal_controller_names, var.tectonic_metal_worker_names), count.index))}"
   profile = "${matchbox_profile.coreos_install.name}"
 
   selector {

--- a/platforms/metal/profiles.tf
+++ b/platforms/metal/profiles.tf
@@ -1,6 +1,6 @@
 // CoreOS Install Profile
 resource "matchbox_profile" "coreos_install" {
-  name   = "coreos-install"
+  name   = "${var.tectonic_cluster_name}-coreos-install"
   kernel = "/assets/coreos/${module.container_linux.version}/coreos_production_pxe.vmlinuz"
 
   initrd = [
@@ -20,12 +20,12 @@ resource "matchbox_profile" "coreos_install" {
 
 // Self-hosted Kubernetes Controller profile
 resource "matchbox_profile" "tectonic_controller" {
-  name                   = "tectonic-controller"
+  name                   = "${var.tectonic_cluster_name}-tectonic-controller"
   container_linux_config = "${file("${path.module}/cl/bootkube-controller.yaml.tmpl")}"
 }
 
 // Self-hosted Kubernetes Worker profile
 resource "matchbox_profile" "tectonic_worker" {
-  name                   = "tectonic-worker"
+  name                   = "${var.tectonic_cluster_name}-tectonic-worker"
   container_linux_config = "${file("${path.module}/cl/bootkube-worker.yaml.tmpl")}"
 }


### PR DESCRIPTION
The installer currently overrides the Matchbox profile and groups from previously installed clusters. This makes it difficult to use for multiple clusters and simultaneous installs impossible with the same Matchbox instance.

This change prefixes Matchbox profile and group names with the cluster name to support installing multiple clusters with the same Matchbox instance.

/cc @dghubble 