### PR TITLE
frontend: Use Redux action creators for all action types

### DIFF
--- a/installer/frontend/__tests__/fields.js
+++ b/installer/frontend/__tests__/fields.js
@@ -4,7 +4,7 @@
 console.debug = console.debug || console.info;
 
 import _ from 'lodash';
-import { __deleteEverything__, configActions } from '../actions';
+import { __deleteEverything__, configActions, formActions } from '../actions';
 import { Field, Form } from '../form';
 import { store } from '../store';
 import { DEFAULT_CLUSTER_CONFIG } from '../cluster-config';
@@ -20,9 +20,9 @@ const expectCC = (path, expected, f) => {
   expect(value).toEqual(expected);
 };
 
-const resetCC = () => configActions.set(DEFAULT_CLUSTER_CONFIG, store.dispatch);
+const resetCC = () => store.dispatch(configActions.set(DEFAULT_CLUSTER_CONFIG));
 
-const updateField = (field, value) => store.dispatch(configActions.updateField(field, value));
+const updateField = (field, value) => store.dispatch(formActions.updateField(field, value));
 
 beforeEach(() => store.dispatch(__deleteEverything__()));
 

--- a/installer/frontend/__tests__/protocols.js
+++ b/installer/frontend/__tests__/protocols.js
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { reducer } from '../reducer';
-import { restoreActionTypes } from '../actions';
+import { restoreActions } from '../actions';
 import { commitToServer } from '../server';
 import '../components/aws-cloud-credentials';
 import '../components/aws-cluster-info';
