### PR TITLE
tests/frontend: Add AWS GUI test for external etcd and custom CA

### DIFF
--- a/installer/frontend/__tests__/examples/aws-custom-vpc-in.json
+++ b/installer/frontend/__tests__/examples/aws-custom-vpc-in.json
@@ -18,6 +18,7 @@
         "value": "testing"
       }
     ],
+    "awsVpcCIDR": "10.0.0.0/16",
     "awsWorkerSubnets": {
       "us-west-1a": "10.0.64.0/19",
       "us-west-1c": "10.0.96.0/19"
@@ -32,7 +33,6 @@
     "aws_ssh": "tectonic-jenkins",
     "aws_workers-instanceType": "t2.medium",
     "aws_workers-numberOfInstances": 2,
-    "aws_workers-storageIOPS": 1500,
     "aws_workers-storageSizeInGiB": 30,
     "aws_workers-storageType": "gp2",
     "caType": "self-signed",

--- a/installer/frontend/__tests__/examples/aws-external-etcd-in.json
+++ b/installer/frontend/__tests__/examples/aws-external-etcd-in.json
@@ -1,0 +1,46 @@
+{
+  "clusterConfig": {
+    "adminEmail": "a.b.c@d.example.com",
+    "adminPassword": "!@#$%^&*()",
+    "awsAccessKeyId": "<AWS_ACCESS_KEY_ID>",
+    "awsHostedZoneId": "Z30TY4B8NT090S",
+    "awsRegion": "us-west-1",
+    "awsSecretAccessKey": "<AWS_SECRET_ACCESS_KEY>",
+    "awsSessionToken": "awsSessionToken",
+    "awsSplitDNS": "off",
+    "awsTags": [
+      {
+        "key": "a",
+        "value": "!@#$%^&*()"
+      },
+      {
+        "key": "A",
+        "value": "文字"
+      }
+    ],
+    "awsVpcCIDR": "10.0.0.0/16",
+    "aws_controllers-instanceType": "m3.large",
+    "aws_controllers-numberOfInstances": 2,
+    "aws_controllers-storageSizeInGiB": 100,
+    "aws_controllers-storageType": "io1",
+    "aws_controllers-storageIOPS": 2000,
+    "aws_ssh": "tectonic-jenkins",
+    "aws_workers-instanceType": "m3.medium",
+    "aws_workers-numberOfInstances": 2,
+    "aws_workers-storageSizeInGiB": 100,
+    "aws_workers-storageType": "standard",
+    "caCertificate": "-----BEGIN CERTIFICATE-----\nMIIFDTCCAvWgAwIBAgIJAIuXq10k2OFlMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV\nBAMMB2Zha2UtY2EwHhcNMTcwMjAxMjIxMzI0WhcNMjcwMTMwMjIxMzI0WjASMRAw\nDgYDVQQDDAdmYWtlLWNhMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA\nzzHsB56F6oZjsVBKzfpicsG+mVHQ/QzA4jqRCbQ8Zr12NtUZKnPUVwDoFf4WTfmy\nZ0u8Uv+6/B/8un3LGsIaJEugPfRboc2oZKJcqfMJSFfLb/wkmT0D/1HJR60ml/M5\nwpHeh4vQ7BhktNsK90EjdlLvr1GDfevXArnye5ksEInOSX9nXVsGPrm0AGSffhmY\nuUAjY8f9IspJa1j4vL6NI89GWO4jqME+SUnuI4SYIkuQJoSElofAIX2b5Tk3dFya\nVKmAq2L89teCMYsciPbFa/Z2HvDNZ7pC17Ow7zr1f+V5BU18h3cLk610YNPcEBw0\nf94+mePsmMSMjUM0f+NMFyDERF+pys60/3qqVWrJe/FkJM6NDCyWXXXAfTxIwLq0\nCVrlWALdTc+RMAPI2sxAdUp4BqAuek4SjIg3FuoJrBs3EAUPfybclJ7g3HJwyXM2\n3WIe10BnSk+rGzd4KMVbYw5/nM8Nc/Y20R2an/vVZn6xTxs9o6hhEHF7d5iws6Bi\n7/jv+jdZhLG8b3sG6Tj7a7YdvKWqH/mSPFlc/sevYOjR7NKYRMwGnl0d9qf+Xe5V\nxyH1llIXPs6+y1B4tRyL/tulyeVqi25+I4QVAYypxWU8CPyw7tsSdOsSTbeGTmXj\nehelY/BCjAqAcexL7oRV7dy7VZ1Ezg6zQRwMt0Tar90CAwEAAaNmMGQwHQYDVR0O\nBBYEFNGPoXTjJnHjG2zMpjSg/9vNO/trMB8GA1UdIwQYMBaAFNGPoXTjJnHjG2zM\npjSg/9vNO/trMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQDAgGGMA0G\nCSqGSIb3DQEBCwUAA4ICAQC9V/0iiEZYHz7xbezHpeGHwmecH5oylEvAeCcN10gx\nHFvUN+XMyBaPqN7iRtx/rSqyp2iN2AK1Cdn1viOSRc09lwPiuj9V4diSDyPwJWxd\n60gqd5E9F9gQXlenWoIdm7kW8Lo8HLfx8ItYKGpE51JUctTmGY5WURRmBlVKr1LA\nhbVsAWBaGQfPyW1CrFcxxc5mCABxWOxjRjLw8A8c5IXD0Q5C5pRd0BckBHKTdl40\nowm893oPEQcu/1C432T4vIddVh1Ktq1pd7O/9BPYOaPryzf7076xSwZ0bSuBUGRq\nVd3STfu5QRqpMv4dIrhqRofmIUzjOHLRX8Lx2pzgYcMgMQ8O+jM+ETrYD6rsDoLQ\nuiVSWZK0YFndKzNTA04u57arRumWKqqfS0kkDFayumyv6KaDS6YZdsqSRmaiLAOG\nF6jchpUtkDhDY0v/Y7jESUneT0hRnqNMPAKJMNhE4hS+1qkcP/ikQQgZl/OWma1z\nHUyBGT4OGP2T3JIfq12Z4vC5FGVD4aD/frTvPMlifV3i8lKlYZs271JPXUo6ASIA\nZSBpV5QilOlE25Q5Lcw0yWmN4KwxqBL9bJ5W9D1I0qhWxaMF78m+8vLIFv+dAylE\nOd27a+1We/P5ey7WRlwCfuEcFV7nYS/qMykYdQ9fxHSPgTPlrGrSwKstaaIIqOkE\nkA==\n-----END CERTIFICATE-----\n",
+    "caPrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzzHsB56F6oZjsVBKzfpicsG+mVHQ/QzA4jqRCbQ8Zr12NtUZ\nKnPUVwDoFf4WTfmyZ0u8Uv+6/B/8un3LGsIaJEugPfRboc2oZKJcqfMJSFfLb/wk\nmT0D/1HJR60ml/M5wpHeh4vQ7BhktNsK90EjdlLvr1GDfevXArnye5ksEInOSX9n\nXVsGPrm0AGSffhmYuUAjY8f9IspJa1j4vL6NI89GWO4jqME+SUnuI4SYIkuQJoSE\nlofAIX2b5Tk3dFyaVKmAq2L89teCMYsciPbFa/Z2HvDNZ7pC17Ow7zr1f+V5BU18\nh3cLk610YNPcEBw0f94+mePsmMSMjUM0f+NMFyDERF+pys60/3qqVWrJe/FkJM6N\nDCyWXXXAfTxIwLq0CVrlWALdTc+RMAPI2sxAdUp4BqAuek4SjIg3FuoJrBs3EAUP\nfybclJ7g3HJwyXM23WIe10BnSk+rGzd4KMVbYw5/nM8Nc/Y20R2an/vVZn6xTxs9\no6hhEHF7d5iws6Bi7/jv+jdZhLG8b3sG6Tj7a7YdvKWqH/mSPFlc/sevYOjR7NKY\nRMwGnl0d9qf+Xe5VxyH1llIXPs6+y1B4tRyL/tulyeVqi25+I4QVAYypxWU8CPyw\n7tsSdOsSTbeGTmXjehelY/BCjAqAcexL7oRV7dy7VZ1Ezg6zQRwMt0Tar90CAwEA\nAQKCAgEAjH2XQ9tThqC1fIerEVvT4WhJ6wA1K0C4kS2RJvlVc3zIaYm5VLXRp2Tv\n+emeCiVjuPL7sXPBwC+YWIPvcidnPnEhKKFGeMJQilwlZP9srecKBNb9ogJjcX5t\ncvKPlrzPz4TFVTeS5GPt9UwJdXpvp025RDGLbZi65BhduT01ScmHXQLMfdq4s1OM\nIDAajZChpAs/c+spU6vCeM2Na73xSfTECI0BFO5jY6KDnQXNeoOuLM/yb3eA6bSY\nPqe7WGVqKDn/CzdFu8KJfzqKkLxzRS+LDJPPU6RSqpwnPy/FQ4G/u768z8YCzZHx\nta4yK6JUXte9ru+DgFrVyvtk38qpzlNYj5PVPkZxOZaWPALYAa6N53/NSJIZ/Pm6\nYaLkncTbpjer0zzEULfEngiHl8e8XrySeirmIZ7W1RPVA/k0f4d9rOVxhvtNM4es\nWaEvCMxC1BOD5e7fX39hI4xjFNjecFSXPLR9RlbTxg0yQAjDfMJYghdNfUgfd8I0\nQP9UmSdLiUcCWJlZ5uF0UG+HNxcp/ML1z7GTLxYjuqC1gLA1giMD8Y7zJJbIsRKt\n8ymtlkqoTkO+AMnQ0/Eno2yQ9ed7+guhYdpLuEvH2f+p5yEVtcrYmE/tiombs9Gq\ntwVTeSvmm8uLygQIdI0QeKnRjoM9qX9+5I1EkloB7vhTXSAQ+oECggEBAPuDyEgq\nB2etxpvveDKOatuRimC+oWQ7eyp6NA8BOaHw+1OgTGPE+807i4/RPlhT9pbTuG16\n/unH8PnRXijtYEeQdFck9TCYjqwJlThZdokg30g827U6K+UECqd5ffejx9cnRpxu\nUke+AfMLdzG7G3EJlGoG76JZyKmow1JKzPhL7qa9YQRWA9dxC+vMjKakWf2Y8OSq\ntkukYRpbn7VC99v5J8vJsNVFXu419N7h0bj2yQ6t64N/ybPWVfjp5xzc9rsNN14f\nj1HoeqX/xw3MSUMjJol1L1V6+kHBhws0JsWFnGma+LTnDj4RE8HzohTlQv7Bhsgz\n2qlW3gizrQEn+FECggEBANLjz4SX0eYF37pbZ1XReqezb9LP8oXiHn8UZpKlRpcF\nDmaoSa9vcEySjwEq3oiR3Nzny46zLfAAJ7O3K2TI4AS/zcTmQw2G4+WjRf8tTq2x\nA8SNq5E6p5bbimJC+80cVVfFAGukeQy9149ZW4ldfYTrk+821o5lBXmo9EqyrbqI\nNrt/EezSHr/Yai9zSV/VnLZ27nvW7vFlNHqbMGwhTHBY8eX6SEdIsobdjsdGdrUn\ni331ImodBJ5/3H6OdNGHUbrizzn8Jm8CgZHkA87a9ON8eKHQ/FOb/Md82qDghnQR\nLfBcoOac357Nprc4F/YGE4MCjXgLmGrgzMkQ0Fwcp80CggEBAM7fwQ/iSf70R2Uh\nXhsvWyNInaofgj4gUplItKMW3eGehgpt0gdKEdboQE3FzOL4BN5gPNUIEr4Vr9a7\naBh/zu5uGdNH2cjj4o4Mv8j+hOobuKwBKrHwrAQOA/lmi77x3sDQVFr8vv61gYL4\njkzAWrzqJUHkfJxr/wnVfvqj/d3JDv3kzPS1DynYmPaVY6b5je9yKcnbxF+JUDlO\n3ZlJAPfVAu+y8JkrGv8SMFxXH5pkmlFRqmKZ7DzYchRvx6HM+cA3CbCIgujbMG5z\naLWnrybitaLgWVOU+Fy3oq0Lc0yKLnIKfsDFP8i7YSXpkAph3G4Qnhzz0cnxYmWD\n7CwERVECggEAaFVKalfOAVXwnLrxwbRUUTll3k8AthnraoWGRZC8/qQCvukNI10n\nmsp7M2GpHLnFIgkPXPbqiC0bdz7smf0DT3Yw7/PXQo70mryPObKJlUbZDVnlgoEZ\nPno42Wo4Nv6Ifla5YYfKV3JofcQAlFILckI2OwfPWD1EWy8qRPZnGryfD13LWXWO\nvuzrg7QundoJoP/v9pacOhMOxoWWjDhhH8fxTQzoy1N891oPdCk5O2BoE5W+Q+89\nRMkPJhGGW87tsV7alN5ZiVwdDDdZZvJOa2k+KRhCbX7jrTHo2+SYwD1rk9nPxKfh\nvigSDd0ThaT17D/MC5L5Ag9bYTIPUzLeFQKCAQEAq6RjI5A3Xppq9OFziOjgrUGv\n2/xIH1NH7hdqGk5V+QRYQdD7Vd9wnF4f0CpIYTR55Mcud4amL3mHcR2IdjhJ4wcL\n0VnSghllTdzO9dcDQ3cigIkzdikGoC+xPQRXMpt3sWS3BYyJZmjsUG1+TgPOZZeb\nDInfb96I9euapu9meSrwzYy7R21eFfmVqqIaVkDv4fYfUiJZoSA9JygYul3jMt4p\nrS7cdWaDaR/EX3aTA1S9S331CFwhzRYC5cj6t+Qz5SIH9czmHFH6STfIvYtkxGvC\nGtROM9ZeDkO+/LwKbQlkbjuazbPCSWy5/163bPbK1w7PA2Ae7jMaJYtm3wYzQQ==\n-----END RSA PRIVATE KEY-----",
+    "caType": "owned",
+    "clusterName": "aws-external-etcd",
+    "clusterSubdomain": "sub-domain",
+    "etcdOption": "external",
+    "externalETCDClient": "etcd.example.com",
+    "platformType": "aws-tf",
+    "podCIDR": "10.8.0.0/20",
+    "pullSecret": "<TECTONIC_PULL_SECRET>",
+    "serviceCIDR": "10.8.16.0/20",
+    "sts_enabled": true,
+    "tectonicLicense": "<TECTONIC_LICENSE>"
+  }
+}

--- a/installer/frontend/__tests__/examples/aws-in.json
+++ b/installer/frontend/__tests__/examples/aws-in.json
@@ -19,7 +19,6 @@
     "aws_ssh": "tectonic-jenkins",
     "aws_workers-instanceType": "m4.large",
     "aws_workers-numberOfInstances": 2,
-    "aws_workers-storageIOPS": 1500,
     "aws_workers-storageSizeInGiB": 32,
     "aws_workers-storageType": "gp2",
     "caType": "self-signed",

--- a/installer/frontend/ui-tests/output/aws-external-etcd.tfvars
+++ b/installer/frontend/ui-tests/output/aws-external-etcd.tfvars
@@ -1,0 +1,40 @@
+{
+  "tectonic_admin_email": "a.b.c@d.example.com",
+  "tectonic_admin_password": "!@#$%^&*()",
+  "tectonic_aws_extra_tags": {
+    "a": "!@#$%^&*()",
+    "A": "文字"
+  },
+  "tectonic_aws_master_custom_subnets": {
+    "us-west-1a": "10.0.0.0/19",
+    "us-west-1c": "10.0.32.0/20"
+  },
+  "tectonic_aws_master_ec2_type": "m3.large",
+  "tectonic_aws_master_root_volume_iops": 2000,
+  "tectonic_aws_master_root_volume_size": 100,
+  "tectonic_aws_master_root_volume_type": "io1",
+  "tectonic_aws_private_endpoints": false,
+  "tectonic_aws_region": "us-west-1",
+  "tectonic_aws_ssh_key": "tectonic-jenkins",
+  "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
+  "tectonic_aws_worker_custom_subnets": {
+    "us-west-1a": "10.0.64.0/19",
+    "us-west-1c": "10.0.96.0/20"
+  },
+  "tectonic_aws_worker_ec2_type": "m3.medium",
+  "tectonic_aws_worker_root_volume_size": 100,
+  "tectonic_aws_worker_root_volume_type": "standard",
+  "tectonic_base_domain": "tectonic-ci.de",
+  "tectonic_ca_cert": "-----BEGIN CERTIFICATE-----\nMIIFDTCCAvWgAwIBAgIJAIuXq10k2OFlMA0GCSqGSIb3DQEBCwUAMBIxEDAOBgNV\nBAMMB2Zha2UtY2EwHhcNMTcwMjAxMjIxMzI0WhcNMjcwMTMwMjIxMzI0WjASMRAw\nDgYDVQQDDAdmYWtlLWNhMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA\nzzHsB56F6oZjsVBKzfpicsG+mVHQ/QzA4jqRCbQ8Zr12NtUZKnPUVwDoFf4WTfmy\nZ0u8Uv+6/B/8un3LGsIaJEugPfRboc2oZKJcqfMJSFfLb/wkmT0D/1HJR60ml/M5\nwpHeh4vQ7BhktNsK90EjdlLvr1GDfevXArnye5ksEInOSX9nXVsGPrm0AGSffhmY\nuUAjY8f9IspJa1j4vL6NI89GWO4jqME+SUnuI4SYIkuQJoSElofAIX2b5Tk3dFya\nVKmAq2L89teCMYsciPbFa/Z2HvDNZ7pC17Ow7zr1f+V5BU18h3cLk610YNPcEBw0\nf94+mePsmMSMjUM0f+NMFyDERF+pys60/3qqVWrJe/FkJM6NDCyWXXXAfTxIwLq0\nCVrlWALdTc+RMAPI2sxAdUp4BqAuek4SjIg3FuoJrBs3EAUPfybclJ7g3HJwyXM2\n3WIe10BnSk+rGzd4KMVbYw5/nM8Nc/Y20R2an/vVZn6xTxs9o6hhEHF7d5iws6Bi\n7/jv+jdZhLG8b3sG6Tj7a7YdvKWqH/mSPFlc/sevYOjR7NKYRMwGnl0d9qf+Xe5V\nxyH1llIXPs6+y1B4tRyL/tulyeVqi25+I4QVAYypxWU8CPyw7tsSdOsSTbeGTmXj\nehelY/BCjAqAcexL7oRV7dy7VZ1Ezg6zQRwMt0Tar90CAwEAAaNmMGQwHQYDVR0O\nBBYEFNGPoXTjJnHjG2zMpjSg/9vNO/trMB8GA1UdIwQYMBaAFNGPoXTjJnHjG2zM\npjSg/9vNO/trMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQDAgGGMA0G\nCSqGSIb3DQEBCwUAA4ICAQC9V/0iiEZYHz7xbezHpeGHwmecH5oylEvAeCcN10gx\nHFvUN+XMyBaPqN7iRtx/rSqyp2iN2AK1Cdn1viOSRc09lwPiuj9V4diSDyPwJWxd\n60gqd5E9F9gQXlenWoIdm7kW8Lo8HLfx8ItYKGpE51JUctTmGY5WURRmBlVKr1LA\nhbVsAWBaGQfPyW1CrFcxxc5mCABxWOxjRjLw8A8c5IXD0Q5C5pRd0BckBHKTdl40\nowm893oPEQcu/1C432T4vIddVh1Ktq1pd7O/9BPYOaPryzf7076xSwZ0bSuBUGRq\nVd3STfu5QRqpMv4dIrhqRofmIUzjOHLRX8Lx2pzgYcMgMQ8O+jM+ETrYD6rsDoLQ\nuiVSWZK0YFndKzNTA04u57arRumWKqqfS0kkDFayumyv6KaDS6YZdsqSRmaiLAOG\nF6jchpUtkDhDY0v/Y7jESUneT0hRnqNMPAKJMNhE4hS+1qkcP/ikQQgZl/OWma1z\nHUyBGT4OGP2T3JIfq12Z4vC5FGVD4aD/frTvPMlifV3i8lKlYZs271JPXUo6ASIA\nZSBpV5QilOlE25Q5Lcw0yWmN4KwxqBL9bJ5W9D1I0qhWxaMF78m+8vLIFv+dAylE\nOd27a+1We/P5ey7WRlwCfuEcFV7nYS/qMykYdQ9fxHSPgTPlrGrSwKstaaIIqOkE\nkA==\n-----END CERTIFICATE-----\n",
+  "tectonic_ca_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBAAKCAgEAzzHsB56F6oZjsVBKzfpicsG+mVHQ/QzA4jqRCbQ8Zr12NtUZ\nKnPUVwDoFf4WTfmyZ0u8Uv+6/B/8un3LGsIaJEugPfRboc2oZKJcqfMJSFfLb/wk\nmT0D/1HJR60ml/M5wpHeh4vQ7BhktNsK90EjdlLvr1GDfevXArnye5ksEInOSX9n\nXVsGPrm0AGSffhmYuUAjY8f9IspJa1j4vL6NI89GWO4jqME+SUnuI4SYIkuQJoSE\nlofAIX2b5Tk3dFyaVKmAq2L89teCMYsciPbFa/Z2HvDNZ7pC17Ow7zr1f+V5BU18\nh3cLk610YNPcEBw0f94+mePsmMSMjUM0f+NMFyDERF+pys60/3qqVWrJe/FkJM6N\nDCyWXXXAfTxIwLq0CVrlWALdTc+RMAPI2sxAdUp4BqAuek4SjIg3FuoJrBs3EAUP\nfybclJ7g3HJwyXM23WIe10BnSk+rGzd4KMVbYw5/nM8Nc/Y20R2an/vVZn6xTxs9\no6hhEHF7d5iws6Bi7/jv+jdZhLG8b3sG6Tj7a7YdvKWqH/mSPFlc/sevYOjR7NKY\nRMwGnl0d9qf+Xe5VxyH1llIXPs6+y1B4tRyL/tulyeVqi25+I4QVAYypxWU8CPyw\n7tsSdOsSTbeGTmXjehelY/BCjAqAcexL7oRV7dy7VZ1Ezg6zQRwMt0Tar90CAwEA\nAQKCAgEAjH2XQ9tThqC1fIerEVvT4WhJ6wA1K0C4kS2RJvlVc3zIaYm5VLXRp2Tv\n+emeCiVjuPL7sXPBwC+YWIPvcidnPnEhKKFGeMJQilwlZP9srecKBNb9ogJjcX5t\ncvKPlrzPz4TFVTeS5GPt9UwJdXpvp025RDGLbZi65BhduT01ScmHXQLMfdq4s1OM\nIDAajZChpAs/c+spU6vCeM2Na73xSfTECI0BFO5jY6KDnQXNeoOuLM/yb3eA6bSY\nPqe7WGVqKDn/CzdFu8KJfzqKkLxzRS+LDJPPU6RSqpwnPy/FQ4G/u768z8YCzZHx\nta4yK6JUXte9ru+DgFrVyvtk38qpzlNYj5PVPkZxOZaWPALYAa6N53/NSJIZ/Pm6\nYaLkncTbpjer0zzEULfEngiHl8e8XrySeirmIZ7W1RPVA/k0f4d9rOVxhvtNM4es\nWaEvCMxC1BOD5e7fX39hI4xjFNjecFSXPLR9RlbTxg0yQAjDfMJYghdNfUgfd8I0\nQP9UmSdLiUcCWJlZ5uF0UG+HNxcp/ML1z7GTLxYjuqC1gLA1giMD8Y7zJJbIsRKt\n8ymtlkqoTkO+AMnQ0/Eno2yQ9ed7+guhYdpLuEvH2f+p5yEVtcrYmE/tiombs9Gq\ntwVTeSvmm8uLygQIdI0QeKnRjoM9qX9+5I1EkloB7vhTXSAQ+oECggEBAPuDyEgq\nB2etxpvveDKOatuRimC+oWQ7eyp6NA8BOaHw+1OgTGPE+807i4/RPlhT9pbTuG16\n/unH8PnRXijtYEeQdFck9TCYjqwJlThZdokg30g827U6K+UECqd5ffejx9cnRpxu\nUke+AfMLdzG7G3EJlGoG76JZyKmow1JKzPhL7qa9YQRWA9dxC+vMjKakWf2Y8OSq\ntkukYRpbn7VC99v5J8vJsNVFXu419N7h0bj2yQ6t64N/ybPWVfjp5xzc9rsNN14f\nj1HoeqX/xw3MSUMjJol1L1V6+kHBhws0JsWFnGma+LTnDj4RE8HzohTlQv7Bhsgz\n2qlW3gizrQEn+FECggEBANLjz4SX0eYF37pbZ1XReqezb9LP8oXiHn8UZpKlRpcF\nDmaoSa9vcEySjwEq3oiR3Nzny46zLfAAJ7O3K2TI4AS/zcTmQw2G4+WjRf8tTq2x\nA8SNq5E6p5bbimJC+80cVVfFAGukeQy9149ZW4ldfYTrk+821o5lBXmo9EqyrbqI\nNrt/EezSHr/Yai9zSV/VnLZ27nvW7vFlNHqbMGwhTHBY8eX6SEdIsobdjsdGdrUn\ni331ImodBJ5/3H6OdNGHUbrizzn8Jm8CgZHkA87a9ON8eKHQ/FOb/Md82qDghnQR\nLfBcoOac357Nprc4F/YGE4MCjXgLmGrgzMkQ0Fwcp80CggEBAM7fwQ/iSf70R2Uh\nXhsvWyNInaofgj4gUplItKMW3eGehgpt0gdKEdboQE3FzOL4BN5gPNUIEr4Vr9a7\naBh/zu5uGdNH2cjj4o4Mv8j+hOobuKwBKrHwrAQOA/lmi77x3sDQVFr8vv61gYL4\njkzAWrzqJUHkfJxr/wnVfvqj/d3JDv3kzPS1DynYmPaVY6b5je9yKcnbxF+JUDlO\n3ZlJAPfVAu+y8JkrGv8SMFxXH5pkmlFRqmKZ7DzYchRvx6HM+cA3CbCIgujbMG5z\naLWnrybitaLgWVOU+Fy3oq0Lc0yKLnIKfsDFP8i7YSXpkAph3G4Qnhzz0cnxYmWD\n7CwERVECggEAaFVKalfOAVXwnLrxwbRUUTll3k8AthnraoWGRZC8/qQCvukNI10n\nmsp7M2GpHLnFIgkPXPbqiC0bdz7smf0DT3Yw7/PXQo70mryPObKJlUbZDVnlgoEZ\nPno42Wo4Nv6Ifla5YYfKV3JofcQAlFILckI2OwfPWD1EWy8qRPZnGryfD13LWXWO\nvuzrg7QundoJoP/v9pacOhMOxoWWjDhhH8fxTQzoy1N891oPdCk5O2BoE5W+Q+89\nRMkPJhGGW87tsV7alN5ZiVwdDDdZZvJOa2k+KRhCbX7jrTHo2+SYwD1rk9nPxKfh\nvigSDd0ThaT17D/MC5L5Ag9bYTIPUzLeFQKCAQEAq6RjI5A3Xppq9OFziOjgrUGv\n2/xIH1NH7hdqGk5V+QRYQdD7Vd9wnF4f0CpIYTR55Mcud4amL3mHcR2IdjhJ4wcL\n0VnSghllTdzO9dcDQ3cigIkzdikGoC+xPQRXMpt3sWS3BYyJZmjsUG1+TgPOZZeb\nDInfb96I9euapu9meSrwzYy7R21eFfmVqqIaVkDv4fYfUiJZoSA9JygYul3jMt4p\nrS7cdWaDaR/EX3aTA1S9S331CFwhzRYC5cj6t+Qz5SIH9czmHFH6STfIvYtkxGvC\nGtROM9ZeDkO+/LwKbQlkbjuazbPCSWy5/163bPbK1w7PA2Ae7jMaJYtm3wYzQQ==\n-----END RSA PRIVATE KEY-----",
+  "tectonic_ca_key_alg": "RSA",
+  "tectonic_cluster_cidr": "10.8.0.0/20",
+  "tectonic_cluster_name": "aws-external-etcd",
+  "tectonic_dns_name": "sub-domain",
+  "tectonic_etcd_servers": ["etcd.example.com"],
+  "tectonic_license_path": "./license.txt",
+  "tectonic_master_count": 2,
+  "tectonic_pull_secret_path": "./pull_secret.json",
+  "tectonic_service_cidr": "10.8.16.0/20",
+  "tectonic_worker_count": 2
+}

--- a/installer/frontend/ui-tests/pages/certificateAuthorityPage.js
+++ b/installer/frontend/ui-tests/pages/certificateAuthorityPage.js
@@ -1,24 +1,32 @@
 const pageCommands = {
-  test () {
+  test (json) {
+    const certFile = 'input[type="file"]#caCertificate';
+    const certText = 'textarea#caCertificate';
+    const keyFile = 'input[type="file"]#caPrivateKey';
+    const keyText = 'textarea#caPrivateKey';
+    const customCaFields = [certFile, certText, keyFile, keyText];
+
     this.expect.element('@optionGenerate').to.be.selected;
-    this.expect.element('@cert').to.not.be.present;
-    this.expect.element('@key').to.not.be.present;
+    customCaFields.forEach(el => this.expect.element(el).to.not.be.present);
 
     this.selectOption('@optionUseOwn');
-    this.expect.element('@cert').to.be.visible;
-    this.expect.element('@key').to.be.visible;
+    customCaFields.forEach(el => this.expect.element(el).to.be.present);
+    this.expect.element(certText).to.be.visible;
+    this.expect.element(keyText).to.be.visible;
 
-    this.selectOption('@optionGenerate');
-    this.expect.element('@cert').to.not.be.present;
-    this.expect.element('@key').to.not.be.present;
+    if (json.caCertificate && json.caPrivateKey) {
+      this.testFileTextCombo(certFile, certText, json.caCertificate, '-----abc-----', 'Invalid certificate');
+      this.testFileTextCombo(keyFile, keyText, json.caPrivateKey, '-----abc------', 'Invalid private key');
+    } else {
+      this.selectOption('@optionGenerate');
+      customCaFields.forEach(el => this.expect.element(el).to.not.be.present);
+    }
   },
 };
 
 module.exports = {
   commands: [pageCommands],
   elements: {
-    cert: 'textarea#caCertificate',
-    key: 'textarea#caPrivateKey',
     optionGenerate: '.wiz-radio-group:nth-child(1) input[type=radio]',
     optionUseOwn: '.wiz-radio-group:nth-child(2) input[type=radio]',
   },

--- a/installer/frontend/ui-tests/pages/clusterInfoPage.js
+++ b/installer/frontend/ui-tests/pages/clusterInfoPage.js
@@ -42,6 +42,14 @@ const clusterInfoPageCommands = {
         .setField('input[id="awsTags.0.key"]', json.awsTags[0].key)
         .setField('input[id="awsTags.0.value"]', json.awsTags[0].value)
         .expectNoValidationError();
+
+      for (let i = 1; i < json.awsTags.length; i++) {
+        this
+          .click('.fa-plus-circle')
+          .setField('input[id="awsTags.1.key"]', json.awsTags[1].key)
+          .setField('input[id="awsTags.1.value"]', json.awsTags[1].value)
+          .expectNoValidationError();
+      }
     }
   },
 };

--- a/installer/frontend/ui-tests/pages/consoleLoginPage.js
+++ b/installer/frontend/ui-tests/pages/consoleLoginPage.js
@@ -6,16 +6,18 @@ const consoleLoginPageCommands = {
       .setField('@email', json.adminEmail)
       .expectNoValidationError();
 
-    this.setField('@password', 'password');
+    const password = json.adminPassword || 'password';
+
+    this.setField('@password', password);
     this.setField('@confirmPassword', 'abc');
     this.expect.element('@alertError').text.to.contain('Passwords do not match');
 
     this.setField('@password', 'abc');
-    this.setField('@confirmPassword', 'password');
+    this.setField('@confirmPassword', password);
     this.expect.element('@alertError').text.to.contain('Passwords do not match');
 
-    this.setField('@password', 'password');
-    this.setField('@confirmPassword', 'password');
+    this.setField('@password', password);
+    this.setField('@confirmPassword', password);
     this.expect.element('@alertError').to.not.be.present;
   },
 };

