### PR TITLE
platforms/vmware: Use NodePort for tectonic-lb service

### DIFF
--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -131,7 +131,7 @@ module "tectonic" {
 
   console_client_id = "tectonic-console"
   kubectl_client_id = "tectonic-kubectl"
-  ingress_kind      = "HostPort"
+  ingress_kind      = "NodePort"
   self_hosted_etcd  = "${var.tectonic_self_hosted_etcd}"
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"


### PR DESCRIPTION
Currently, the VMware platform uses a HostPort service for the tectonic
ingress controller which exposes port 443 on all worker nodes.  This
change will route https traffic to port 32000 for tectonic ingress.

