### PR TITLE
frontend: Remove some uses of DEFAULT_CLUSTER_CONFIG

### DIFF
--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -108,9 +108,6 @@ export const configActions = {
 export const __deleteEverything__ = () => {
   [FIELDS, FIELD_TO_DEPS, FORMS, DEFAULT_CLUSTER_CONFIG]
     .forEach(o => _.keys(o).forEach(k => delete o[k]));
-
-  ['error', 'inFly', 'extra'].forEach(k => DEFAULT_CLUSTER_CONFIG[k] = {});
-
   return {type: configActionTypes.RESET};
 };
 

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -106,8 +106,7 @@ export const configActions = {
 };
 
 export const __deleteEverything__ = () => {
-  [FIELDS, FIELD_TO_DEPS, FORMS, DEFAULT_CLUSTER_CONFIG]
-    .forEach(o => _.keys(o).forEach(k => delete o[k]));
+  [FIELDS, FIELD_TO_DEPS, FORMS].forEach(o => _.keys(o).forEach(k => delete o[k]));
   return {type: configActionTypes.RESET};
 };
 
@@ -157,7 +156,7 @@ export const registerForm = (form, fields) => {
     if (!fieldName) {
       throw new Error(`form ${formName}: field has no name!`);
     }
-    if (DEFAULT_CLUSTER_CONFIG[fieldName]) {
+    if (FIELDS[fieldName]) {
       throw new Error(`form ${formName}: field ${fieldName} already exists`);
     }
 

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -124,8 +124,6 @@ export const getTectonicDomain = (cc) => {
 export const DEFAULT_CLUSTER_CONFIG = {
   [BM_MATCHBOX_HTTP]: '',
   [BM_OS_TO_USE]: '',
-  [DRY_RUN]: false,
-  [RETRY]: false, // whether we're retrying a terraform apply
 };
 
 export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
@@ -141,11 +139,11 @@ export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
   });
 
   const ret = {
-    dryRun: cc[DRY_RUN],
+    dryRun: !!cc[DRY_RUN],
     platform: 'aws',
     license: cc[TECTONIC_LICENSE],
     pullSecret: cc[PULL_SECRET],
-    retry: cc[RETRY],
+    retry: !!cc[RETRY],
     credentials: {
       AWSAccessKeyID: cc[AWS_ACCESS_KEY_ID],
       AWSSecretAccessKey: cc[AWS_SECRET_ACCESS_KEY],
@@ -227,11 +225,11 @@ export const toBaremetal_TF = ({clusterConfig: cc}, FORMS) => {
   const workers = cc[BM_WORKERS];
 
   const ret = {
-    dryRun: cc[DRY_RUN],
+    dryRun: !!cc[DRY_RUN],
     platform: 'metal',
     license: cc[TECTONIC_LICENSE],
     pullSecret: cc[PULL_SECRET],
-    retry: cc[RETRY],
+    retry: !!cc[RETRY],
     variables: {
       tectonic_admin_password: cc[ADMIN_PASSWORD],
       tectonic_cluster_name: cc[CLUSTER_NAME],

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -122,9 +122,6 @@ export const getTectonicDomain = (cc) => {
 };
 
 export const DEFAULT_CLUSTER_CONFIG = {
-  error: {}, // to store validation errors
-  inFly: {}, // to store inFly
-  extra: {}, // extraneous, non-value data for this field
   [BM_MATCHBOX_HTTP]: '',
   [BM_OS_TO_USE]: '',
   [DRY_RUN]: false,


### PR DESCRIPTION
Steps towards the ultimate goal of removing `DEFAULT_CLUSTER_CONFIG`.

`__deleteEverything__()` is only used by the unit tests.