### PR TITLE
Some CLI fixes

### DIFF
--- a/installer/pkg/terraform-generator/tectonic.go
+++ b/installer/pkg/terraform-generator/tectonic.go
@@ -24,7 +24,7 @@ type Tectonic struct {
 	EtcdCACertPath            string `json:"tectonic_etcd_ca_cert_path,omitempty"`
 	EtcdClientCertPath        string `json:"tectonic_etcd_client_cert_path,omitempty"`
 	EtcdClientKeyPath         string `json:"tectonic_etcd_client_key_path,omitempty"`
-	EtcdCount                 string `json:"tectonic_etcd_count,omitempty"`
+	EtcdCount                 int    `json:"tectonic_etcd_count,omitempty"`
 	EtcdServers               string `json:"tectonic_etcd_servers,omitempty"`
 	EtcdTLSEnabled            string `json:"tectonic_etcd_tls_enabled,omitempty"`
 	HTTPProxyAddress          string `json:"tectonic_http_proxy_address,omitempty"`
@@ -62,7 +62,7 @@ func NewTectonic(cluster config.Cluster) Tectonic {
 		// EtcdCACertPath:            "",
 		// EtcdClientCertPath:        "",
 		// EtcdClientKeyPath:         "",
-		// EtcdCount:                 "",
+		EtcdCount: cluster.Etcd.NodeCount,
 		// EtcdServers:               "",
 		// EtcdTLSEnabled:            "",
 		// HTTPProxyAddress:          "",

--- a/installer/pkg/workflow/destroy.go
+++ b/installer/pkg/workflow/destroy.go
@@ -16,13 +16,37 @@ func NewDestroyWorkflow(clusterDir string) Workflow {
 }
 
 func destroyAssetsStep(m *metadata) error {
-	return tfDestroy(m.clusterDir, assetsStep, findTemplatesForStep(assetsStep))
+	if !hasStateFile(m.clusterDir, assetsStep) {
+		// there is no statefile, therefore nothing to destroy for this step
+		return nil
+	}
+	templateDir, err := findTemplatesForStep(assetsStep)
+	if err != nil {
+		return err
+	}
+	return tfDestroy(m.clusterDir, assetsStep, templateDir)
 }
 
 func destroyBootstrapStep(m *metadata) error {
-	return tfDestroy(m.clusterDir, bootstrapStep, findTemplatesForStep(bootstrapStep))
+	if !hasStateFile(m.clusterDir, bootstrapStep) {
+		// there is no statefile, therefore nothing to destroy for this step
+		return nil
+	}
+	templateDir, err := findTemplatesForStep(bootstrapStep)
+	if err != nil {
+		return err
+	}
+	return tfDestroy(m.clusterDir, bootstrapStep, templateDir)
 }
 
 func destroyJoinStep(m *metadata) error {
-	return tfDestroy(m.clusterDir, joinStep, findTemplatesForStep(joinStep))
+	if !hasStateFile(m.clusterDir, joinStep) {
+		// there is no statefile, therefore nothing to destroy for this step
+		return nil
+	}
+	templateDir, err := findTemplatesForStep(joinStep)
+	if err != nil {
+		return err
+	}
+	return tfDestroy(m.clusterDir, joinStep, templateDir)
 }

--- a/installer/pkg/workflow/destroy.go
+++ b/installer/pkg/workflow/destroy.go
@@ -16,37 +16,26 @@ func NewDestroyWorkflow(clusterDir string) Workflow {
 }
 
 func destroyAssetsStep(m *metadata) error {
-	if !hasStateFile(m.clusterDir, assetsStep) {
-		// there is no statefile, therefore nothing to destroy for this step
-		return nil
-	}
-	templateDir, err := findTemplatesForStep(assetsStep)
-	if err != nil {
-		return err
-	}
-	return tfDestroy(m.clusterDir, assetsStep, templateDir)
+	return runDestroyStep(m.clusterDir, assetsStep)
 }
 
 func destroyBootstrapStep(m *metadata) error {
-	if !hasStateFile(m.clusterDir, bootstrapStep) {
-		// there is no statefile, therefore nothing to destroy for this step
-		return nil
-	}
-	templateDir, err := findTemplatesForStep(bootstrapStep)
-	if err != nil {
-		return err
-	}
-	return tfDestroy(m.clusterDir, bootstrapStep, templateDir)
+	return runDestroyStep(m.clusterDir, bootstrapStep)
 }
 
 func destroyJoinStep(m *metadata) error {
-	if !hasStateFile(m.clusterDir, joinStep) {
+	return runDestroyStep(m.clusterDir, joinStep)
+}
+
+func runDestroyStep(clusterDir, step string) error {
+	if !hasStateFile(clusterDir, step) {
 		// there is no statefile, therefore nothing to destroy for this step
 		return nil
 	}
-	templateDir, err := findTemplatesForStep(joinStep)
+	templateDir, err := findTemplates(step)
 	if err != nil {
 		return err
 	}
-	return tfDestroy(m.clusterDir, joinStep, templateDir)
+
+	return tfDestroy(clusterDir, step, templateDir)
 }

--- a/installer/pkg/workflow/install.go
+++ b/installer/pkg/workflow/install.go
@@ -65,11 +65,7 @@ func installBootstrapStep(m *metadata) error {
 		return err
 	}
 
-	if err := destroyCNAME(m.clusterDir); err != nil {
-		return err
-	}
-
-	return nil
+	return destroyCNAME(m.clusterDir)
 }
 
 func installJoinStep(m *metadata) error {
@@ -80,7 +76,10 @@ func installJoinStep(m *metadata) error {
 }
 
 func runInstallStep(clusterDir, step string) error {
-	templateDir := findTemplatesForStep(step)
+	templateDir, err := findTemplatesForStep(step)
+	if err != nil {
+		return err
+	}
 	if err := tfInit(clusterDir, templateDir); err != nil {
 		return err
 	}

--- a/installer/pkg/workflow/install.go
+++ b/installer/pkg/workflow/install.go
@@ -76,7 +76,7 @@ func installJoinStep(m *metadata) error {
 }
 
 func runInstallStep(clusterDir, step string) error {
-	templateDir, err := findTemplatesForStep(step)
+	templateDir, err := findTemplates(step)
 	if err != nil {
 		return err
 	}

--- a/installer/pkg/workflow/terraform.go
+++ b/installer/pkg/workflow/terraform.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func terraformExec(clusterDir string, args ...string) error {
@@ -26,4 +27,10 @@ func tfDestroy(clusterDir, state, templateDir string) error {
 
 func tfInit(clusterDir, templateDir string) error {
 	return terraformExec(clusterDir, "init", templateDir)
+}
+
+func hasStateFile(stateDir string, stateName string) bool {
+	stepStateFile := filepath.Join(stateDir, fmt.Sprintf("%s.tfstate", stateName))
+	_, err := os.Stat(stepStateFile)
+	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
This change fixes destroy steps on incomplete builds. 

In cases where a user does a `tectonic install assets...` and then attempts a `tectonic destroy ...` the tool will fail with an error. The error is caused by the destroy operations that don't have a preceding initialized state. In this case, all destroy steps after `assets` don't have their modules and state initialized and will fail.

It also enables the CLI executable to determine its location and extrapolate the locations of other resources as per expected tarball layout.
