### PR TITLE
config.tf: Update tectonic-error-server to 1.1

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -74,7 +74,7 @@ variable "tectonic_container_images" {
     calico                       = "quay.io/calico/node:v2.6.1"
     calico_cni                   = "quay.io/calico/cni:v1.11.0"
     console                      = "quay.io/coreos/tectonic-console:v4.0.1"
-    error_server                 = "quay.io/coreos/tectonic-error-server:1.0"
+    error_server                 = "quay.io/coreos/tectonic-error-server:1.1"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"
     flannel                      = "quay.io/coreos/flannel:v0.8.0-amd64"


### PR DESCRIPTION
Fixes an issue with error-server always responding with HTTP 200 codes.