### PR TITLE
Bump ALM to 0.3.1

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -80,7 +80,7 @@ variable "tectonic_container_images" {
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.3.1"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.1"
     kubernetes_addon_operator    = "quay.io/coreos/kubernetes-addon-operator:beryllium-m1"
-    tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:v0.3.0"
+    tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:v0.3.1"
     tectonic_utility_operator    = "quay.io/coreos/tectonic-utility-operator:beryllium-m1"
     tectonic_network_operator    = "quay.io/coreos/tectonic-network-operator:beryllium-m1"
   }
@@ -114,7 +114,7 @@ variable "tectonic_versions" {
     monitoring = "1.9.1"
     tectonic   = "1.8.4-tectonic.2"
     cluo       = "0.3.1"
-    alm        = "0.3.0"
+    alm        = "0.3.1"
   }
 }
 

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -25,12 +25,11 @@ spec:
       containers:
       - name: tectonic-alm-operator
         image: ${tectonic_alm_operator_image}
-        command:
-        - /app/x-operator/cmd/xoperator/tectonic-x-operator.binary
-        - '--operator-name=tectonic-alm-operator'
-        - '--appversion-name=tectonic-alm-operator'
-        - '--v=2'
-        - '-manifest-dir=/manifests'
+        args:
+        - --manifest-dir=/manifests
+        - --operator-name=tectonic-alm-operator
+        - --appversion-name=tectonic-alm-operator
+        - --v=2
       imagePullSecrets:
         - name: coreos-pull-secret
       nodeSelector:


### PR DESCRIPTION
0.3.1 contains fixes for CRD validation on k8s 1.9

The corresponding e2e test container for this release is here:  `quay.io/coreos/alm-e2e:v0.3.1`