### PR TITLE
frontend: Change DEFAULT_CLUSTER_CONFIG  to FIELD_DEFAULTS and make Field's default optional

### DIFF
--- a/installer/frontend/__tests__/fields.js
+++ b/installer/frontend/__tests__/fields.js
@@ -4,10 +4,12 @@
 console.debug = console.debug || console.info;
 
 import _ from 'lodash';
-import { __deleteEverything__, configActions, FIELD_DEFAULTS, formActions } from '../actions';
+import { configActions, FIELDS, FIELD_DEFAULTS, FIELD_TO_DEPS, FORMS, formActions } from '../actions';
 import { Field, Form } from '../form';
 import { store } from '../store';
 import { toError, toExtraData, toExtraDataError, toExtraDataInFly } from '../utils';
+
+const {dispatch} = store;
 
 const invalid = 'is invalid';
 const fieldName = 'aField';
@@ -19,11 +21,12 @@ const expectCC = (path, expected, f) => {
   expect(value).toEqual(expected);
 };
 
-const resetCC = () => store.dispatch(configActions.set(FIELD_DEFAULTS));
+const updateField = (field, value) => dispatch(formActions.updateField(field, value));
 
-const updateField = (field, value) => store.dispatch(formActions.updateField(field, value));
-
-beforeEach(() => store.dispatch(__deleteEverything__()));
+beforeEach(() => {
+  [FIELDS, FIELD_DEFAULTS, FIELD_TO_DEPS, FORMS].forEach(o => _.each(o, (v, k) => delete o[k]));
+  dispatch(configActions.reset());
+});
 
 test('updates a Field', () => {
   expect.assertions(4);
@@ -38,7 +41,7 @@ test('updates a Field', () => {
   });
 
   new Form('aForm', [aField]);
-  resetCC();
+  dispatch(configActions.set(FIELD_DEFAULTS));
 
   expectCC(name, 'a');
   updateField(name, 'b');
@@ -233,7 +236,7 @@ test('deep dependency chains', async done => {
   });
 
   new Form('aForm', [field1, field2, field3]);
-  resetCC();
+  dispatch(configActions.set(FIELD_DEFAULTS));
 
   expectCC(fieldName, '1');
   await updateField(fieldName, 'new value');

--- a/installer/frontend/__tests__/fields.js
+++ b/installer/frontend/__tests__/fields.js
@@ -4,10 +4,9 @@
 console.debug = console.debug || console.info;
 
 import _ from 'lodash';
-import { __deleteEverything__, configActions, formActions } from '../actions';
+import { __deleteEverything__, configActions, FIELD_DEFAULTS, formActions } from '../actions';
 import { Field, Form } from '../form';
 import { store } from '../store';
-import { DEFAULT_CLUSTER_CONFIG } from '../cluster-config';
 import { toError, toExtraData, toExtraDataError, toExtraDataInFly } from '../utils';
 
 const invalid = 'is invalid';
@@ -20,7 +19,7 @@ const expectCC = (path, expected, f) => {
   expect(value).toEqual(expected);
 };
 
-const resetCC = () => store.dispatch(configActions.set(DEFAULT_CLUSTER_CONFIG));
+const resetCC = () => store.dispatch(configActions.set(FIELD_DEFAULTS));
 
 const updateField = (field, value) => store.dispatch(formActions.updateField(field, value));
 

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -182,7 +182,9 @@ export const registerForm = (form, fields) => {
       throw new Error(`form ${formName}: field ${fieldName} already exists`);
     }
 
-    FIELD_DEFAULTS[fieldName] = f.default;
+    if (!_.isNil(f.default)) {
+      FIELD_DEFAULTS[fieldName] = f.default;
+    }
     FIELDS[fieldName] = f;
 
     _.each(f.dependencies, d => addDep(f.id, d));

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -1,7 +1,5 @@
 import _ from 'lodash';
 
-import { DEFAULT_CLUSTER_CONFIG } from './cluster-config';
-
 export const awsActionTypes = {
   SET: 'AWS_SET',
 };
@@ -96,6 +94,7 @@ export const commitPhases = {
 };
 
 export const FIELDS = {};
+export const FIELD_DEFAULTS = {};
 export const FIELD_TO_DEPS = {};
 export const FORMS = {};
 
@@ -187,7 +186,7 @@ export const registerForm = (form, fields) => {
       throw new Error(`form ${formName}: field ${fieldName} already exists`);
     }
 
-    DEFAULT_CLUSTER_CONFIG[fieldName] = f.default;
+    FIELD_DEFAULTS[fieldName] = f.default;
     FIELDS[fieldName] = f;
 
     _.each(f.dependencies, d => addDep(f.id, d));

--- a/installer/frontend/actions.js
+++ b/installer/frontend/actions.js
@@ -24,6 +24,7 @@ export const configActions = {
     }
   },
   batchSetIn: payload => ({payload, type: configActionTypes.BATCH_SET_IN}),
+  reset: () => ({type: configActionTypes.RESET}),
   set: payload => ({payload, type: configActionTypes.SET}),
   setIn: (path, value) => ({payload: {path, value}, type: configActionTypes.SET_IN}),
 };
