### PR TITLE
tests/frontend: Fix GUI tfvars test to wait until diff is complete

### DIFF
--- a/installer/frontend/ui-tests/utils/terraformTfvars.js
+++ b/installer/frontend/ui-tests/utils/terraformTfvars.js
@@ -5,7 +5,7 @@ const path = require('path');
 const request = require('request');
 
 const diffTfvars = (client, assetsZip, expected, ignoredKeys = []) => {
-  JSZip.loadAsync(assetsZip).then(zip => {
+  return JSZip.loadAsync(assetsZip).then(zip => {
     zip.file(/tfvars$/)[0].async('string').then(tfvars => {
       const actual = JSON.parse(tfvars);
       ignoredKeys.forEach(k => {
@@ -52,11 +52,12 @@ const testManualBoot = (client, expectedOutputFilePath, ignoredKeys) => {
       // eslint-disable-next-line no-sync
       const expected = JSON.parse(fs.readFileSync(path.join(__dirname, expectedOutputFilePath), 'utf8'));
 
-      diffTfvars(client, assetsZip, expected, ignoredKeys);
+      diffTfvars(client, assetsZip, expected, ignoredKeys)
+        .then(() => client.click('.btn-link .fa-refresh'));
     });
   });
 
-  page.click('.btn-link .fa-refresh');
+  page.expect.element('select#platformType').to.be.visible.before(60000);
 };
 
 const jsonDir = path.join(__dirname, '..', '..', '__tests__', 'examples');


### PR DESCRIPTION
The next test was starting before the diff completed, which could cause the failure to go unreported if the diff was the final test step.