### PR TITLE
platforms/vmware: Use NodePort for tectonic-lb service

### DIFF
--- a/platforms/vmware/tectonic.tf
+++ b/platforms/vmware/tectonic.tf
@@ -136,7 +136,7 @@ module "tectonic" {
 
   console_client_id = "tectonic-console"
   kubectl_client_id = "tectonic-kubectl"
-  ingress_kind      = "HostPort"
+  ingress_kind      = "NodePort"
   master_count      = "${var.tectonic_master_count}"
   stats_url         = "${var.tectonic_stats_url}"
 


### PR DESCRIPTION
Currently, the VMware platform uses a HostPort service for the tectonic
ingress controller which exposes port 443 on all worker nodes. This
change will route https traffic to port 32000 for tectonic ingress.
