### PR TITLE
frontend: Add additional info for AWS VPCs and subnets

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -496,9 +496,9 @@ input.wiz-super-short-input {
   color: #fff;
   display: block;
   left: 50%;
-  max-width: 400px;
+  max-width: 500px;
   opacity: 0;
-  padding: 8px 15px 6px;;
+  padding: 8px 15px 6px;
   pointer-events: none;
   position: absolute;
   text-align: center;

--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -205,7 +205,7 @@ export const AWS_CloudCredentials = connect(stateToProps)(
       </div>
       <div className="col-xs-8">
         <Connect field={AWS_REGION}>
-          <Select id="awsRegion" availableValues={regionSelections} disabled={regionSelections.inFly}>
+          <Select id="awsRegion" options={regionSelections.value} disabled={regionSelections.inFly}>
             <option value="" disabled>Please select region</option>
           </Select>
         </Connect>

--- a/installer/frontend/components/cidr.jsx
+++ b/installer/frontend/components/cidr.jsx
@@ -2,36 +2,31 @@ import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { CIDR, Connect, Deselect } from './ui';
+import { CIDR, Connect, Deselect, localeNum } from './ui';
 import { cidrEnd, cidrSize, cidrStart } from '../cidr';
-import { DESELECTED_FIELDS } from '../cluster-config';
 
-const CIDRTooltip = connect(
-  ({clusterConfig}, {field}) => ({cidr: _.get(clusterConfig, field)})
-)(({cidr}) => {
+export const CIDRTooltip = ({cidr}) => {
   const size = cidrSize(cidr);
   if (!_.isInteger(size)) {
     return null;
   }
   return <div className="tooltip">
-    {size.toLocaleString('en', {useGrouping: true})} IP address{size > 1 && 'es'} ({size === 1 ? cidrStart(cidr) : `${cidrStart(cidr)} to ${cidrEnd(cidr)}`})
-  </div>;
-});
-
-export const CIDRRow = ({field, name, disabled, placeholder, autoFocus, selectable, fieldName, validator}) => {
-  fieldName = fieldName || field;
-  return <div className="row form-group">
-    <div className="col-xs-4">
-      {selectable && <Deselect field={fieldName} />}
-      <label htmlFor={(selectable ? `${DESELECTED_FIELDS}.` : '') + fieldName}>{name}</label>
-    </div>
-    <div className="col-xs-5">
-      <div className="withtooltip">
-        <Connect field={field}>
-          <CIDR autoFocus={autoFocus} disabled={disabled} id={field} placeholder={placeholder} validator={validator} />
-        </Connect>
-        <CIDRTooltip field={field} />
-      </div>
-    </div>
+    {localeNum(size)} IP address{size > 1 && 'es'} ({size === 1 ? cidrStart(cidr) : `${cidrStart(cidr)} to ${cidrEnd(cidr)}`})
   </div>;
 };
+
+export const CIDRRow = connect(
+  ({clusterConfig}, {field}) => ({cidr: _.get(clusterConfig, field)})
+)(({autoFocus, cidr, deselectId, disabled, field, placeholder, name, validator}) => <div className="row form-group">
+  <div className="col-xs-4">
+    {deselectId ? <Deselect field={deselectId} label={name} /> : <label htmlFor={field}>{name}</label>}
+  </div>
+  <div className="col-xs-5">
+    <div className="withtooltip">
+      <Connect field={field}>
+        <CIDR autoFocus={autoFocus} disabled={disabled} id={field} placeholder={placeholder} validator={validator} />
+      </Connect>
+      <CIDRTooltip cidr={cidr} />
+    </div>
+  </div>
+</div>);

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -61,6 +61,8 @@ const FIELD_PROPS = ImmutableSet([
 
 export const ExternalLinkIcon = () => <i className="fa fa-external-link" style={{marginLeft: 5}} />;
 
+export const localeNum = num => num.toLocaleString('en', {useGrouping: true});
+
 // Same as an <a> except defaults to rel="noopener noreferrer" and target="_blank"
 export const A = props => <a rel="noopener noreferrer" target="_blank" {...props} />;
 
@@ -238,10 +240,9 @@ export const FileArea = props => {
 // <Select id:REQUIRED value onValue>
 //   <option....>
 // </Select>
-export const Select = ({id, children, value, onValue, invalid, isDirty, makeDirty, availableValues, className, disabled, style}) => {
+export const Select = ({id, children, value, onValue, invalid, isDirty, makeDirty, options, className, disabled, style}) => {
   const optionElems = [];
-  if (availableValues) {
-    let options = availableValues.value;
+  if (options) {
     if (value && !options.map(r => r.value).includes(value)) {
       options = [{label: value, value}].concat(options);
     }
@@ -380,7 +381,7 @@ class Connect_ extends React.Component {
 
 export const Connect = connect(stateToProps, dispatchToProps)(Connect_);
 
-// if undefined, default to true
+// If undefined, default to not deselected
 const stateToIsDeselected = ({clusterConfig}, {field}) => {
   field = `${DESELECTED_FIELDS}.${field}`;
   return {
@@ -392,13 +393,16 @@ const stateToIsDeselected = ({clusterConfig}, {field}) => {
 export const Deselect = connect(
   stateToIsDeselected,
   {updateField: configActions.updateField}
-)(({field, isDeselected, updateField}) => <span className="deselect">
-  <CheckBox id={field} value={!isDeselected} onValue={v => updateField(field, !v)} />
-</span>);
+)(({field, isDeselected, label, updateField}) => <div>
+  <span className="deselect">
+    <CheckBox id={field} value={!isDeselected} onValue={v => updateField(field, !v)} />
+  </span>
+  <label htmlFor={field}>{label}</label>
+</div>);
 
 export const DeselectField = connect(stateToIsDeselected)(({children, isDeselected}) => React.cloneElement(
   React.Children.only(children),
-  {disabled: isDeselected, selectable: true}
+  {disabled: isDeselected}
 ));
 
 const certPlaceholder = `Paste your certificate here. It should start with:


### PR DESCRIPTION
For VPCs, add CIDR to dropdown labels and add CIDR tooltip with number of IP addresses and address range.

For subnets, add Name (from AWS tag) to dropdown labels and add CIDR tooltip with number IP addresses, address range and number of available addresses.

Change label format of both dropdowns to `<CIDR> (<NAME> | <ID>)`, which matches the format in AWS Console.

Change `Select` to accept an `options` array instead of an `availableValues` object.

Change `Deselect` to also output the field label, which makes things easier because the deselect checkbox is expected to be rendered alongside the label and it's easier to ensure they use matching `id` / `htmlFor` attributes if they are rendered together.

Rename `fieldName` to `deselectId` and change `CIDRRow` to take `deselectId` instead of a `selectable` boolean.

cc @robszumski 

Before | After
--- | ---
![screenshot-2](https://user-images.githubusercontent.com/460802/35965605-c7662d6e-0cfe-11e8-9c95-b9404a117772.png) | ![screenshot-1](https://user-images.githubusercontent.com/460802/35965590-c02a2bfe-0cfe-11e8-8ccd-c15ea57c3365.png)