### PR TITLE
Installer API: Add buildTime and tectonicVersion

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --color=yes --workspace_status_command=./buildvars.sh

--- a/buildvars.sh
+++ b/buildvars.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -ex
+
+# Vars exported to the build info
+echo TECTONIC_VERSION ${TECTONIC_VERSION}
+echo BUILD_TIME $(date -u '+%d_%b_%Y_%I:%M:%S%p')

--- a/installer/api/BUILD.bazel
+++ b/installer/api/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//installer/assets:go_default_library",
+        "//installer/version:go_default_library",
         "//installer/pkg/aws:go_default_library",
         "//installer/pkg/containerlinux:go_default_library",
         "//installer/pkg/terraform:go_default_library",

--- a/installer/api/api.go
+++ b/installer/api/api.go
@@ -103,6 +103,7 @@ func New(config *Config) (http.Handler, error) {
 
 	//handlers_latest_release.go
 	mux.Handle("/releases/latest", logRequests(httpHandler("GET", ctx, latestReleaseHandler)))
+	mux.Handle("/releases/current", logRequests(httpHandler("GET", ctx, currentReleaseHandler)))
 	return mux, nil
 }
 

--- a/installer/api/handlers_latest_release.go
+++ b/installer/api/handlers_latest_release.go
@@ -3,6 +3,8 @@ package api
 import (
 	"io"
 	"net/http"
+
+	"github.com/coreos/tectonic-installer/installer/version"
 )
 
 // latestReleaseHandler gets the tectonic's latest release from coreos.com.
@@ -14,4 +16,17 @@ func latestReleaseHandler(w http.ResponseWriter, req *http.Request, _ *Context) 
 	io.Copy(w, res.Body)
 	res.Body.Close()
 	return nil
+}
+
+// Fetch tectonic's Build version and return in JSON format
+func currentReleaseHandler(w http.ResponseWriter, req *http.Request, _ *Context) error {
+	version := struct {
+		TectonicVersion string `json:"tectonicVersion"`
+		BuildTime       string `json:"buildTime"`
+	}{
+		TectonicVersion: version.TectonicVersion,
+		BuildTime:       version.BuildTime,
+	}
+
+	return writeJSONResponse(w, req, http.StatusOK, version)
 }

--- a/installer/version/BUILD.bazel
+++ b/installer/version/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["version.go"],
+    importpath = "github.com/coreos/tectonic-installer/installer/version",
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "TectonicVersion": "{TECTONIC_VERSION}",
+        "BuildTime": "{BUILD_TIME}"
+    },
+)

--- a/installer/version/version.go
+++ b/installer/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+// TectonicVersion - defaults to 'dev-build' if TECTONIC_VERSION was not set
+var TectonicVersion = "dev-build"
+
+// BuildTime - set to $(date -u '+%d_%b_%Y_%I:%M:%S%p')
+var BuildTime string


### PR DESCRIPTION
this will add a new endpoint `/releases/current` to the API
which will fetch TECTONIC_VERSION from the build environment
and displays the build time in a JSON format.
