### PR TITLE
digitalocean: Upgrade do-spaces-tool

### DIFF
--- a/platforms/digitalocean/resources/do-puller.sh
+++ b/platforms/digitalocean/resources/do-puller.sh
@@ -15,11 +15,11 @@ export REGION=${do_region}
 FILENAME_DEST=$(basename $${2})
 
 # A tool for interacting with DO's object storage: https://github.com/aknuds1/do-spaces-tool
-docker pull aknudsen/do-spaces-tool:0.2.0 > /dev/null
+docker pull aknudsen/do-spaces-tool:v0.2.1 > /dev/null
 
 do_pull() {
   # shellcheck disable=SC2034,SC1083
-  docker run --rm -e ACCESS_KEY_ID -e SECRET_ACCESS_KEY -e REGION -t --net=host -v /tmp:/spaces aknudsen/do-spaces-tool:0.2.0 download $${1} /spaces/$${2}
+  docker run --rm -e ACCESS_KEY_ID -e SECRET_ACCESS_KEY -e REGION -t --net=host -v /tmp:/spaces aknudsen/do-spaces-tool:v0.2.1 download $${1} /spaces/$${2}
 }
 
 until do_pull $$1 $$FILENAME_DEST; do

--- a/platforms/digitalocean/resources/do-pusher.sh
+++ b/platforms/digitalocean/resources/do-pusher.sh
@@ -17,7 +17,7 @@ filename=$(basename $${1})
 # shellcheck disable=SC2034,SC1083
 cp $${1} /tmp
 # A tool for interacting with DO's object storage: https://github.com/aknuds1/do-spaces-tool
-docker pull aknudsen/do-spaces-tool:0.2.0 > /dev/null
+docker pull aknudsen/do-spaces-tool:v0.2.1 > /dev/null
 # shellcheck disable=SC2034,SC1083
-docker run -t --net=host -e ACCESS_KEY_ID -e SECRET_ACCESS_KEY -e REGION -v /tmp:/spaces aknudsen/do-spaces-tool:0.2.0 upload /spaces/$${filename} $${2}
+docker run -t --net=host -e ACCESS_KEY_ID -e SECRET_ACCESS_KEY -e REGION -v /tmp:/spaces aknudsen/do-spaces-tool:v0.2.1 upload /spaces/$${filename} $${2}
 rm -f /tmp/$${filename}


### PR DESCRIPTION
Use the latest version of aknudsen/do-spaces-tool as it fixes a [critical bug](https://github.com/aknuds1/do-spaces-tool/issues/1), which makes cluster bootstrapping fail due to not being able to upload to the DigitalOcean bucket.