### PR TITLE
tests: Archive tarball for release automation to consume

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,7 @@ pipeline {
 
                   stash name: 'tectonic.tar.gz', includes: 'tectonic.tar.gz'
                   stash name: 'smoke-tests', includes: 'smoke'
+                  archiveArtifacts allowEmptyArchive: true, artifacts: 'tectonic.tar.gz'
                 }
 
                 withDockerContainer(params.builder_image) {


### PR DESCRIPTION
This patch archives the Tectonic installer build tarball from Bazel as a
Jenkins artifact to be consumed by e.g. the release automation pipeline.

@coverprice Would this be a possible solution for the release pipeline to consume build artefacts from the Tectonic installer pipeline? I would imagine a workflow like:
1. Release automation triggers Tectonic installer pipeline
2. Once Tectonic installer pipeline finishes and build result is green
    - Retrieve tarball artefact from Tectonic installer build
    - Release tarball artefact e.g. as a nightly

@cpanato This might result in a high number of tarballs, that we persist. The [`buildDiscarder`](https://github.com/coreos/tectonic-installer/blob/master/Jenkinsfile#L81) should take care of that, right?

