### PR TITLE
frontend: Get current version info from /tectonic/facts

### DIFF
--- a/installer/assets/frontend/css/styles.css
+++ b/installer/assets/frontend/css/styles.css
@@ -748,10 +748,6 @@ span.spacer {
   background-color: #fff;
 }
 
-.co-navbar-nav > li > span {
-  font-size: 14px;
-}
-
 .co-navbar--right {
   float: right;
 }
@@ -775,7 +771,7 @@ span.spacer {
 }
 
 .co-navbar-nav-item__version {
-  font-size: 12px;
+  font-size: 14px;
   padding-right: 20px;
 }
 

--- a/installer/frontend/.babelrc
+++ b/installer/frontend/.babelrc
@@ -9,13 +9,6 @@
   ],
   "plugins": [
     "syntax-async-functions",
-    "transform-regenerator",
-    [
-      "git-version",
-      {
-        "showDirty": true,
-        "commitLength": 7
-      }
-    ]
+    "transform-regenerator"
   ]
 }

--- a/installer/frontend/package.json
+++ b/installer/frontend/package.json
@@ -26,7 +26,6 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-git-version": "github:coreos/babel-plugin-git-version-build#3f828164febc6b2f486f043fef75157989e97315",
     "babyparse": "0.4.x",
     "classnames": "2.2.x",
     "file-saver": "1.3.x",

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -176,22 +176,19 @@ const reducersTogether = combineReducers({
       return {
         loaded: false,
         error: null,
-        awsRegions: null,
       };
     }
 
     switch (action.type) {
     case loadFactsActionTypes.LOADED:
-      return {
+      return Object.assign({}, action.payload, {
         loaded: true,
         error: null,
-        awsRegions: action.payload.awsRegions,
-      };
+      });
     case loadFactsActionTypes.ERROR:
       return {
         loaded: true,
         error: action.payload,
-        awsRegions: null,
       };
     default:
       return state;

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -119,12 +119,16 @@ export const commitToServer = (dryRun = false, retry = false) => (dispatch, getS
 // Guaranteed not to reject.
 export const loadFacts = (dispatch) => {
   return fetchJSON('/tectonic/facts', {retries: 5})
-    .then(m => {
-      addIn(TECTONIC_LICENSE, m.license, dispatch);
-      addIn(PULL_SECRET, m.pullSecret, dispatch);
+    .then(facts => {
+      addIn(TECTONIC_LICENSE, facts.license, dispatch);
+      addIn(PULL_SECRET, facts.pullSecret, dispatch);
       dispatch({
         type: loadFactsActionTypes.LOADED,
-        payload: {awsRegions: _.map(m.amis, 'name')},
+        payload: {
+          awsRegions: _.map(facts.amis, 'name'),
+          buildTime: facts.buildTime,
+          version: facts.tectonicVersion,
+        },
       });
     },
     err => {

--- a/installer/frontend/tectonic-ga.js
+++ b/installer/frontend/tectonic-ga.js
@@ -1,4 +1,10 @@
-import { isReleaseVersion } from './utils';
+import _ from 'lodash';
+import semver from 'semver';
+
+import { store } from './store';
+
+const version = () => _.get(store.getState(), 'serverFacts.version');
+const isReleaseVersion = () => semver.valid(version()) !== null && !version().includes('-rc.');
 
 const send = (obj) => {
   if (!isReleaseVersion()) {
@@ -41,14 +47,14 @@ export const TectonicGA = {
   },
 
   sendPageView: (page) => {
-    send({ type: 'pageview', page});
+    send({type: 'pageview', page});
   },
 
   sendError: (message, stack = '') => {
     send({
       type: 'event',
       category: 'installerError',
-      label: `${GIT_TAG} ${message} Stack: ${stack}`,
+      label: `${version()} ${message} Stack: ${stack}`,
     });
   },
 
@@ -56,7 +62,7 @@ export const TectonicGA = {
     send({
       type: 'event',
       category, action,
-      label: `${platform}-${GIT_TAG} ${label}`,
+      label: `${platform}-${version()} ${label}`,
     });
   },
 
@@ -65,7 +71,7 @@ export const TectonicGA = {
       type: 'event',
       category: 'Installer Docs Link',
       action: 'click',
-      label: `${platform}-${GIT_TAG} User clicks on documentation link`,
+      label: `${platform}-${version()} User clicks on documentation link`,
     });
   },
 };

--- a/installer/frontend/utils.js
+++ b/installer/frontend/utils.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import semver from 'semver';
 
 // Compares two version strings, of the form \d+(.\d+)*
 // Suitable for use with Array.sort()
@@ -58,7 +57,3 @@ export const toInFly = toPath('inFly');
 export const toExtraData = toPath('extra');
 export const toExtraDataError = toPath('extraError');
 export const toExtraDataInFly = toPath('extraInFly');
-
-export const isReleaseVersion = () => {
-  return GIT_RELEASE_TAG === 'unknown' ? false : semver.valid(GIT_RELEASE_TAG) && !GIT_RELEASE_TAG.includes('-rc.');
-};

--- a/installer/frontend/yarn.lock
+++ b/installer/frontend/yarn.lock
@@ -452,10 +452,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-"babel-plugin-git-version@github:coreos/babel-plugin-git-version-build#3f828164febc6b2f486f043fef75157989e97315":
-  version "0.2.3"
-  resolved "https://codeload.github.com/coreos/babel-plugin-git-version-build/tar.gz/3f828164febc6b2f486f043fef75157989e97315"
-
 babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"


### PR DESCRIPTION
Fetch current version info from `/tectonic/facts` API endpoint instead of
using `babel-plugin-git-version`.

`isReleaseVersion()` (used to determine whether to send Google Analytics
events) will now return `true` if the value of `tectonicVersion` is a valid
semver string that doesn't contain the substring `-rc.`.

If `buildTime` is set, use it as the version info's `title` attribute.

Simplify `hasNewVersion()` by using the fact that our version strings are
now defined such that determining which is greater should just be a case
of comparing them lexicographically.

Slightly simplify version info CSS.

cc: @kalmog, @robszumski, @tlwu2013 

![screenshot-1](https://user-images.githubusercontent.com/460802/36360925-57b5fc68-156b-11e8-8ba1-707d6b98ea75.png)

![screenshot-2](https://user-images.githubusercontent.com/460802/36360927-603e2716-156b-11e8-9065-bfd804d25a33.png)