### PR TITLE
frontend: Remove inFly updates from validate()

### DIFF
--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -13,7 +13,7 @@ import { AWS_DomainValidation } from './aws-domain-validation';
 import { KubernetesCIDRs } from './k8s-cidrs';
 import { CIDRTooltip, CIDRRow } from './cidr';
 import { Field, Form } from '../form';
-import { toError } from '../utils';
+import { toError, toInFly } from '../utils';
 
 import {
   AWS_ADVANCED_NETWORKING,
@@ -95,12 +95,17 @@ const validateVPC = async (data, cc, updatedId, dispatch) => {
     network.awsVpcId = awsVpcId;
   }
 
+  const inFlyPath = toInFly(AWS_VPC_FORM);
+  setIn(inFlyPath, true, dispatch);
+  let result;
   try {
-    return await dispatch(validateSubnets(network))
+    result = await dispatch(validateSubnets(network))
       .then(json => json.valid ? undefined : json.message);
   } catch (e) {
-    return e.message || e.toString();
+    result = e.message || e.toString();
   }
+  setIn(inFlyPath, false, dispatch);
+  return result;
 };
 
 const vpcInfoForm = new Form(AWS_VPC_FORM, [

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -60,15 +60,11 @@ class Node {
   }
 
   async validate (dispatch, getState, updatedId = undefined, isNow = () => true) {
-    const inFlyPath = toInFly(this.id);
-    setIn(inFlyPath, true, dispatch);
-
     const cc = getState().clusterConfig;
     const error = await this.validator(this.getData(cc), cc, updatedId, dispatch);
     if (isNow()) {
       await setIn(toError(this.id), _.isEmpty(error) ? undefined : error, dispatch);
     }
-    setIn(inFlyPath, false, dispatch);
     return _.isEmpty(error);
   }
 


### PR DESCRIPTION
Instead validators that actually need to set `inFly` (currently just the AWS VPC validator) should do so themselves. This is much more efficient.