### PR TITLE
modules/openstack/secgroups/*: Allow ingress traffic within cluster

### DIFF
--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -25,6 +25,11 @@ if [ -d /opt/tectonic/net-manifests ]; then
     rm -r /opt/tectonic/net-manifests
 fi
 
+mkdir -p /etc/kubernetes/bootstrap-secrets
+cp /opt/tectonic/tls/etcd-* /etc/kubernetes/bootstrap-secrets
+mkdir -p /etc/kubernetes/secrets
+cp /opt/tectonic/tls/etcd-* /etc/kubernetes/secrets
+
 # shellcheck disable=SC2154
 /usr/bin/docker run \
     --volume "$(pwd)":/assets \

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -12,7 +12,7 @@ rm -rf /etc/kubernetes/manifests
 mkdir -p /etc/kubernetes/manifests/
 
 # Move optional self hosted etcd manifests into bootkube friendly locations
-if [ -d /opt/tectonic/etcd ]; then
+if [ -d /opt/tectonic/etcd/bootstrap-manifests ]; then
     mv /opt/tectonic/etcd/manifests/* /opt/tectonic/manifests/
     rm -r /opt/tectonic/etcd/manifests
     mv /opt/tectonic/etcd/bootstrap-manifests/* /opt/tectonic/bootstrap-manifests/

--- a/modules/ignition/resources/dropins/40-etcd-cluster.conf
+++ b/modules/ignition/resources/dropins/40-etcd-cluster.conf
@@ -5,7 +5,8 @@ ${metadata_deps}
 Environment="ETCD_IMAGE=${container_image}"
 ${metadata_env}
 Environment="RKT_RUN_ARGS=--volume etcd-ssl,kind=host,source=/etc/ssl/etcd \
-  --mount volume=etcd-ssl,target=/etc/ssl/etcd"
+  --mount volume=etcd-ssl,target=/etc/ssl/etcd \
+  --uuid-file-save=/var/lib/coreos/etcd-member-wrapper.uuid"
 ExecStart=
 ExecStart=/usr/lib/coreos/etcd-wrapper \
   --name=${name} \

--- a/modules/openstack/nodes/ignition.tf
+++ b/modules/openstack/nodes/ignition.tf
@@ -80,7 +80,6 @@ data "ignition_file" "sshd" {
 
   content {
     content = <<EOF
-UsePrivilegeSeparation sandbox
 Subsystem sftp internal-sftp
 
 PermitRootLogin no

--- a/modules/openstack/secgroups/rules/k8s/secgroup.tf
+++ b/modules/openstack/secgroups/rules/k8s/secgroup.tf
@@ -8,11 +8,11 @@ resource "openstack_networking_secgroup_rule_v2" "https" {
   security_group_id = "${var.secgroup_id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "cAdvisor" {
+resource "openstack_networking_secgroup_rule_v2" "cluster" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  port_range_min    = 4194
-  port_range_max    = 4194
+  port_range_min    = 1
+  port_range_max    = 65535
   protocol          = "tcp"
   remote_ip_prefix  = "${var.cluster_cidr}"
   security_group_id = "${var.secgroup_id}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -89,7 +89,7 @@ module "bootkube" {
 
   etcd_backup_size          = "${var.tectonic_etcd_backup_size}"
   etcd_backup_storage_class = "${var.tectonic_etcd_backup_storage_class}"
-  etcd_endpoints            = "${module.dns.etcd_a_nodes}"
+  etcd_endpoints            = "${data.template_file.etcd_hostname_list.*.rendered}"
   self_hosted_etcd          = "${var.tectonic_self_hosted_etcd}"
 
   master_count = "${var.tectonic_master_count}"

--- a/platforms/openstack/neutron/main.tf
+++ b/platforms/openstack/neutron/main.tf
@@ -198,12 +198,12 @@ module "ignition_masters" {
   kubelet_debug_config      = "${var.tectonic_kubelet_debug_config}"
   kubelet_node_label        = "node-role.kubernetes.io/master"
   kubelet_node_taints       = "node-role.kubernetes.io/master=:NoSchedule"
-  metadata_provider         = "openstack-metadata"
   nfs_config_file           = "${local._tectonic_nfs_config_file}"
   no_proxy                  = "${var.tectonic_no_proxy}"
   ntp_servers               = "${var.tectonic_ntp_servers}"
   proxy_exclusive_units     = "${var.tectonic_proxy_exclusive_units}"
   tectonic_vanilla_k8s      = "${var.tectonic_vanilla_k8s}"
+  use_metadata              = "false"
 }
 
 module "master_nodes" {


### PR DESCRIPTION
Relax the security group rules to allow ingress on all ports on the
internal subnet used by the k8s cluster. This subnet is not exposed
to the internet, and network policy can be applied directly to the k8s
cluster via NetworkPolicy objects, so the security posture remains
essentially unchanged.

/cc @squat 