--- a/installer/frontend/ui-tests/pages/nodesPage.js
+++ b/installer/frontend/ui-tests/pages/nodesPage.js
@@ -26,13 +26,21 @@ const nodesPageCommands = {
 
     testInstanceCount('@mastersCount', json['aws_controllers-numberOfInstances'], 100);
     testInstanceCount('@workersCount', json['aws_workers-numberOfInstances'], 1000);
-    testInstanceCount('@etcdCount', json['aws_etcds-numberOfInstances'], 9);
+    if (json['aws_etcds-numberOfInstances']) {
+      testInstanceCount('@etcdCount', json['aws_etcds-numberOfInstances'], 9);
+    }
 
     this
       .selectOption(`[id=aws_controllers--instance] [value="${json['aws_controllers-instanceType']}"]`)
       .selectOption(`[id=aws_workers--instance] [value="${json['aws_workers-instanceType']}"]`)
-      .selectOption(`[id=aws_etcds--instance] [value="${json['aws_etcds-instanceType']}"]`)
       .expectNoValidationError();
+
+    const etcdInstanceType = json['aws_etcds-instanceType'];
+    if (etcdInstanceType) {
+      this
+        .selectOption(`[id=aws_etcds--instance] [value="${etcdInstanceType}"]`)
+        .expectNoValidationError();
+    }
 
     const testVolumeSize = (field, value) => {
       const min = 30;
@@ -40,16 +48,47 @@ const nodesPageCommands = {
         .setField(field, min - 1)
         .expectValidationErrorContains(`Cannot be less than ${min}`)
         .setField(field, min)
-        .expectNoValidationError()
-        .setField(field, value)
         .expectNoValidationError();
+
+      if (value) {
+        this
+          .setField(field, value)
+          .expectNoValidationError();
+      }
     };
 
     testVolumeSize('[id=aws_controllers--storage-size]', json['aws_controllers-storageSizeInGiB']);
     testVolumeSize('[id=aws_workers--storage-size]', json['aws_workers-storageSizeInGiB']);
     testVolumeSize('[id=aws_etcds--storage-size]', json['aws_etcds-storageSizeInGiB']);
 
+    const mastersStorageType = json['aws_controllers-storageType'];
+    if (mastersStorageType) {
+      this.selectOption(`[id=aws_controllers--storage-type] [value="${mastersStorageType}"]`);
+    }
+    const workersStorageType = json['aws_workers-storageType'];
+    if (workersStorageType) {
+      this.selectOption(`[id=aws_workers--storage-type] [value="${workersStorageType}"]`);
+    }
+    this.expectNoValidationError();
+
+    const mastersIOPS = json['aws_controllers-storageIOPS'];
+    if (mastersIOPS) {
+      this.setField('[id=aws_controllers--storage-iops]', mastersIOPS);
+    }
+    const workersIOPS = json['aws_workers-storageIOPS'];
+    if (workersIOPS) {
+      this.setField('[id=aws_workers--storage-iops]', workersIOPS);
+    }
+    this.expectNoValidationError();
+
     testExternalEtcd(this);
+
+    if (json.etcdOption === 'external') {
+      this
+        .selectOption('#external')
+        .setField('#externalETCDClient', json.externalETCDClient)
+        .expectNoValidationError();
+    }
   },
 };
 

--- a/installer/frontend/ui-tests/tests/aws.js
+++ b/installer/frontend/ui-tests/tests/aws.js
@@ -64,5 +64,6 @@ const ignoredKeys = [
 module.exports = Object.assign(
   toExport,
   steps('aws', '../../../../tests/smoke/aws/vars/aws.tfvars.json', ignoredKeys),
+  steps('aws-external-etcd', '../output/aws-external-etcd.tfvars'),
   steps('aws-custom-vpc', '../output/aws-custom-vpc.tfvars')
 );


### PR DESCRIPTION
Adds some AWS GUI checks not included in our other tests:
  - External etcd input fields
  - Custom CA input fields
  - Variety of different valid input values for other fields