### PR TITLE
tests: Stash installer binary for gui tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,6 +198,7 @@ pipeline {
                     rm -fr frontend/tests_output
                     """
                     stash name: 'node-modules', includes: 'installer/frontend/node_modules/**'
+                    stash name: 'installer-binary', includes: 'installer/bin/linux/installer'
                   }
                 }
                 withDockerContainer(tectonicSmokeTestEnvImage) {


### PR DESCRIPTION
In the long run the GUI tests should use the tarball produced by Bazel
as well. As a short fix, this patch stashes the installer binary again,
so the GUI tests can use it.