### PR TITLE
frontend: Use external link icons more consistently

### DIFF
--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { compose, validate } from '../validate';
-import { A, DocsA, Input, Password, Select, RadioBoolean, Connect } from './ui';
+import { A, DocsA, ExternalLinkIcon, Input, Password, Select, RadioBoolean, Connect } from './ui';
 import { Alert } from './alert';
 
 import { getRegions } from '../aws-actions';
@@ -161,7 +161,7 @@ export const AWS_CloudCredentials = connect(stateToProps)(
               Use a normal access key
             </label>&nbsp;(default)
             <p className="text-muted">
-              Go to the <A href="https://console.aws.amazon.com/iam/home#/users">AWS console user section</A>, select your user name, and the Security Credentials tab.
+              Go to the <A href="https://console.aws.amazon.com/iam/home#/users">AWS console user section<ExternalLinkIcon /></A>, select your user name, and the Security Credentials tab.
             </p>
           </div>
           <div className="wiz-radio-group__body">

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { compose, validate } from '../validate';
 import { getDefaultSubnets, getZones, getVpcs, getVpcSubnets, validateSubnets } from '../aws-actions';
-import { A, AsyncSelect, Connect, Deselect, DeselectField, DocsA, Input, Radio, Select, ToggleButton } from './ui';
+import { A, AsyncSelect, Connect, Deselect, DeselectField, DocsA, ExternalLinkIcon, Input, Radio, Select, ToggleButton } from './ui';
 import { Alert } from './alert';
 import { configActions } from '../actions';
 import { AWS_DomainValidation } from './aws-domain-validation';
@@ -324,7 +324,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
     <hr />
 
     <p className="text-muted">
-      Please select a Route 53 hosted zone. For more information, see AWS Route 53 docs on <A href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html">Working with Hosted Zones</A>.
+      Please select a Route 53 hosted zone. For more information, see AWS Route 53 docs on <A href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/AboutHZWorkingWith.html">Working with Hosted Zones<ExternalLinkIcon /></A>.
     </p>
     <div className="row form-group">
       <div className="col-xs-2">
@@ -354,7 +354,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
             </Select>
           </Connect>
           <p className="text-muted wiz-help-text">
-            See AWS <A href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html">Split-View DNS documentation&nbsp;<i className="fa fa-external-link" /></A>
+            See AWS <A href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html">Split-View DNS documentation<ExternalLinkIcon /></A>
           </p>
         </div>
       </div>
@@ -384,7 +384,7 @@ export const AWS_VPC = connect(stateToProps, dispatchToProps)(props => {
           </Alert>
           <div className="row form-group">
             <div className="col-xs-12">
-              Specify a range of IPv4 addresses for the VPC in the form of a <A href="https://tools.ietf.org/html/rfc4632">CIDR block</A>. Safe defaults have been chosen for you.
+              Specify a range of IPv4 addresses for the VPC in the form of a <A href="https://tools.ietf.org/html/rfc4632">CIDR block<ExternalLinkIcon /></A>. Safe defaults have been chosen for you.
             </div>
           </div>
           <CIDRRow name="CIDR Block" field={AWS_VPC_CIDR} placeholder={DEFAULT_AWS_VPC_CIDR} />

--- a/installer/frontend/components/cluster-type.jsx
+++ b/installer/frontend/components/cluster-type.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { validate } from '../validate';
-import { Connect, DocsA, Select } from './ui';
+import { Connect, DocsA, ExternalLinkIcon, Select } from './ui';
 import { Field, Form } from '../form';
 import { PLATFORM_TYPE, PLATFORM_FORM } from '../cluster-config';
 import { TectonicGA } from '../tectonic-ga';
@@ -12,22 +12,21 @@ import { AWS_TF, BARE_METAL_TF, DOCS, PLATFORM_NAMES, isSupported, optGroups } f
 const ErrorComponent = connect(({clusterConfig}) => ({platform: clusterConfig[PLATFORM_TYPE]}))(
   ({error, platform}) => {
     const platformName = PLATFORM_NAMES[platform];
-    const icon = <i className="fa fa-external-link" />;
     if (error) {
       return <p>
         Use the documentation and the Terraform CLI to install a cluster with specific infrastructure use-cases.
         This method is designed for automation and doesn't use the graphical installer.
         <br />
         <DocsA path={DOCS[platform]}>
-          <button className="btn btn-primary" style={{marginTop: 8}}>{platformName && platformName.split('(Alpha)')[0]} Docs&nbsp;&nbsp;{icon}</button>
+          <button className="btn btn-primary" style={{marginTop: 8}}>{platformName && platformName.split('(Alpha)')[0]} Docs<ExternalLinkIcon /></button>
         </DocsA>
       </p>;
     }
     return <p className="text-muted">
       Use the graphical installer to input cluster details, this is best for demos and your first Tectonic cluster.
       &nbsp;&nbsp;{platform === BARE_METAL_TF
-        ? <span><br />{platformName} <DocsA path="/install/bare-metal/requirements.html">requirements&nbsp;&nbsp;{icon}</DocsA> and <DocsA path={DOCS[platform]}>install guide&nbsp;&nbsp;{icon}</DocsA>.</span>
-        : <DocsA path={DOCS[platform]}>{platformName} documentation&nbsp;&nbsp;{icon}</DocsA>}
+        ? <span><br />{platformName} <DocsA path="/install/bare-metal/requirements.html">requirements<ExternalLinkIcon /></DocsA> and <DocsA path={DOCS[platform]}>install guide<ExternalLinkIcon /></DocsA>.</span>
+        : <DocsA path={DOCS[platform]}>{platformName} documentation<ExternalLinkIcon /></DocsA>}
     </p>;
   });
 

--- a/installer/frontend/components/dry-run.jsx
+++ b/installer/frontend/components/dry-run.jsx
@@ -6,7 +6,7 @@ export const DryRun = () => <div className="row">
   <div className="col-xs-12">
     <div className="form-group">
       Your cluster assets have been created. You can download these <DocsA path="/admin/assets-zip.html">assets</DocsA> and customize underlying infrastructure as needed.
-      Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.&nbsp; <DocsA path="/install/aws/manual-boot.html">Read more here.&nbsp;&nbsp;<i className="fa fa-external-link" /></DocsA>
+      Note: changes to Kubernetes manifests or Tectonic components run in the cluster are not supported.&nbsp; <DocsA path="/install/aws/manual-boot.html">Read more here.</DocsA>
     </div>
     <div className="from-group">
       <div className="wiz-giant-button-container">

--- a/installer/frontend/components/success.jsx
+++ b/installer/frontend/components/success.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { getTectonicDomain, PLATFORM_TYPE } from '../cluster-config';
 import { TectonicGA } from '../tectonic-ga';
+import { ExternalLinkIcon } from './ui';
 
 const handleAllDone = (platformType) => TectonicGA.sendEvent('Installer Button', 'click', 'User clicks over to the console', platformType);
 
@@ -35,7 +36,7 @@ export const Success = connect(stateToProps)(
         <a href={`https://${tectonicDomain}`} target="_blank">
           <button className="btn btn-primary wiz-giant-button"
             style={{marginTop: 20, marginBottom: 80}}
-            onClick={() => handleAllDone(platformType)}>Go to my Tectonic Console&nbsp;&nbsp;<i className="fa fa-external-link"></i></button>
+            onClick={() => handleAllDone(platformType)}>Go to my Tectonic Console<ExternalLinkIcon /></button>
         </a>
       </div>
     </div>

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -59,6 +59,8 @@ const FIELD_PROPS = ImmutableSet([
   'width',
 ]);
 
+export const ExternalLinkIcon = () => <i className="fa fa-external-link" style={{marginLeft: 5}} />;
+
 // Same as an <a> except defaults to rel="noopener noreferrer" and target="_blank"
 export const A = props => <a rel="noopener noreferrer" target="_blank" {...props} />;
 


### PR DESCRIPTION
Consistently use the external link icon for non coreos.com links and don't use it for coreos.com links. The only exception is the on the first wizard page (select platform page).

Add `ExternalLinkIcon` component.

cc @robszumski 

### Changed Pages
Before | After
--- | ---
![screenshot-5](https://user-images.githubusercontent.com/460802/35958699-73a14556-0ce5-11e8-9e26-8eac08d08f53.png) | ![screenshot-1](https://user-images.githubusercontent.com/460802/35958696-6fc71a64-0ce5-11e8-9db5-ffd9a511571c.png)
![screenshot-6](https://user-images.githubusercontent.com/460802/35958724-a39838f0-0ce5-11e8-93e8-58cc4e2343e1.png) | ![screenshot-2](https://user-images.githubusercontent.com/460802/35958722-9d793f8c-0ce5-11e8-8ffb-4a879867334e.png)
![screenshot-3](https://user-images.githubusercontent.com/460802/35958733-ae72a9ae-0ce5-11e8-8216-a51510654d1f.png) | ![screenshot-4](https://user-images.githubusercontent.com/460802/35958735-b1d781d2-0ce5-11e8-9414-bd50d9971114.png)