### PR TITLE
frontend: Fix confusing Cluster Name validation error message

### DIFF
--- a/installer/frontend/fields.js
+++ b/installer/frontend/fields.js
@@ -18,8 +18,8 @@ FIELDS[CLUSTER_NAME] = new Field(CLUSTER_NAME, {
       if (s.toLowerCase() !== s) {
         return 'Value must be lower case.';
       }
-      if (!/^[a-zA-Z][-a-zA-Z0-9]*$/.test(s)) {
-        return 'Value must be a valid AWS Stack Name: [a-zA-Z][-a-zA-Z0-9]*';
+      if (!/^[a-z][-a-z0-9]*$/.test(s)) {
+        return 'Value must be a lower case AWS Stack Name: [a-z][-a-z0-9]*';
       }
       if (s.endsWith('-')) {
         return 'Value must not end with -';

--- a/installer/frontend/ui-tests/pages/clusterInfoPage.js
+++ b/installer/frontend/ui-tests/pages/clusterInfoPage.js
@@ -5,7 +5,7 @@ const clusterInfoPageCommands = {
   test (json, platform) {
     this.setField('@name', 'a%$#b');
     if (platform === 'aws-tf') {
-      this.expectValidationErrorContains('must be a valid AWS Stack Name');
+      this.expectValidationErrorContains('must be a lower case AWS Stack Name');
     }
     if (platform === 'bare-metal-tf') {
       this.expectValidationErrorContains('must be alphanumeric');


### PR DESCRIPTION
We don't allow lower case characters in the name, so change the validation error message to indicate that.

Before this change, the name `1a` would result in the error `Value must be a valid AWS Stack Name: [a-zA-Z][-a-zA-Z0-9]*`, which was confusing because we don't actually allow upper case characters.