### PR TITLE
installer: ensure reproducible build of bindata

### DIFF
--- a/installer/assets/BUILD.bazel
+++ b/installer/assets/BUILD.bazel
@@ -28,7 +28,7 @@ genrule(
         "//installer/frontend",
     ],
     outs = ["bindata.go"],
-    cmd = "mkdir -p $(@D)/frontend/scripts && cp $(location //installer/frontend:frontend) $(@D)/frontend/scripts && cp -R installer/assets/* $(@D) && $(location //installer/vendor/github.com/jteeuwen/go-bindata/go-bindata:go-bindata) -o $@ -pkg assets -prefix $(@D) -ignore=$@ -ignore=doc.go -ignore=assets.go $(@D)/...",
+    cmd = "mkdir -p $(@D)/frontend/scripts && cp -R installer/assets/* $(@D) && cp $(location //installer/frontend:frontend) $(@D)/frontend/scripts && $(location //installer/vendor/github.com/jteeuwen/go-bindata/go-bindata:go-bindata) -o $@ -pkg assets -prefix $(@D) -ignore=$@ -ignore=doc.go -ignore=assets.go $(@D)/...",
     tools = [
         "//installer/vendor/github.com/jteeuwen/go-bindata/go-bindata",
     ],


### PR DESCRIPTION
Ensure that the frontend files generated by Bazel override any files
that may already exist in the `installer/assets` directory to ensure that
the final `bindata.go` contains the expected assets.
fixes: INST-939

cc @sym3tri @cpanato 