### PR TITLE
*: bump monitoring stack to 1.9.5

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -95,7 +95,7 @@ variable "tectonic_container_images" {
     stats_extender               = "quay.io/coreos/tectonic-stats-extender:487b3da4e175da96dabfb44fba65cdb8b823db2e"
     tectonic_channel_operator    = "quay.io/coreos/tectonic-channel-operator:0.6.2"
     tectonic_etcd_operator       = "quay.io/coreos/tectonic-etcd-operator:v0.0.2"
-    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.4"
+    tectonic_prometheus_operator = "quay.io/coreos/tectonic-prometheus-operator:v1.9.5"
     tectonic_cluo_operator       = "quay.io/coreos/tectonic-cluo-operator:v0.3.1"
     tectonic_torcx               = "quay.io/coreos/tectonic-torcx:v0.2.0"
     tectonic_alm_operator        = "quay.io/coreos/tectonic-alm-operator:v0.3.0"
@@ -129,7 +129,7 @@ variable "tectonic_versions" {
   default = {
     etcd          = "3.1.8"
     kubernetes    = "1.8.7+tectonic.2"
-    monitoring    = "1.9.4"
+    monitoring    = "1.9.5"
     tectonic      = "1.8.7-tectonic.2"
     tectonic-etcd = "0.0.1"
     cluo          = "0.3.1"


### PR DESCRIPTION
This fixes TECREL-188

@pst @ant31 @fabxc 

/cc @sym3tri @cpanato @mxinden @sudhaponnaganti 

Note this is a preview, https://github.com/coreos-inc/tectonic-prometheus-operator/pull/173 still has to be merged first and the release has to be finished.