### PR TITLE
frontend: Remove field default check in configActionTypes.SET reducer

### DIFF
--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -104,13 +104,7 @@ const reducersTogether = combineReducers({
     case configActionTypes.RESET:
       return {};
     case configActionTypes.SET:
-      Object.keys(action.payload).forEach(k => {
-        if (!DEFAULT_CLUSTER_CONFIG.hasOwnProperty(k)) {
-          throw Error(`attempt to set cluster property ${k} missing from defaults`);
-        }
-      });
       return Object.assign({}, state, action.payload);
-
     case configActionTypes.BATCH_SET_IN: {
       let object = fromJS(state);
       action.payload.forEach(batch => {


### PR DESCRIPTION
This reducer is not supposed to be specifically for fields, so should not enforce this check. Also, we do an equivalent check in `formActions.updateField()`, which should be sufficient.