### PR TITLE
modules/tectonic: fix alertmanager ingress config.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -95,7 +95,7 @@ variable "tectonic_container_images" {
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.6.2"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.2"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.3"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.3.1"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
     tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:v0.3.0"
@@ -129,7 +129,7 @@ variable "tectonic_versions" {
   default = {
     etcd          = "3.1.8"
     kubernetes    = "1.8.7+tectonic.1"
-    monitoring    = "1.9.2"
+    monitoring    = "1.9.3"
     tectonic      = "1.8.7-tectonic.1"
     tectonic-etcd = "0.0.1"
     cluo          = "0.3.1"

--- a/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
+++ b/modules/tectonic/resources/manifests/updater/tectonic-monitoring-config.yaml
@@ -14,7 +14,7 @@ data:
     alertmanagerMain:
       baseImage: ${alertmanager_base_image}
     ingress:
-      baseAddress: ${console_base_host}
+      baseAddress: ${base_address}
     auth:
       baseImage: ${tectonic_monitoring_auth_base_image}
     nodeExporter:


### PR DESCRIPTION
The alert manager ingress config expects both the host and the port.
Previously we only provided the host. This can break on some platforms
where the port is required to access Tectonic ingress.

