### PR TITLE
frontend: Add message when in progress install is detected

### DIFF
--- a/installer/frontend/components/tf-poweron.jsx
+++ b/installer/frontend/components/tf-poweron.jsx
@@ -275,11 +275,14 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
 
       const tfTitle = `Terraform ${_.startCase(action)}`;
 
+      // If we detected an install in progress when the app started, then the cluster config will not be populated
+      const isClusterConfigPopulated = !!clusterName;
+
       // Show Terraform actions menu if,
       //   (1) The Terraform apply step has succeeded, and
       //   (2) The cluster state data is populated (required by some of the menu actions)
       // Otherwise, we will just show the Terraform logs instead.
-      const showTfActions = isApplySuccess && !!clusterName;
+      const showTfActions = isApplySuccess && isClusterConfigPopulated;
 
       return <div>
         {!isBareMetal &&
@@ -308,6 +311,7 @@ export const TF_PowerOn = connect(stateToProps, dispatchToProps)(
           </div>
         }
         <hr />
+        {!isClusterConfigPopulated && <Alert>Detected installation already in progress.</Alert>}
         <div className="row">
           <div className="col-xs-12 wiz-launch-progress">
             <Step done={statusMsg === 'success'} error={tfError}>


### PR DESCRIPTION
The case where the app detects that an install is already in progress when the app loads is potentially confusing, so add a message to explain why it skipped to the Start Installation page.

![screenshot-1](https://user-images.githubusercontent.com/460802/36368047-dc4de26a-1598-11e8-8083-d4cdb6022809.png)
