### PR TITLE
frontend: Remove CSS rule that actually makes vertical alignment worse

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -627,7 +627,6 @@ span.spacer {
 .deselect {
   display: inline-block;
   margin-right: 5px;
-  vertical-align: -2px;
 }
 
 .log-pane {


### PR DESCRIPTION
Before | After
--- | ---
![screenshot-1](https://user-images.githubusercontent.com/460802/35955299-e4d46c8a-0cd1-11e8-8451-b1a127806f7d.png) | ![screenshot-2](https://user-images.githubusercontent.com/460802/35955302-e9d73ac8-0cd1-11e8-91c2-e221aff06e79.png)
