### PR TITLE
platforms/metal: add fail and retry flags to curl

### DIFF
--- a/platforms/metal/cl/coreos-install.yaml.tmpl
+++ b/platforms/metal/cl/coreos-install.yaml.tmpl
@@ -20,7 +20,7 @@ storage:
       contents:
         inline: |
           #!/bin/bash -ex
-          curl "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
+          curl -f --retry 5 "{{.ignition_endpoint}}?{{.request.raw_query}}&os=installed" -o ignition.json
           coreos-install -d /dev/sda -C {{.coreos_channel}} -V {{.coreos_version}} -i ignition.json {{if index . "baseurl"}}-b {{.baseurl}}{{end}}
           udevadm settle
           systemctl reboot


### PR DESCRIPTION
This adds additional flags to curl, so that it can tolerate transient
network failures but hard-fail on permanent errors too.
This way we block a node earlier while still in a debuggable environment,
instead of rebooting into an initramfs emergency console.
