### PR TITLE
Hack to allow interrupted bootkube to restart after torcx reboot

### DIFF
--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Hack to clear static manifests that may have been created by bootkube
+# between k8s-node-bootstrapper finishing and the initial reboot.
+rm -rf /etc/kubernetes/manifests
+
 # When self-hosted etcd is enabled, bootkube places an static pod manifest in
 # /etc/kubernetes/manifests for Kubelet to boot a temporary etcd instance.
 # However, Kubelet might not have started yet and therefore the folder might


### PR DESCRIPTION
In the case that bootkube is able to start between k8s-node-bootstrapper finishing and the machine going down for reboot, bootkube will create some static manifests in /etc/kubernetes/manifests then be interrupted and never bring up a full control plane. The existence of these manifests will prevent bootkube from running successfully on the next reboot due to errors like:

```
Feb 02 21:14:56 node001.metal.k8s.work systemd[1]: Stopped Bootstrap a Kubernetes cluster.
-- Reboot --
Feb 02 21:15:18 node001.metal.k8s.work systemd[1]: Starting Bootstrap a Kubernetes cluster...
Feb 02 21:15:25 node001.metal.k8s.work bash[5768]: Starting temporary bootstrap control plane...
Feb 02 21:15:25 node001.metal.k8s.work bash[5768]: Error: open /etc/kubernetes/manifests/bootstrap-apiserver.yaml: file exists
Feb 02 21:15:25 node001.metal.k8s.work bash[5768]: Tearing down temporary bootstrap control plane...
Feb 02 21:15:25 node001.metal.k8s.work bash[5768]: Error: open /etc/kubernetes/manifests/bootstrap-apiserver.yaml: file exists
Feb 02 21:15:25 node001.metal.k8s.work bash[5768]: open /etc/kubernetes/manifests/bootstrap-apiserver.yaml: file exists
Feb 02 21:15:25 node001.metal.k8s.work systemd[1]: bootkube.service: Main process exited, code=exited, status=1/FAILURE
Feb 02 21:15:25 node001.metal.k8s.work systemd[1]: bootkube.service: Failed with result 'exit-code'.
Feb 02 21:15:25 node001.metal.k8s.work systemd[1]: Failed to start Bootstrap a Kubernetes cluster.
```

as documented in TECREL-153.

This commit implements a hack to ensure that the static manifests directory is empty before bootkube starts to allow an interrupted bootkube to restart on a machine reboot.

cc @coresolve 