### PR TITLE
Parameterize github repository in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
       description: ''
     )
     string(
-      name : 'github_repo',
+      name : 'GITHUB_REPO',
       defaultValue: 'coreos/tectonic-installer',
       description: 'Github repository'
     )
@@ -154,7 +154,7 @@ pipeline {
   stages {
     stage('Build & Test') {
       environment {
-        GO_PROJECT = "/go/src/github.com/${params.github_repo}"
+        GO_PROJECT = "/go/src/github.com/${params.GITHUB_REPO}"
         MAKEFLAGS = '-j4'
       }
       steps {
@@ -541,7 +541,7 @@ def runRSpecTestBareMetal(testFilePath, credentials) {
 def reportStatusToGithub(status, context, commitId) {
   withCredentials(creds) {
     sh """#!/bin/bash -ex
-      ./tests/jenkins-jobs/scripts/report-status-to-github.sh ${status} ${context} ${commitId} ${params.github_repo}
+      ./tests/jenkins-jobs/scripts/report-status-to-github.sh ${status} ${context} ${commitId} ${params.GITHUB_REPO}
     """
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,12 +144,17 @@ pipeline {
       defaultValue: false,
       description: ''
     )
+    string(
+      name : 'github_repo',
+      defaultValue: 'coreos/tectonic-installer',
+      description: 'Github repository'
+    )
   }
 
   stages {
     stage('Build & Test') {
       environment {
-        GO_PROJECT = '/go/src/github.com/coreos/tectonic-installer'
+        GO_PROJECT = "/go/src/github.com/${params.github_repo}"
         MAKEFLAGS = '-j4'
       }
       steps {
@@ -161,7 +166,7 @@ pipeline {
                 forcefullyCleanWorkspace()
                 checkout scm
                 stash name: 'clean-repo', excludes: 'installer/vendor/**,tests/smoke/vendor/**'
-                originalCommitId = sh(returnStdout: true, script: 'git rev-parse origin/"\${BRANCH_NAME}"')
+                originalCommitId = sh(returnStdout: true, script: 'git rev-parse origin/"\${BRANCH_NAME}"').trim()
                 echo "originalCommitId: ${originalCommitId}"
 
                 withDockerContainer(tectonicBazelImage) {
@@ -536,7 +541,7 @@ def runRSpecTestBareMetal(testFilePath, credentials) {
 def reportStatusToGithub(status, context, commitId) {
   withCredentials(creds) {
     sh """#!/bin/bash -ex
-      ./tests/jenkins-jobs/scripts/report-status-to-github.sh ${status} ${context} ${commitId}
+      ./tests/jenkins-jobs/scripts/report-status-to-github.sh ${status} ${context} ${commitId} ${params.github_repo}
     """
   }
 }

--- a/tests/jenkins-jobs/scripts/report-status-to-github.sh
+++ b/tests/jenkins-jobs/scripts/report-status-to-github.sh
@@ -4,9 +4,10 @@ STATUS="$1"
 CONTEXT=${2/spec/smoke-tests}
 CONTEXT=${CONTEXT/_spec.rb/}
 COMMIT="$3"
+GITHUB_REPO="${4:-coreos/tectonic-installer}"
 
 curl -f \
      -H 'Content-Type: application/json' \
      -u "$GITHUB_CREDENTIALS" \
-     "https://api.github.com/repos/coreos/tectonic-installer/statuses/${COMMIT}" \
+     "https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT}" \
      -d "{\"state\": \"${STATUS}\", \"target_url\": \"${BUILD_URL}\", \"description\": \"\", \"context\": \"${CONTEXT}\"}"

--- a/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
+++ b/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
@@ -12,7 +12,7 @@ job("builders/tectonic-builder-docker-image") {
     stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream Terraform download url, defaults to upstream Terraform release')
     stringParam('TECTONIC_BUILDER_TAG', '', 'Tectonic Builder Docker tag')
     booleanParam('DRY_RUN', true, 'Just build the docker image')
-    stringParam('github_repo', 'coreos/tectonic-installer', 'Github repository')
+    stringParam('GITHUB_REPO', 'coreos/tectonic-installer', 'Github repository')
   }
 
   wrappers {
@@ -26,7 +26,7 @@ job("builders/tectonic-builder-docker-image") {
   scm {
     git {
       remote {
-        url('https://github.com/\${github_repo}')
+        url('https://github.com/\${GITHUB_REPO}')
       }
       branch('origin/master')
     }

--- a/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
+++ b/tests/jenkins-jobs/tectonic_builder_docker_image.groovy
@@ -12,6 +12,7 @@ job("builders/tectonic-builder-docker-image") {
     stringParam('TERRAFORM_UPSTREAM_URL', '', 'upstream Terraform download url, defaults to upstream Terraform release')
     stringParam('TECTONIC_BUILDER_TAG', '', 'Tectonic Builder Docker tag')
     booleanParam('DRY_RUN', true, 'Just build the docker image')
+    stringParam('github_repo', 'coreos/tectonic-installer', 'Github repository')
   }
 
   wrappers {
@@ -25,7 +26,7 @@ job("builders/tectonic-builder-docker-image") {
   scm {
     git {
       remote {
-        url('https://github.com/coreos/tectonic-installer')
+        url('https://github.com/\${github_repo}')
       }
       branch('origin/master')
     }

--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -12,11 +12,11 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   parameters {
     stringParam('ghprbPullId', '', 'PR number')
-    stringParam('github_repo', 'coreos/tectonic-installer', 'Github repository')
+    stringParam('GITHUB_REPO', 'coreos/tectonic-installer', 'Github repository')
   }
 
   properties {
-    githubProjectUrl('https://github.com/\${github_repo}')
+    githubProjectUrl('https://github.com/\${GITHUB_REPO}')
   }
 
   wrappers {
@@ -60,7 +60,7 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   steps {
     shell """#!/bin/bash -ex
-      curl "https://api.github.com/repos/\${github_repo}/labels?per_page=100" > repoLabels
+      curl "https://api.github.com/repos/\${GITHUB_REPO}/labels?per_page=100" > repoLabels
       repoLabels=\$(jq ".[] | .name" repoLabels)
       repoLabels=\$(echo \$repoLabels | tr -d "\\"" | tr [a-z] [A-Z] | tr - _)
       for label in \$repoLabels
@@ -69,7 +69,7 @@ job("triggers/tectonic-installer-pr-trigger") {
       done
 
 
-      curl "https://api.github.com/repos/\${github_repo}/issues/\${ghprbPullId}" > pr
+      curl "https://api.github.com/repos/\${GITHUB_REPO}/issues/\${ghprbPullId}" > pr
       labels=\$(jq ".labels | .[] | .name" pr)
       labels=\$(echo \$labels | tr -d "\\"" | tr [a-z] [A-Z] | tr - _)
       for label in \$labels

--- a/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
+++ b/tests/jenkins-jobs/tectonic_installer_public_pr_trigger.groovy
@@ -12,10 +12,11 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   parameters {
     stringParam('ghprbPullId', '', 'PR number')
+    stringParam('github_repo', 'coreos/tectonic-installer', 'Github repository')
   }
 
   properties {
-    githubProjectUrl('https://github.com/coreos/tectonic-installer')
+    githubProjectUrl('https://github.com/\${github_repo}')
   }
 
   wrappers {
@@ -59,7 +60,7 @@ job("triggers/tectonic-installer-pr-trigger") {
 
   steps {
     shell """#!/bin/bash -ex
-      curl "https://api.github.com/repos/coreos/tectonic-installer/labels?per_page=100" > repoLabels
+      curl "https://api.github.com/repos/\${github_repo}/labels?per_page=100" > repoLabels
       repoLabels=\$(jq ".[] | .name" repoLabels)
       repoLabels=\$(echo \$repoLabels | tr -d "\\"" | tr [a-z] [A-Z] | tr - _)
       for label in \$repoLabels
@@ -68,7 +69,7 @@ job("triggers/tectonic-installer-pr-trigger") {
       done
 
 
-      curl "https://api.github.com/repos/coreos/tectonic-installer/issues/\${ghprbPullId}" > pr
+      curl "https://api.github.com/repos/\${github_repo}/issues/\${ghprbPullId}" > pr
       labels=\$(jq ".labels | .[] | .name" pr)
       labels=\$(echo \$labels | tr -d "\\"" | tr [a-z] [A-Z] | tr - _)
       for label in \$labels

--- a/tests/jenkins-jobs/tectonic_smoke_test_docker_image_job.groovy
+++ b/tests/jenkins-jobs/tectonic_smoke_test_docker_image_job.groovy
@@ -11,7 +11,7 @@ job("builders/tectonic-smoke-env-docker-image") {
   parameters {
     stringParam('TECTONIC_SMOKE_TAG', '', 'Tectonic Smoke Docker tag')
     booleanParam('DRY_RUN', true, 'Just build the docker image')
-    stringParam('github_repo', 'coreos/tectonic-installer', 'Github repository')
+    stringParam('GITHUB_REPO', 'coreos/tectonic-installer', 'Github repository')
   }
 
   wrappers {
@@ -25,7 +25,7 @@ job("builders/tectonic-smoke-env-docker-image") {
   scm {
     git {
       remote {
-        url('https://github.com/\${github_repo}')
+        url('https://github.com/\${GITHUB_REPO}')
       }
       branch('origin/master')
     }

--- a/tests/jenkins-jobs/tectonic_smoke_test_docker_image_job.groovy
+++ b/tests/jenkins-jobs/tectonic_smoke_test_docker_image_job.groovy
@@ -11,6 +11,7 @@ job("builders/tectonic-smoke-env-docker-image") {
   parameters {
     stringParam('TECTONIC_SMOKE_TAG', '', 'Tectonic Smoke Docker tag')
     booleanParam('DRY_RUN', true, 'Just build the docker image')
+    stringParam('github_repo', 'coreos/tectonic-installer', 'Github repository')
   }
 
   wrappers {
@@ -24,7 +25,7 @@ job("builders/tectonic-smoke-env-docker-image") {
   scm {
     git {
       remote {
-        url('https://github.com/coreos/tectonic-installer')
+        url('https://github.com/\${github_repo}')
       }
       branch('origin/master')
     }


### PR DESCRIPTION
This is to support making changes to the Jenkinsfile safely from another repo, and in future from another Jenkins instance.

Of note, the .trim() line was added because the "originalCommitId" had a hidden trailing newline.
