### PR TITLE
Bumped Golang version to 1.9.2

### DIFF
--- a/images/kubernetes-e2e/Dockerfile
+++ b/images/kubernetes-e2e/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.9.1
+ARG GO_VERSION=1.9.2
 FROM golang:${GO_VERSION}
 
 # install e2e dependencies

--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -16,7 +16,7 @@
 # docker push quay.io/coreos/tectonic-builder:<next-semver>-upstream-terraform
 ###
 
-FROM golang:1.9.1-stretch
+FROM golang:1.9.2-stretch
 
 ### For golang testing stuff
 RUN go get -u github.com/golang/lint/golint

--- a/images/tectonic-installer/Dockerfile
+++ b/images/tectonic-installer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.1-stretch
+FROM golang:1.9.2-stretch
 
 ENV TERRAFORM_VERSION="0.11.1"
 


### PR DESCRIPTION
Trying to get the master / 1.8.7 + release-automation repo Golangs in sync.
Ref: https://jira.coreos.com/browse/TECREL-156
