### PR TITLE
modules/aws: enable cluster recovery after cleanup

### DIFF
--- a/modules/aws/master-asg/resources/init-assets.sh
+++ b/modules/aws/master-asg/resources/init-assets.sh
@@ -27,6 +27,13 @@ fi
 # Download the assets from S3.
 # shellcheck disable=SC2154
 /usr/bin/bash /opt/s3-puller.sh "${assets_s3_location}" /var/tmp/tectonic.zip
+
+# If the file is 0 bytes, then this means that the cluster already bootstrapped once and the assets bundle was cleaned. In this case, exit successfully so the kubelet will start and this master will join the existing cluster or support bootkube recovery.
+if [ ! -s /var/tmp/tectonic.zip ]; then
+    echo "zip files is 0 bytes; assuming cluster is being recovered"
+    exit 0
+fi
+
 unzip -o -d /var/tmp/tectonic/ /var/tmp/tectonic.zip
 rm /var/tmp/tectonic.zip
 # make files in /opt/tectonic available atomically


### PR DESCRIPTION
If the assets zip is 0 bytes, then this means that the cluster already
bootstrapped once and the assets bundle was cleaned. In this case, exit
successfully so the kubelet will start and the cluster can be recovered
via bootkube.

Fixes: TECREL-187

cc @coresolve @coverprice @sym3tri