@@ -80,10 +80,7 @@ const readExample = filename => {
 describe('progress file example', () => {
   tests.forEach(t => {
     it(t.description, () => {
-      const restored = reducer(initialState, {
-        payload: readExample(t.state),
-        type: restoreActionTypes.RESTORE_STATE,
-      });
+      const restored = reducer(initialState, restoreActions.restore(readExample(t.state)));
 
       global.fetch = jest.fn(() => Promise.resolve({
         ok: true,

--- a/installer/frontend/__tests__/reducer.js
+++ b/installer/frontend/__tests__/reducer.js
@@ -2,17 +2,14 @@
 jest.unmock('../reducer');
 
 import { reducer, savable } from '../reducer';
-import { restoreActionTypes } from '../actions';
+import { restoreActions } from '../actions';
 
 const initialState = reducer(undefined, {type: 'Some Initial Action'});
 
 describe('reducer', () => {
   it('saves and restores the initial state faithfully', () => {
     const saved = savable(initialState);
-    const restoredState = reducer(initialState, {
-      type: restoreActionTypes.RESTORE_STATE,
-      payload: saved,
-    });
+    const restoredState = reducer(initialState, restoreActions.restore(saved));
     expect(initialState).toEqual(restoredState);
   });
 });

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -64,7 +64,7 @@ export const commitPhases = {
   FAILED: 'COMMIT_FAILED',
 };
 export const FIELDS = {};
-const FIELD_TO_DEPS = {};
+export const FIELD_TO_DEPS = {};
 export const FORMS = {};
 
 const getField = name => {
@@ -96,12 +96,12 @@ export const configActions = {
   },
   refreshExtraData: fieldName => (dispatch, getState) => {
     const field = getField(fieldName);
-    field.getExtraStuff(dispatch, getState, FIELDS);
+    field.getExtraStuff(dispatch, getState);
   },
   updateField: (fieldName, inputValue) => (dispatch, getState) => {
     const [name, ...split] = fieldName.split('.');
     const field = getField(name);
-    return field.update(dispatch, inputValue, getState, FIELDS, FIELD_TO_DEPS, split);
+    return field.update(dispatch, inputValue, getState, split);
   },
 };
 
@@ -125,7 +125,7 @@ export const validateFields = async (ids, getState, dispatch, updatedId, isNow) 
       throw new Error(`Unresolvable fields: ${unvisitedIds}`);
     }
     await Promise.all(toVisit.map(
-      id => FIELDS[id].getExtraStuff(dispatch, getState, FIELDS, isNow)
+      id => FIELDS[id].getExtraStuff(dispatch, getState, isNow)
         .then(() => FIELDS[id].validate(dispatch, getState, updatedId, isNow))
     ));
     _.pullAll(unvisitedIds, toVisit);

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -5,6 +5,11 @@ import { DEFAULT_CLUSTER_CONFIG } from './cluster-config';
 export const awsActionTypes = {
   SET: 'AWS_SET',
 };
+export const awsActions = {
+  error: (key, error) => awsActions.set(key, {error, inFly: false, value: []}),
+  loaded: (key, value) => awsActions.set(key, {error: null, inFly: false, value}),
+  set: (key, data) => ({payload: {[key]: data}, type: awsActionTypes.SET}),
+};
 
 export const configActionTypes = {
   ADD_IN: 'CONFIG_ACTION_ADD_IN',
@@ -17,9 +22,14 @@ export const configActionTypes = {
 };
 
 export const clusterReadyActionTypes = {
-  ERROR: 'clusterReadyActionTypes.ERROR',
-  STATUS: 'clusterReadyActionTypes.CLUSTER_STATUS',
-  NOT_READY: 'clusterReadyActionTypes.NOT_READY',
+  ERROR: 'CLUSTER_READY_ERROR',
+  NOT_READY: 'CLUSTER_READY_NOT_READY',
+  STATUS: 'CLUSTER_READY_STATUS',
+};
+export const clusterReadyActions = {
+  error: payload => ({payload, type: clusterReadyActionTypes.ERROR}),
+  notReady: () => ({type: clusterReadyActionTypes.NOT_READY}),
+  status: payload => ({payload, type: clusterReadyActionTypes.STATUS}),
 };
 
 export const dirtyActionTypes = {
@@ -34,27 +44,41 @@ export const dirtyActions = {
 export const eventErrorsActionTypes = {
   ERROR: 'EVENT_ERRORS_ERROR',
 };
+export const eventErrorsActions = {
+  error: payload => ({payload, type: eventErrorsActionTypes.ERROR}),
+};
 
 export const loadFactsActionTypes = {
-  LOADED: 'LOAD_FACTS_LOADED',
   ERROR: 'LOAD_FACTS_ERROR',
+  LOADED: 'LOAD_FACTS_LOADED',
+};
+export const loadFactsActions = {
+  error: payload => ({payload, type: loadFactsActionTypes.ERROR}),
+  loaded: payload => ({payload, type: loadFactsActionTypes.LOADED}),
 };
 
 export const restoreActionTypes = {
   RESTORE_STATE: 'RESTORE_RESTORE_STATE',
 };
-
-export const serverActionTypes = {
-  COMMIT_REQUESTED: 'COMMIT_REQUESTED',
-  COMMIT_SENT: 'COMMIT_SENT',
-  COMMIT_SUCCESSFUL: 'COMMIT_SUCCESSFUL',
-  COMMIT_FAILED: 'COMMIT_FAILED',
+export const restoreActions = {
+  restore: payload => ({payload, type: restoreActionTypes.RESTORE_STATE}),
 };
 
-// Commit state machine
-//
-// IDLE|FAILED -> REQUESTED -> WAITING -> SUCCEEDED|FAILED
+export const serverActionTypes = {
+  COMMIT_REQUESTED: 'SERVER_COMMIT_REQUESTED',
+  COMMIT_SENT: 'SERVER_COMMIT_SENT',
+  COMMIT_SUCCESSFUL: 'SERVER_COMMIT_SUCCESSFUL',
+  COMMIT_FAILED: 'SERVER_COMMIT_FAILED',
+};
+export const serverActions = {
+  requested: () => ({type: serverActionTypes.COMMIT_REQUESTED}),
+  sent: () => ({type: serverActionTypes.COMMIT_SENT}),
+  successful: payload => ({payload, type: serverActionTypes.COMMIT_SUCCESSFUL}),
+  failed: payload => ({payload, type: serverActionTypes.COMMIT_FAILED}),
+};
 
+// Commit state machine:
+//   IDLE|FAILED -> REQUESTED -> WAITING -> SUCCEEDED|FAILED
 export const commitPhases = {
   IDLE: 'COMMIT_IDLE',
   REQUESTED: 'COMMIT_REQUESTED',
@@ -62,6 +86,7 @@ export const commitPhases = {
   SUCCEEDED: 'COMMIT_SUCCEEDED',
   FAILED: 'COMMIT_FAILED',
 };
+
 export const FIELDS = {};
 export const FIELD_TO_DEPS = {};
 export const FORMS = {};

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -43,11 +43,10 @@ export const clusterReadyActions = {
 
 export const dirtyActionTypes = {
   ADD: 'DIRTY_ADD',
-  CLEAN: 'DIRTY_CLEAN',
+  DELETE_IN: 'DIRTY_DELETE_IN',
 };
 export const dirtyActions = {
-  add: field => ({type: dirtyActionTypes.ADD, payload: field}),
-  clean: field => ({type: dirtyActionTypes.CLEAN, payload: field}),
+  add: path => ({payload: path, type: dirtyActionTypes.ADD}),
 };
 
 export const eventErrorsActionTypes = {
@@ -121,7 +120,9 @@ export const formActions = {
   },
   removeFieldListRow: (fieldListId, index) => (dispatch, getState) => {
     const fieldList = getField(fieldListId);
-    dispatch({payload: [fieldListId, index], type: configActionTypes.DELETE_IN});
+    const payload = [fieldListId, index];
+    dispatch({payload, type: configActionTypes.DELETE_IN});
+    dispatch({payload, type: dirtyActionTypes.DELETE_IN});
     fieldList.validate(dispatch, getState);
   },
   updateField: (fieldName, inputValue) => (dispatch, getState) => {

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -13,7 +13,6 @@ export const configActionTypes = {
   SET: 'CONFIG_ACTION_SIMPLE_SET',
   SET_IN: 'CONFIG_ACTION_SET_IN',
   BATCH_SET_IN: 'CONFIG_ACTION_BATCH_SET_IN',
-  MERGE: 'CONFIG_ACTION_MERGE',
   RESET: 'CONFIG_ACTION_RESET',
 };
 
@@ -80,7 +79,6 @@ export const configActions = {
   set: (payload, dispatch) => dispatch({type: configActionTypes.SET, payload}),
   setIn: (path, value, dispatch) => dispatch({payload: {path, value}, type: configActionTypes.SET_IN}),
   batchSetIn: (dispatch, payload) => dispatch({payload, type: configActionTypes.BATCH_SET_IN}),
-  merge: payload => dispatch => dispatch({payload, type: configActionTypes.MERGE}),
 
   // TODO: (kans) move below to form actions...
   removeField: (fieldListId, index) => (dispatch, getState) => {

--- a/installer/frontend/app.jsx
+++ b/installer/frontend/app.jsx
@@ -10,7 +10,7 @@ import { Router } from 'react-router-dom';
 import createHistory from 'history/createBrowserHistory';
 import Cookie from 'js-cookie';
 
-import { clusterReadyActionTypes, FIELDS, restoreActionTypes, validateFields } from './actions';
+import { clusterReadyActionTypes, FIELDS, restoreActions, validateFields } from './actions';
 import { PLATFORM_TYPE } from './cluster-config';
 import { trail } from './trail';
 import { TectonicGA } from './tectonic-ga';
@@ -42,10 +42,7 @@ window.addEventListener('beforeunload', saveState);
 try {
   const state = JSON.parse(sessionStorage.getItem('state'));
   if (!_.isEmpty(state)) {
-    dispatch({
-      type: restoreActionTypes.RESTORE_STATE,
-      payload: state,
-    });
+    dispatch(restoreActions.restore(state));
     console.debug('Restored state from sessionStorage.');
   }
 } catch (e) {

--- a/installer/frontend/aws-actions.js
+++ b/installer/frontend/aws-actions.js
@@ -108,7 +108,7 @@ export const getDefaultSubnets = (body, creds, isNow) => (dispatch, getState) =>
       }
 
       // Use addIn to preserve any existing values
-      const add = (path, v) => configActions.addIn(path, v, dispatch);
+      const add = (path, v) => dispatch(configActions.addIn(path, v));
       add(AWS_CONTROLLER_SUBNETS, _.fromPairs(_.map(subnets.public, s => [s.availabilityZone, s.instanceCIDR])));
       add(AWS_CONTROLLER_SUBNET_IDS, {});
       add(AWS_WORKER_SUBNETS, _.fromPairs(_.map(subnets.private, s => [s.availabilityZone, s.instanceCIDR])));

--- a/installer/frontend/aws-actions.js
+++ b/installer/frontend/aws-actions.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import * as awsApis from './aws-api';
-import { awsActionTypes, configActions } from './actions';
+import { awsActions, configActions } from './actions';
 import {
   AWS_ACCESS_KEY_ID,
   AWS_CONTROLLER_SUBNET_IDS,
@@ -37,10 +37,7 @@ const createAction = (name, fn, shouldReject = false) => (body, creds, isNow) =>
     obj.error = null;
   }
 
-  dispatch({
-    type: awsActionTypes.SET,
-    payload: {[name]: obj},
-  });
+  dispatch(awsActions.set(name, obj));
 
   let platform;
   if (clusterConfig[PLATFORM_TYPE] === BARE_METAL_TF) {
@@ -51,16 +48,7 @@ const createAction = (name, fn, shouldReject = false) => (body, creds, isNow) =>
       if (isNow && !isNow()) {
         return;
       }
-      dispatch({
-        type: awsActionTypes.SET,
-        payload: {
-          [name]: {
-            inFly: false,
-            value,
-            error: null,
-          },
-        },
-      });
+      dispatch(awsActions.loaded(name, value));
       return value;
     })
     .catch(error => {
@@ -71,16 +59,8 @@ const createAction = (name, fn, shouldReject = false) => (body, creds, isNow) =>
 
       console.error(error.stack || error);
 
-      dispatch({
-        type: awsActionTypes.SET,
-        payload: {
-          [name]: {
-            inFly: false,
-            value: [],
-            error,
-          },
-        },
-      });
+      dispatch(awsActions.error(name, error));
+
       if (!shouldReject) {
         return error;
       }

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -96,7 +96,7 @@ const validateVPC = async (data, cc, updatedId, dispatch) => {
   }
 
   const inFlyPath = toInFly(AWS_VPC_FORM);
-  setIn(inFlyPath, true, dispatch);
+  dispatch(setIn(inFlyPath, true));
   let result;
   try {
     result = await dispatch(validateSubnets(network))
@@ -104,7 +104,7 @@ const validateVPC = async (data, cc, updatedId, dispatch) => {
   } catch (e) {
     result = e.message || e.toString();
   }
-  setIn(inFlyPath, false, dispatch);
+  dispatch(setIn(inFlyPath, false));
   return result;
 };
 
@@ -216,8 +216,8 @@ const stateToProps = ({aws, clusterConfig: cc}) => {
 };
 
 const dispatchToProps = dispatch => ({
-  clearControllerSubnets: () => setIn(AWS_CONTROLLER_SUBNET_IDS, {}, dispatch),
-  clearWorkerSubnets: () => setIn(AWS_WORKER_SUBNET_IDS, {}, dispatch),
+  clearControllerSubnets: () => dispatch(setIn(AWS_CONTROLLER_SUBNET_IDS, {})),
+  clearWorkerSubnets: () => dispatch(setIn(AWS_WORKER_SUBNET_IDS, {})),
   getVpcSubnets: vpcID => dispatch(getVpcSubnets({vpcID})),
 });
 

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -41,7 +41,7 @@ const dispatchToProps = dispatch => ({
       [BM_OS_TO_USE]: DEFAULT_CLUSTER_CONFIG[BM_OS_TO_USE],
       matchboxHTTP: value,
     };
-    configActions.set(payload, dispatch);
+    dispatch(configActions.set(payload));
   },
   getOsToUse: matchboxHTTP => {
     if (validate.hostPort(matchboxHTTP)) {
@@ -64,7 +64,7 @@ const dispatchToProps = dispatch => ({
         }
 
         const useVersion = available.map(v => v.version).sort(compareVersions).pop();
-        configActions.set({[BM_OS_TO_USE]: useVersion}, dispatch);
+        dispatch(configActions.set({[BM_OS_TO_USE]: useVersion}));
 
         return Promise.resolve(true);
       })

--- a/installer/frontend/components/bm-nodeforms.jsx
+++ b/installer/frontend/components/bm-nodeforms.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { connect } from 'react-redux';
 
-import { configActions, dirtyActions } from '../actions';
+import { dirtyActions, formActions } from '../actions';
 import { Alert } from './alert';
 import { MAX_MASTERS, MAX_WORKERS } from './nodes';
 import { validate } from '../validate';
@@ -16,13 +16,13 @@ import { Input, Connect, FieldRowList } from './ui';
 
 const BulkUpload = connect(null, dispatch => ({
   updateNodes: (fieldID, payload) => {
-    dispatch(configActions.updateField(fieldID, payload));
+    dispatch(formActions.updateField(fieldID, payload));
     _.each(payload, (row, i) => {
       _.each(row, (ignore, key) => {
         dispatch(dirtyActions.add(`${fieldID}.${i}.${key}`));
       });
     });
-    dispatch(configActions.updateField(fieldID, payload));
+    dispatch(formActions.updateField(fieldID, payload));
   },
 }))(
   class BulkUpload extends React.Component {

--- a/installer/frontend/components/ui.jsx
+++ b/installer/frontend/components/ui.jsx
@@ -10,7 +10,7 @@ import { readFile } from '../readfile';
 import { TectonicGA } from '../tectonic-ga';
 import { toError, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from '../utils';
 
-import { dirtyActions, configActions } from '../actions';
+import { dirtyActions, formActions } from '../actions';
 import { DESELECTED_FIELDS, PLATFORM_TYPE } from '../cluster-config.js';
 
 import { Alert } from './alert';
@@ -288,7 +288,7 @@ export const AsyncSelect = connect(
     extraData: _.get(cc, toExtraData(id)),
     inFly: _.get(cc, toInFly(id)) || _.get(cc, toExtraDataInFly(id)),
   }),
-  (dispatch, {id}) => ({refreshExtraData: () => dispatch(configActions.refreshExtraData(id))})
+  (dispatch, {id}) => ({refreshExtraData: () => dispatch(formActions.refreshExtraData(id))})
 )(props => {
   const value = props.value;
   const options = _.get(props, 'extraData.options', []);
@@ -326,7 +326,7 @@ const stateToProps = ({clusterConfig, dirty}, {field}) => ({
 
 const dispatchToProps = (dispatch, {field}) => ({
   makeDirty: () => dispatch(dirtyActions.add(field)),
-  updateField: v => dispatch(configActions.updateField(field, v)),
+  updateField: v => dispatch(formActions.updateField(field, v)),
 });
 
 class Connect_ extends React.Component {
@@ -392,7 +392,7 @@ const stateToIsDeselected = ({clusterConfig}, {field}) => {
 
 export const Deselect = connect(
   stateToIsDeselected,
-  {updateField: configActions.updateField}
+  {updateField: formActions.updateField}
 )(({field, isDeselected, label, updateField}) => <div>
   <span className="deselect">
     <CheckBox id={field} value={!isDeselected} onValue={v => updateField(field, !v)} />
@@ -440,7 +440,7 @@ export const FieldRowList = connect(
     globalError: _.get(clusterConfig, `${toError(id)}.global`),
     rowIndexes: _.keys(clusterConfig[id]),
   }),
-  {appendField: configActions.appendField, removeField: configActions.removeField}
+  {appendRow: formActions.appendFieldListRow, removeRow: formActions.removeFieldListRow}
 )(
   class FieldRowList_ extends React.Component {
     constructor (props) {
@@ -451,7 +451,7 @@ export const FieldRowList = connect(
     }
 
     render () {
-      const {appendField, globalError, id, placeholder, removeField, Row, rowFields, rowIndexes} = this.props;
+      const {appendRow, globalError, id, placeholder, removeRow, Row, rowFields, rowIndexes} = this.props;
 
       return <div>
         {_.map(rowIndexes, i => {
@@ -459,7 +459,7 @@ export const FieldRowList = connect(
           return <div className="row" key={i} style={{padding: '0 0 20px 0'}}>
             <Row autoFocus={this.state.autoFocus && i === _.last(rowIndexes)} placeholder={placeholder} row={row} />
             <div className="col-xs-1">
-              <i className="fa fa-minus-circle list-add-or-subtract pull-right" onClick={() => removeField(id, i)}></i>
+              <i className="fa fa-minus-circle list-add-or-subtract pull-right" onClick={() => removeRow(id, i)}></i>
             </div>
           </div>;
         })}
@@ -467,7 +467,7 @@ export const FieldRowList = connect(
           <div className="col-xs-3">
             <span className="wiz-link" id="addMore" onClick={() => {
               this.setState({autoFocus: true});
-              appendField(id);
+              appendRow(id);
             }}>
               <i className="fa fa-plus-circle list-add wiz-link"></i>&nbsp; Add More
             </span>

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -36,26 +36,26 @@ class Node {
     }
 
     const inFlyPath = toExtraDataInFly(this.id);
-    setIn(inFlyPath, true, dispatch);
+    dispatch(setIn(inFlyPath, true));
 
     return this.getExtraStuff_(dispatch, isNow, cc).then(data => {
       if (!isNow()) {
         return;
       }
-      batchSetIn(dispatch, [
+      dispatch(batchSetIn([
         [inFlyPath, undefined],
         [toExtraData(this.id), data],
         [toExtraDataError(this.id), undefined],
-      ]);
+      ]));
     }, e => {
       if (!isNow()) {
         return;
       }
-      batchSetIn(dispatch, [
+      dispatch(batchSetIn([
         [inFlyPath, undefined],
         [toExtraData(this.id), undefined],
         [toExtraDataError(this.id), e.message || e.toString()],
-      ]);
+      ]));
     });
   }
 
@@ -63,7 +63,7 @@ class Node {
     const cc = getState().clusterConfig;
     const error = await this.validator(this.getData(cc), cc, updatedId, dispatch);
     if (isNow()) {
-      await setIn(toError(this.id), _.isEmpty(error) ? undefined : error, dispatch);
+      await dispatch(setIn(toError(this.id), _.isEmpty(error) ? undefined : error));
     }
     return _.isEmpty(error);
   }
@@ -97,7 +97,7 @@ export class Field extends Node {
     const now = this.clock;
     const isNow = () => this.clock === now;
 
-    setIn([this.id, ...split], value, dispatch);
+    dispatch(setIn([this.id, ...split], value));
     const isFieldValid = await this.validate(dispatch, getState, this.id, isNow);
 
     if (!isFieldValid) {

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { connect } from 'react-redux';
 
-import { configActions, registerForm, validateFields } from './actions';
+import { configActions, FIELDS, FIELD_TO_DEPS, registerForm, validateFields } from './actions';
 import { toError, toExtraData, toInFly, toExtraDataInFly, toExtraDataError } from './utils';
 import { ErrorComponent } from './components/ui';
 import { TectonicGA } from './tectonic-ga';
@@ -24,7 +24,7 @@ class Node {
     this.getExtraStuff_ = opts.getExtraStuff;
   }
 
-  getExtraStuff (dispatch, getState, FIELDS, isNow = () => true) {
+  getExtraStuff (dispatch, getState, isNow = () => true) {
     if (!this.getExtraStuff_) {
       return Promise.resolve();
     }
@@ -90,7 +90,7 @@ export class Field extends Node {
     return cc[this.id];
   }
 
-  async update (dispatch, value, getState, FIELDS, FIELD_TO_DEPS, split) {
+  async update (dispatch, value, getState, split) {
     // Create an isNow() function that only returns true until this.update() is called again. This allows async
     // callbacks to confirm that we are still dealing with the same Field update event.
     this.clock = this.clock + 1;

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -215,33 +215,12 @@ const reducersTogether = combineReducers({
     }
 
     switch (action.type) {
-    case configActionTypes.DELETE_IN:
-      return fromJS(state).deleteIn(action.payload.path).toJS();
     case dirtyActionTypes.ADD: {
-      // {awsTags: [{key: true}]
-      const split = action.payload.split('.')
-        .map(s => {
-          const int = parseInt(s, 10);
-          return isNaN(int) ? s : int;
-        });
-      // mirror structure of clusterconfig for storing field dirtiness
-      const obj = _.cloneDeep(state);
-      let s = split[0];
-      let current = obj;
-      for (let i = 1; i < split.length; ++i) {
-        if (!_.has(current, s) || current[s] === null) {
-          current[s] = _.isInteger(split[i]) ? [] : {};
-        }
-        current = current[s];
-        s = split[i];
-      }
-      current[s] = true;
-      return obj;
+      const pathArray = _.isString(action.payload) ? action.payload.split('.') : action.payload;
+      return fromJS(state).setIn(pathArray, true).toJS();
     }
-    case dirtyActionTypes.CLEAN: {
-      const array = _.isString(action.payload) ? action.payload.split('.') : action.payload;
-      return fromJS(state).deleteIn(array).toJS();
-    }
+    case dirtyActionTypes.DELETE_IN:
+      return fromJS(state).deleteIn(action.payload).toJS();
     default:
       return state;
     }

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -136,9 +136,6 @@ const reducersTogether = combineReducers({
     case configActionTypes.SET_IN:
       return setIn(state, action.payload.path, action.payload.value);
 
-    case configActionTypes.MERGE:
-      return fromJS(state).mergeDeep(action.payload).toJS();
-
     case configActionTypes.APPEND: {
       const length = _.get(state, action.payload.path).length;
       const path = `${action.payload.path}.${length}`;

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -37,12 +37,6 @@ const DEFAULT_AWS = {
   destroy: UNLOADED_AWS_VALUE,
 };
 
-// setIn({...}, 'a.b.c', 'd')
-function setIn (object, path, value) {
-  const array = _.isString(path) ? path.split('.') : path;
-  return fromJS(object).setIn(array, value).toJS();
-}
-
 const reducersTogether = combineReducers({
 
   // State machine associated with server submissions
@@ -126,26 +120,13 @@ const reducersTogether = combineReducers({
       });
       return object.toJS();
     }
-
-    // Adds a value at a given path or no-op if a value already exists for the path
-    case configActionTypes.ADD_IN:
-      return _.isEmpty(_.get(state, action.payload.path))
-        ? setIn(state, action.payload.path, action.payload.value)
-        : state;
-
-    case configActionTypes.SET_IN:
-      return setIn(state, action.payload.path, action.payload.value);
-
-    case configActionTypes.APPEND: {
-      const length = _.get(state, action.payload.path).length;
-      const path = `${action.payload.path}.${length}`;
-      return setIn(state, path, action.payload.value);
+    case configActionTypes.SET_IN: {
+      const {path, value} = action.payload;
+      const pathArray = _.isString(path) ? path.split('.') : path;
+      return fromJS(state).setIn(pathArray, value).toJS();
     }
-
-    case configActionTypes.REMOVE_FIELD_LIST_ROW: {
-      const {fieldListId, index} = action.payload;
-      return fromJS(state).deleteIn([fieldListId, index]).toJS();
-    }
+    case configActionTypes.DELETE_IN:
+      return fromJS(state).deleteIn(action.payload).toJS();
     default:
       return state;
     }
@@ -234,10 +215,8 @@ const reducersTogether = combineReducers({
     }
 
     switch (action.type) {
-    case configActionTypes.REMOVE_FIELD_LIST_ROW: {
-      const {fieldListId, index} = action.payload;
-      return fromJS(state).deleteIn([fieldListId, index]).toJS();
-    }
+    case configActionTypes.DELETE_IN:
+      return fromJS(state).deleteIn(action.payload.path).toJS();
     case dirtyActionTypes.ADD: {
       // {awsTags: [{key: true}]
       const split = action.payload.split('.')

--- a/installer/frontend/server.js
+++ b/installer/frontend/server.js
@@ -74,8 +74,8 @@ let observeInterval;
 
 // An action creator that builds a server message, calls fetch on that message, fires the appropriate actions
 export const commitToServer = (dryRun = false, retry = false) => (dispatch, getState) => {
-  setIn(DRY_RUN, dryRun, dispatch);
-  setIn(RETRY, retry, dispatch);
+  dispatch(setIn(DRY_RUN, dryRun));
+  dispatch(setIn(RETRY, retry));
   dispatch(serverActions.requested);
 
   const state = getState();
@@ -113,8 +113,8 @@ export const loadFacts = (dispatch) => {
   return fetchJSON('/tectonic/facts', {retries: 5})
     .then(
       facts => {
-        addIn(TECTONIC_LICENSE, facts.license, dispatch);
-        addIn(PULL_SECRET, facts.pullSecret, dispatch);
+        dispatch(addIn(TECTONIC_LICENSE, facts.license));
+        dispatch(addIn(PULL_SECRET, facts.pullSecret));
         dispatch(loadFactsActions.loaded({
           awsRegions: _.map(facts.amis, 'name'),
           buildTime: facts.buildTime,


### PR DESCRIPTION
Benefits
- Makes action dispatch consistent (was a mix of action creators, action dispatching "helpers" and using the action types directly)
- Moves complexity from reducers (which should be kept simple) to action creators
- Reduces boilerplate

Remove `configActionTypes.APPEND` and `configActionTypes.ADD_IN` reducers (logic moved to action creators).

Convert `configActionTypes.REMOVE_FIELD_LIST_ROW` action to a more generic
`configActionTypes.DELETE_IN` action and convert `dirtyActionTypes.CLEAN` to `dirtyActionTypes.DELETE_IN` to match.

Greatly simplify the `dirtyActionTypes.ADD` reducer by using Immutable.js.

Separate form actions out into `formActions`.

Make `extraData`, `inFly` and `refreshExtraData()` only available to components that need them (currently just `AsyncSelect`).