### PR TITLE
bootkube: Add ingress namespace creation.

### DIFF
--- a/modules/bootkube/resources/manifests/02-ingress-namespace.yaml
+++ b/modules/bootkube/resources/manifests/02-ingress-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tectonic-ingress # Create the namespace first.
+  labels: # network policy can only select by labels
+    name: tectonic-ingress


### PR DESCRIPTION
The 'tectonic-ingress' namespace is needed for ingress operator.

/cc @diegs @abhinavdahiya 
