### PR TITLE
Add a simple label to the `tectonic-system` namespace for NetworkPolicy

### DIFF
--- a/modules/bootkube/resources/manifests/01-tectonic-namespace.yaml
+++ b/modules/bootkube/resources/manifests/01-tectonic-namespace.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tectonic-system # Create the namespace first.
+  labels: # network policy can only select by labels
+    name: tectonic-system


### PR DESCRIPTION
NetworkPolicy can only select external namespaces by labels, not by name. So add a `name` label.