### PR TITLE
Bazel docs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -102,6 +102,7 @@ genrule(
         ":tarball_terraform_binary_linux",
         ":tarball_terraform_provider_matchbox_darwin",
         ":tarball_terraform_provider_matchbox_linux",
+        ":tarball_examples",
     ],
     outs = ["tectonic.tar.gz"],
     cmd = '\n'.join([
@@ -126,14 +127,14 @@ pkg_tar(
     name = "tarball_installer_binary_darwin",
     mode = "0755",
     package_dir = "tectonic-installer/darwin",
-    srcs = ["//installer/cmd/installer:installer_darwin"],
+    srcs = ["//installer/cmd/installer:darwin"],
 )
 
 pkg_tar(
     name = "tarball_installer_binary_linux",
     mode = "0755",
     package_dir = "tectonic-installer/linux",
-    srcs = ["//installer/cmd/installer:installer_linux"],
+    srcs = ["//installer/cmd/installer:linux"],
 )
 
 pkg_tar(
@@ -162,6 +163,14 @@ pkg_tar(
     mode = "0755",
     package_dir = "tectonic-installer/linux",
     srcs = ["@terraform_provider_matchbox_linux//:terraform-provider-matchbox"],
+)
+
+load("//:variables.bzl", "PLATFORMS")
+
+pkg_tar(
+    name = "tarball_examples",
+    package_dir = "examples",
+    srcs = ["//examples:terraform.tfvars." + p for p in PLATFORMS],
 )
 
 filegroup(

--- a/Documentation/dev/build.md
+++ b/Documentation/dev/build.md
@@ -1,0 +1,142 @@
+# Building Tectonic Installer
+
+The Tectonic Installer leverages the [Bazel build system](https://bazel.build/) to build all artifacts, binaries, and documentation.
+
+## Getting Started
+
+Install Bazel > 0.10.x using the instructions [provided online](https://docs.bazel.build/versions/master/install.html).
+*Note*: compiling Bazel from source requires Bazel.
+*Note*: cross-compilation of Golang binaries, which the Tectonic Installer leverages, is [broken in Bazel 0.9.0](https://github.com/bazelbuild/rules_go/issues/1161).
+
+Clone the Tectonic Installer git repository locally:
+
+```sh
+git clone git@github.com:coreos/tectonic-installer.git && cd tectonic-installer
+```
+
+## Quickstart
+
+To build Tectonic for development or testing, run the `tarball` script located in the base directory:
+
+```sh
+./tarball
+```
+
+This will produce an archive named `tectonic.tar.gz` containing all the assets necessary to bring up a Tectonic cluster, namely the:
+
+* Tectonic Installer binary;
+* Terraform modules;
+* Terraform binary;
+* Terraform provider binaries; and
+* examples
+
+To build a versioned Tectonic release tarball, set a `VERSION` environment variable and run the `tarball` script:
+
+```sh
+export VERSION=1.2.3-beta
+./tarball
+```
+
+This will create an archive named `tectonic_1.2.3-beta.tar.gz` in the base directory.
+
+For more details on building a Tectonic release or other Tectonic assets as well as workarounds to some known issues, read on.
+
+## Building A Release Tarball
+
+To build a release tarball for the Tectonic Installer, issue the following command from the `tectonic-installer` root directory:
+
+```sh
+bazel build tarball
+```
+
+*Note*: Bazel < 0.9.0 is known to [fail to build tarballs when using Python 3](https://github.com/bazelbuild/bazel/issues/3816); to avoid this issue, force Python 2 by using:
+
+```sh
+bazel build --force_python=py2 --python_path=/usr/bin/python2 tarball
+```
+
+This will create a tarball named `tectonic.tar.gz` in the `bazel-bin` directory with the following directory structure:
+
+```
+tectonic
+├── config.tf
+├── examples
+├── modules
+├── platforms
+└── tectonic-installer
+    ├── darwin
+    │   ├── terraform
+    │   └── terraform-provider-matchbox
+    └── linux
+        ├── installer
+        ├── terraform
+        └── terraform-provider-matchbox
+```
+
+*Note*: declarative cross-compilation of Golang binaries from Linux to other platforms is [currently broken in Bazel](https://github.com/bazelbuild/rules_go/issues/1148) so the tarball will not include a Darwin binary. 
+
+To build a tarball with the Darwin binary included, run the temporary `tarball` script:
+
+```sh
+./tarball
+```
+
+In order to build a release tarball with the version string in the directory name within the tarball, export a `VERSION` environment variable and then build the tarball while passing the variable to the build:
+
+```sh
+export VERSION=1.2.3-beta
+bazel build tarball --action_env=VERSION
+```
+
+This will create a tarball named `tectonic.tar.gz` in the `bazel-bin` directory with the following directory structure:
+
+```
+tectonic_1.2.3-beta
+├── config.tf
+├── examples
+├── modules
+├── platforms
+└── tectonic-installer
+```
+
+*Note*: the generated tarball will not include the version string in its own name since output names must be known ahead of time in Bazel. To include the version in the tarball name copy or move the archive with the desired name in the destination.
+
+Similarly, to build a versioned tarball with the Darwin binary included, export the `VERSION` environment variable and run the `tarball` shell script:
+
+```sh
+export VERSION=1.2.3-beta
+./tarball
+```
+
+This will create a tarball named `tectonic_1.2.3-beta.tar.gz` in the base directory.
+
+
+## Building the Installer Binary
+
+For cases where the entire Tectonic tarball is not needed and only the Tectonic Installer GUI is required, the installer binary can be built by itself.
+To build the Tectonic Installer binary, issue the following command from the `tectonic-installer` root directory:
+
+```sh
+bazel build backend
+```
+
+This will produce a binary located at `bazel-bin/installer/cmd/installer/linux_amd64_pure_stripped/installer` when built on a Linux machine or `bazel-bin/installer/cmd/installer/darwin_amd64_pure_stripped/installer` if built on a Mac.
+
+To build a cross-compiled binary for another platform, e.g. a Darwin binary on a Linux machine, specify the target platform explicitly:
+
+```sh
+bazel build backend --experimental_platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64
+```
+
+## Building the Smoke Test Binary
+
+We are also using Bazel to build the smoke test binary. To do so, run:
+
+```sh
+bazel build tests/smoke
+```
+
+This operation will produce a binary located at `bazel-bin/tests/smoke/linux_amd64_stripped/smoke`, if on a Linux machine, or `bazel-bin/tests/smoke/darwin_amd64_stripped/smoke`, if on a Mac.
+Follow the [smoke test instructions][smoke-test] to test a Tectonic cluster using this newly compiled binary.
+
+[smoke-test]: ../../tests/smoke/README.md

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -10,4 +10,5 @@ EXAMPLES = {p: (PLATFORMS[p] + "/variables.tf", "terraform.tfvars." + p) for p i
     outs = [example[1][1]],
     cmd = "$(location //contrib/terraform-examples:terraform-examples) $(SRCS) > $@",
     tools = ["//contrib/terraform-examples:terraform-examples"],
+    visibility = ["//visibility:public"],
 ) for example in EXAMPLES.items()]

--- a/installer/cmd/installer/BUILD.bazel
+++ b/installer/cmd/installer/BUILD.bazel
@@ -27,7 +27,8 @@ go_binary(
 )
 
 go_binary(
-    name = "installer_darwin",
+    name = "darwin",
+    basename = "installer",
     embed = [":go_default_library"],
     importpath = "github.com/coreos/tectonic-installer/installer/cmd/installer",
     visibility = ["//visibility:public"],
@@ -35,10 +36,12 @@ go_binary(
     # This has the nice side effect of making the binary statically linked.
     pure = "on",
     goos = "darwin",
+    goarch = "amd64",
 )
 
 go_binary(
-    name = "installer_linux",
+    name = "linux",
+    basename = "installer",
     embed = [":go_default_library"],
     importpath = "github.com/coreos/tectonic-installer/installer/cmd/installer",
     visibility = ["//visibility:public"],
@@ -46,4 +49,5 @@ go_binary(
     # This has the nice side effect of making the binary statically linked.
     pure = "on",
     goos = "linux",
+    goarch = "amd64",
 )

--- a/tarball
+++ b/tarball
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+VERSION=${VERSION:-}
+DIR=tectonic
+[ ! -z "$VERSION" ] && DIR="$DIR"_"$VERSION"
+
+bazel build tarball --action_env=VERSION
+bazel build backend --experimental_platforms=@io_bazel_rules_go//go/toolchain:darwin_amd64
+TEMP="$(mktemp -d)"
+tar -xzf bazel-bin/tectonic.tar.gz -C "$TEMP"
+cp bazel-bin/installer/cmd/installer/darwin_amd64_pure_stripped/installer "$TEMP"/"$DIR"/tectonic-installer/darwin/
+tar -C "$TEMP"/ -czf "$DIR".tar.gz "$DIR"


### PR DESCRIPTION
Notable changes:

- bazel: add terraform examples to tarball
- installer: refactor so binaries do not have platform suffix
- tarball: add helper to build tarball with darwin bin
- Documentation: add docs for building with bazel

fixes: INST-747

cc @alexsomesan @mxinden 