### PR TITLE
tests/frontend: Add "id" attributes to simplify Nightwatch tests

### DIFF
--- a/installer/frontend/components/submit-definition.jsx
+++ b/installer/frontend/components/submit-definition.jsx
@@ -45,7 +45,7 @@ export const SubmitDefinition = withNav(connect(
       </div>
       <p>
         <b>Advanced mode: </b>
-        <a onClick={() => onFinish(true)}>Manually boot</a> your own cluster. Validate configuration, generate assets, but don't create the cluster.
+        <a id="manualBoot" onClick={() => onFinish(true)}>Manually boot</a> your own cluster. Validate configuration, generate assets, but don't create the cluster.
       </p>
       <div className={errorClasses}>
         {errorMessage}

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -201,7 +201,7 @@ export const ToggleButton = connect(
     onValue(!value);
     dispatch(dirtyActions.add(id));
   }}),
-)(({children, className, onClick, value}) => <button className={className} onClick={onClick}>
+)(({children, className, id, onClick, value}) => <button className={className} id={id} onClick={onClick}>
   {value ? 'Hide' : 'Show'}&nbsp;{children}
   <i style={{marginLeft: 7}} className={classNames('fa', {'fa-chevron-up': value, 'fa-chevron-down': !value})}></i>
 </button>);
@@ -461,7 +461,7 @@ export const FieldRowList = connect(
         })}
         <div className="row">
           <div className="col-xs-3">
-            <span className="wiz-link" onClick={() => {
+            <span className="wiz-link" id="addMore" onClick={() => {
               this.setState({autoFocus: true});
               appendField(id);
             }}>

--- a/installer/frontend/ui-tests/pages/defineMastersPage.js
+++ b/installer/frontend/ui-tests/pages/defineMastersPage.js
@@ -33,10 +33,7 @@ module.exports = {
     mac1: 'input[id="masters.1.mac"]',
     hosts1: 'input[id="masters.1.host"]',
     deleteIcon1: '.row:nth-child(2) i.fa-minus-circle',
-    addMore: {
-      selector: '//*[text()[contains(.,"Add More")]]',
-      locateStrategy: 'xpath',
-    },
+    addMore: '#addMore',
     alertError: '.alert-error',
   },
 };

--- a/installer/frontend/ui-tests/pages/defineWorkersPage.js
+++ b/installer/frontend/ui-tests/pages/defineWorkersPage.js
@@ -31,10 +31,7 @@ module.exports = {
     deleteIcon0: '.row:nth-child(1) i.fa-minus-circle',
     mac1: 'input[id="workers.1.mac"]',
     hosts1: 'input[id="workers.1.host"]',
-    addMore: {
-      selector: '//*[text()[contains(.,"Add More")]]',
-      locateStrategy: 'xpath',
-    },
+    addMore: '#addMore',
     alertError: '.alert-error',
   },
 };

--- a/installer/frontend/ui-tests/pages/downloadAssetsPage.js
+++ b/installer/frontend/ui-tests/pages/downloadAssetsPage.js
@@ -1,8 +1,3 @@
 module.exports = {
-  elements: {
-    downloadAsserts: {
-      selector: '(//i[class=".fa-download"])[1]',
-      locateStrategy: 'xpath',
-    },
-  },
+  elements: {},
 };

--- a/installer/frontend/ui-tests/pages/networkingPage.js
+++ b/installer/frontend/ui-tests/pages/networkingPage.js
@@ -106,10 +106,7 @@ const pageCommands = {
 module.exports = {
   commands: [pageCommands],
   elements: {
-    advanced: {
-      selector: '//*[text()[contains(.,"Advanced Settings")]]',
-      locateStrategy: 'xpath',
-    },
+    advanced: '#awsAdvancedNetworking',
     alertError: '.alert-error',
     k8sCIDRsErrorTitle: '#k8sCIDRs .alert-error b',
     k8sCIDRsWarningTitle: '#k8sCIDRs .alert-info b',

--- a/installer/frontend/ui-tests/pages/submitPage.js
+++ b/installer/frontend/ui-tests/pages/submitPage.js
@@ -1,8 +1,5 @@
 module.exports = {
   elements: {
-    manuallyBoot: {
-      selector: '//a[contains(text(), "Manually boot")]',
-      locateStrategy: 'xpath',
-    },
+    manualBoot: '#manualBoot',
   },
 };

--- a/installer/frontend/ui-tests/utils/terraformTfvars.js
+++ b/installer/frontend/ui-tests/utils/terraformTfvars.js
@@ -28,10 +28,10 @@ const testManualBoot = (client, expectedOutputFilePath, ignoredKeys) => {
 
   // It should be safe to refresh the page and have all field values preserved
   client.refresh();
-  page.expect.element('@manuallyBoot').to.be.visible.before(60000);
+  page.expect.element('@manualBoot').to.be.visible.before(60000);
 
   page
-    .click('@manuallyBoot')
+    .click('@manualBoot')
     .expect.element('a[href="/terraform/assets"]').to.be.visible.before(120000);
 
   client.getCookie('tectonic-installer', ({value}) => {


### PR DESCRIPTION
Along with #2926, this removes the need for xpath selectors in Nightwatch.