@@ -129,11 +130,6 @@ export const formActions = {
     const field = getField(name);
     return field.update(dispatch, inputValue, getState, split);
   },
-};
-
-export const __deleteEverything__ = () => {
-  [FIELDS, FIELD_TO_DEPS, FORMS].forEach(o => _.keys(o).forEach(k => delete o[k]));
-  return {type: configActionTypes.RESET};
 };
 
 export const validateFields = async (ids, getState, dispatch, updatedId, isNow) => {

--- a/installer/frontend/cluster-config.js
+++ b/installer/frontend/cluster-config.js
@@ -121,8 +121,6 @@ export const getTectonicDomain = (cc) => {
   return cc[CLUSTER_SUBDOMAIN] + (cc[CLUSTER_SUBDOMAIN].endsWith('.') ? '' : '.') + getAwsZoneDomain(cc);
 };
 
-export const DEFAULT_CLUSTER_CONFIG = {};
-
 export const toAWS_TF = ({clusterConfig: cc, dirty}, FORMS) => {
   const controllers = FORMS[AWS_CONTROLLERS].getData(cc);
   const etcds = FORMS[AWS_ETCDS].getData(cc);

--- a/installer/frontend/components/aws-cloud-credentials.jsx
+++ b/installer/frontend/components/aws-cloud-credentials.jsx
@@ -23,7 +23,6 @@ import {
 const awsCredsForm = new Form(AWS_CREDS, [
   new Field(STS_ENABLED, {default: false}),
   new Field(AWS_ACCESS_KEY_ID, {
-    default: '',
     validator: compose(validate.nonEmpty, (v) => {
       if (v.indexOf('@') >= 0) {
         return 'AWS access key IDs are not email addresses.';
@@ -37,7 +36,6 @@ const awsCredsForm = new Form(AWS_CREDS, [
     }),
   }),
   new Field(AWS_SECRET_ACCESS_KEY, {
-    default: '',
     validator: compose(validate.nonEmpty, (v) => {
       if (v.length < 40) {
         return 'AWS secrets are at least 40 characters.';
@@ -48,7 +46,6 @@ const awsCredsForm = new Form(AWS_CREDS, [
     }),
   }),
   new Field(AWS_SESSION_TOKEN, {
-    default: '',
     validator: validate.nonEmpty,
     dependencies: [STS_ENABLED],
     ignoreWhen: cc => !cc[STS_ENABLED],
@@ -58,7 +55,6 @@ const awsCredsForm = new Form(AWS_CREDS, [
 const selectRegionForm = new Form(AWS_REGION_FORM, [
   awsCredsForm,
   new Field(AWS_REGION, {
-    default: '',
     validator: validate.nonEmpty,
     dependencies: [AWS_CREDS],
     getExtraStuff: (dispatch, isNow) => dispatch(getRegions(isNow)),

--- a/installer/frontend/components/aws-submit-keys.jsx
+++ b/installer/frontend/components/aws-submit-keys.jsx
@@ -11,7 +11,6 @@ import { AWS_SSH, AWS_REGION_FORM, AWS_REGION } from '../cluster-config';
 
 const awsSshForm = new Form('AWSSSHForm', [
   new Field(AWS_SSH, {
-    default: '',
     validator: validate.nonEmpty,
     dependencies: [AWS_REGION_FORM],
     getExtraStuff: (dispatch, isNow) => dispatch(awsActions.getSsh(null, null, isNow)).then(options => ({options: _.sortBy(options, 'label')})),

--- a/installer/frontend/components/aws-tags.jsx
+++ b/installer/frontend/components/aws-tags.jsx
@@ -54,14 +54,8 @@ const validators = {
 };
 
 const rowFields = {
-  key: {
-    default: '',
-    validator: validators.AWSTagKey,
-  },
-  value: {
-    default: '',
-    validator: validators.AWSTagValue,
-  },
+  key: {validator: validators.AWSTagKey},
+  value: {validator: validators.AWSTagValue},
 };
 
 const tagsFields = new FieldList(AWS_TAGS, rowFields, {

--- a/installer/frontend/components/aws-vpc.jsx
+++ b/installer/frontend/components/aws-vpc.jsx
@@ -124,7 +124,6 @@ const vpcInfoForm = new Form(AWS_VPC_FORM, [
   }),
   new Field(AWS_CREATE_VPC, {default: VPC_CREATE}),
   new Field(AWS_HOSTED_ZONE_ID, {
-    default: '',
     dependencies: [AWS_REGION_FORM],
     validator: (value, cc) => {
       const empty = validate.nonEmpty(value);
@@ -159,7 +158,6 @@ const vpcInfoForm = new Form(AWS_VPC_FORM, [
   new Field(AWS_SPLIT_DNS, {default: SPLIT_DNS_ON}),
   new Field(AWS_VPC_CIDR, {default: DEFAULT_AWS_VPC_CIDR, validator: validate.AWSsubnetCIDR}),
   new Field(AWS_VPC_ID, {
-    default: '',
     dependencies: [AWS_REGION_FORM],
     getExtraStuff: (dispatch, isNow) => dispatch(getVpcs(null, null, isNow)).then(vpcs => ({options: toOptions(vpcs)})),
     ignoreWhen: cc => cc[AWS_CREATE_VPC] === VPC_CREATE,
@@ -167,7 +165,7 @@ const vpcInfoForm = new Form(AWS_VPC_FORM, [
   }),
   new Field(AWS_WORKER_SUBNETS, {default: {}}),
   new Field(AWS_WORKER_SUBNET_IDS, {default: {}}),
-  new Field(CLUSTER_SUBDOMAIN, {default: '', validator: compose(validate.nonEmpty, validate.domainName)}),
+  new Field(CLUSTER_SUBDOMAIN, {validator: compose(validate.nonEmpty, validate.domainName)}),
   new Field(DESELECTED_FIELDS, {default: {}}),
 ], {
   dependencies: [POD_CIDR, SERVICE_CIDR],

--- a/installer/frontend/components/bm-credentials.jsx
+++ b/installer/frontend/components/bm-credentials.jsx
@@ -9,9 +9,9 @@ import { validate } from '../validate';
 import { CertArea, Connect, PrivateKeyArea } from './ui';
 
 const form = new Form('BM_MATCHBOX_CREDENTIALS', [
-  new Field(BM_MATCHBOX_CA, {default: '', validator: validate.certificate}),
-  new Field(BM_MATCHBOX_CLIENT_CERT, {default: '', validator: validate.certificate}),
-  new Field(BM_MATCHBOX_CLIENT_KEY, {default: '', validator: validate.privateKey}),
+  new Field(BM_MATCHBOX_CA, {validator: validate.certificate}),
+  new Field(BM_MATCHBOX_CLIENT_CERT, {validator: validate.certificate}),
+  new Field(BM_MATCHBOX_CLIENT_KEY, {validator: validate.privateKey}),
 ]);
 
 export const BM_Credentials = () => <div>

--- a/installer/frontend/components/bm-hostname.jsx
+++ b/installer/frontend/components/bm-hostname.jsx
@@ -9,8 +9,8 @@ import { CONTROLLER_DOMAIN, BM_TECTONIC_DOMAIN } from '../cluster-config';
 const validator = compose(validate.nonEmpty, validate.domainName);
 
 const hostNamesForm = new Form('BM_Hostname', [
-  new Field(CONTROLLER_DOMAIN, { validator, default: '' }),
-  new Field(BM_TECTONIC_DOMAIN, { validator, default: '' }),
+  new Field(CONTROLLER_DOMAIN, {validator}),
+  new Field(BM_TECTONIC_DOMAIN, {validator}),
 ]);
 
 export const BM_Hostname = () =>

--- a/installer/frontend/components/bm-matchbox.jsx
+++ b/installer/frontend/components/bm-matchbox.jsx
@@ -12,7 +12,7 @@ import { Connect, DocsA, Input } from './ui';
 import { BM_MATCHBOX_HTTP, BM_MATCHBOX_RPC, BM_OS_TO_USE } from '../cluster-config';
 
 new Form('BM_MATCHBOX_ADDRESS', [
-  new Field(BM_MATCHBOX_RPC, {default: '', validator: validate.hostPort}),
+  new Field(BM_MATCHBOX_RPC, {validator: validate.hostPort}),
 ]);
 
 const COREOS_VERSIONS_ERROR_NAME = 'COREOS_VERSIONS_ERROR_NAME';

--- a/installer/frontend/components/bm-nodeforms.jsx
+++ b/installer/frontend/components/bm-nodeforms.jsx
@@ -174,14 +174,8 @@ const BulkUpload = connect(null, dispatch => ({
 );
 
 const rowFields = {
-  mac: {
-    default: '',
-    validator: validate.MAC,
-  },
-  host: {
-    default: '',
-    validator: validate.host,
-  },
+  mac: {validator: validate.MAC},
+  host: {validator: validate.host},
 };
 
 const makeFieldList = (id, name, maxNodes) => new FieldList(id, rowFields, {

--- a/installer/frontend/components/bm-sshkeys.jsx
+++ b/installer/frontend/components/bm-sshkeys.jsx
@@ -15,10 +15,7 @@ you@example.com
 `;
 
 const sshKeyForm = new Form(BM_SSH_KEY, [
-  new Field(SSH_AUTHORIZED_KEY, {
-    default: '',
-    validator: validate.SSHKey,
-  }),
+  new Field(SSH_AUTHORIZED_KEY, {validator: validate.SSHKey}),
 ]);
 
 export const BM_SSHKeys = () => <div>

--- a/installer/frontend/components/certificate-authority.jsx
+++ b/installer/frontend/components/certificate-authority.jsx
@@ -9,11 +9,9 @@ import { CertArea, Connect, PrivateKeyArea, Radio } from './ui';
 const form = new Form('CERTIFICATE_AUTHORITY', [
   new Field(CA_TYPE, {default: CA_TYPES.SELF_SIGNED}),
   new Field(CA_CERTIFICATE, {
-    default: '',
     ignoreWhen: cc => cc[CA_TYPE] !== CA_TYPES.OWNED,
   }),
   new Field(CA_PRIVATE_KEY, {
-    default: '',
     ignoreWhen: cc => cc[CA_TYPE] !== CA_TYPES.OWNED,
   }),
 ], {

--- a/installer/frontend/components/cluster-info.jsx
+++ b/installer/frontend/components/cluster-info.jsx
@@ -13,7 +13,6 @@ import { A, Connect, FileInput, Input } from './ui';
 const accountLink = <A href="https://account.coreos.com" rel="noopener">account.coreos.com</A>;
 
 const licenseField = new Field(TECTONIC_LICENSE, {
-  default: '',
   validator: token => {
     const err = validate.nonEmpty(token);
     if (err) {
@@ -32,8 +31,6 @@ const licenseField = new Field(TECTONIC_LICENSE, {
 });
 
 const pullSecretField = new Field(PULL_SECRET, {
-  default: '',
-  // eslint-disable-next-line react/display-name
   validator: secret => {
     const err = validate.nonEmpty(secret);
     if (err) {

--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -176,7 +176,6 @@ const etcdForm = new Form('etcdForm', [
   new Field(ETCD_OPTION, {default: ETCD_OPTIONS.PROVISIONED}),
   etcdNodeForm,
   new Field(EXTERNAL_ETCD_CLIENT, {
-    default: '',
     validator: compose(validate.nonEmpty, validate.host),
     dependencies: [ETCD_OPTION],
     ignoreWhen: cc => cc[ETCD_OPTION] !== ETCD_OPTIONS.EXTERNAL,

--- a/installer/frontend/components/users.jsx
+++ b/installer/frontend/components/users.jsx
@@ -6,9 +6,9 @@ import { Field, Form } from '../form';
 import { Input, Password, Connect } from './ui';
 
 const credsForm = new Form(CREDS, [
-  new Field(ADMIN_EMAIL, {default: '', validator: validate.email}),
-  new Field(ADMIN_PASSWORD, {default: '', validator: validate.nonEmpty}),
-  new Field(ADMIN_PASSWORD2, {default: '', validator: validate.nonEmpty}),
+  new Field(ADMIN_EMAIL, {validator: validate.email}),
+  new Field(ADMIN_PASSWORD, {validator: validate.nonEmpty}),
+  new Field(ADMIN_PASSWORD2, {validator: validate.nonEmpty}),
 ], {
   validator: (data, cc) => {
     if (cc[ADMIN_PASSWORD] && cc[ADMIN_PASSWORD2] && cc[ADMIN_PASSWORD] !== cc[ADMIN_PASSWORD2]) {

--- a/installer/frontend/fields.js
+++ b/installer/frontend/fields.js
@@ -6,7 +6,6 @@ const FIELDS = {};
 export default FIELDS;
 
 FIELDS[CLUSTER_NAME] = new Field(CLUSTER_NAME, {
-  default: '',
   validator: (s = '', CC) => {
     switch (CC[PLATFORM_TYPE]) {
     case AWS_TF:

--- a/installer/frontend/form.js
+++ b/installer/frontend/form.js
@@ -80,9 +80,6 @@ class Node {
 export class Field extends Node {
   constructor (id, opts = {}) {
     super(id, opts);
-    if (!_.has(opts, 'default')) {
-      throw new Error(`${id} needs a default`);
-    }
     this.default = opts.default;
   }
 

--- a/installer/frontend/reducer.js
+++ b/installer/frontend/reducer.js
@@ -2,18 +2,17 @@ import _ from 'lodash';
 import { combineReducers } from 'redux';
 import { fromJS } from 'immutable';
 
-import { DEFAULT_CLUSTER_CONFIG } from './cluster-config';
-
 import {
+  FIELD_DEFAULTS,
   awsActionTypes,
   clusterReadyActionTypes,
+  commitPhases,
   configActionTypes,
   dirtyActionTypes,
   eventErrorsActionTypes,
   loadFactsActionTypes,
   restoreActionTypes,
   serverActionTypes,
-  commitPhases,
 } from './actions';
 
 const UNLOADED_AWS_VALUE = {
@@ -97,7 +96,7 @@ const reducersTogether = combineReducers({
   // The user's intentions for their cluster
   clusterConfig: (state, action) => {
     if (!state) {
-      return DEFAULT_CLUSTER_CONFIG;
+      return FIELD_DEFAULTS;
     }
 
     switch (action.type) {
@@ -232,7 +231,7 @@ export const reducer = (state, action) => {
     });
     restored.aws = _.defaults(restored.aws, DEFAULT_AWS);
     if (restored.clusterConfig) {
-      restored.clusterConfig = _.defaults(restored.clusterConfig, DEFAULT_CLUSTER_CONFIG);
+      restored.clusterConfig = _.defaults(restored.clusterConfig, FIELD_DEFAULTS);
     }
     break;
   default:


### PR DESCRIPTION
Rename `DEFAULT_CLUSTER_CONFIG` to `FIELD_DEFAULTS`, which is now only used for storing `default` values passed to `new Field`.

Make `default` optional for `Field`.

Remove `__deleteEverything__` action and move that logic to the unit tests because it is specifically for the unit tests.