### PR TITLE
Installer: Move tectonicVersion and buildTime to /tectonic/facts

### DIFF
--- a/installer/api/api.go
+++ b/installer/api/api.go
@@ -103,7 +103,6 @@ func New(config *Config) (http.Handler, error) {
 
 	//handlers_latest_release.go
 	mux.Handle("/releases/latest", logRequests(httpHandler("GET", ctx, latestReleaseHandler)))
-	mux.Handle("/releases/current", logRequests(httpHandler("GET", ctx, currentReleaseHandler)))
 	return mux, nil
 }
 

--- a/installer/api/handlers_latest_release.go
+++ b/installer/api/handlers_latest_release.go
@@ -3,8 +3,6 @@ package api
 import (
 	"io"
 	"net/http"
-
-	"github.com/coreos/tectonic-installer/installer/version"
 )
 
 // latestReleaseHandler gets the tectonic's latest release from coreos.com.
@@ -16,17 +14,4 @@ func latestReleaseHandler(w http.ResponseWriter, req *http.Request, _ *Context) 
 	io.Copy(w, res.Body)
 	res.Body.Close()
 	return nil
-}
-
-// Fetch tectonic's Build version and return in JSON format
-func currentReleaseHandler(w http.ResponseWriter, req *http.Request, _ *Context) error {
-	version := struct {
-		TectonicVersion string `json:"tectonicVersion"`
-		BuildTime       string `json:"buildTime"`
-	}{
-		TectonicVersion: version.TectonicVersion,
-		BuildTime:       version.BuildTime,
-	}
-
-	return writeJSONResponse(w, req, http.StatusOK, version)
 }

--- a/installer/api/handlers_tectonic.go
+++ b/installer/api/handlers_tectonic.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coreos/tectonic-installer/installer/pkg/containerlinux"
 	"github.com/coreos/tectonic-installer/installer/pkg/terraform"
+	"github.com/coreos/tectonic-installer/installer/version"
 	"github.com/dghubble/sessions"
 )
 
@@ -350,9 +351,18 @@ func tectonicFactsHandler(w http.ResponseWriter, req *http.Request, ctx *Context
 	}
 
 	type response struct {
-		AMIs       []containerlinux.AMI `json:"amis"`
-		License    string               `json:"license"`
-		PullSecret string               `json:"pullSecret"`
+		AMIs            []containerlinux.AMI `json:"amis"`
+		BuildTime       string               `json:"buildTime"`
+		License         string               `json:"license"`
+		PullSecret      string               `json:"pullSecret"`
+		TectonicVersion string               `json:"tectonicVersion"`
 	}
-	return writeJSONResponse(w, req, http.StatusOK, response{amis, string(license), string(pullSecret)})
+
+	return writeJSONResponse(w, req, http.StatusOK, response{
+		amis,
+		version.BuildTime,
+		string(license),
+		string(pullSecret),
+		version.TectonicVersion,
+	})
 }


### PR DESCRIPTION
This commit moves the `tectonicVersion and` `buildTime` build facts to `/tectonic/facts`.

