### PR TITLE
frontend: Use monospace font for Terraform log output

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -647,7 +647,8 @@ span.spacer {
 
 .log-area {
   box-shadow: inset 0px 3px 5px 0px rgba(0,0,0,0.75);
-  font-size: 13px;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: 10px;
   background-color: #333;
   position: relative;
 }


### PR DESCRIPTION
Terraform log output area now uses the same font-family rule as the textarea inputs.

cc @robszumski, @tlwu2013 

Before | After
--- | ---
<img width="605" alt="screenshot-2" src="https://user-images.githubusercontent.com/460802/36288514-4d4ce5c6-12fe-11e8-970b-f7c6ee88ee80.png"> | <img width="578" alt="screenshot-1" src="https://user-images.githubusercontent.com/460802/36288522-533dd40e-12fe-11e8-9ef8-dc40076aafbb.png">
