### PR TITLE
frontend: Remove Etcd radio "required" validator

### DIFF
--- a/installer/frontend/components/nodes.jsx
+++ b/installer/frontend/components/nodes.jsx
@@ -181,14 +181,7 @@ const etcdForm = new Form('etcdForm', [
     dependencies: [ETCD_OPTION],
     ignoreWhen: cc => cc[ETCD_OPTION] !== ETCD_OPTIONS.EXTERNAL,
   }),
-], {
-  validator: value => {
-    const etcd = value[ETCD_OPTION];
-    if (!_.values(ETCD_OPTIONS).includes(etcd)) {
-      return 'Please select an option.';
-    }
-  },
-});
+]);
 
 const mastersForm = makeNodeForm(AWS_CONTROLLERS, validate.int({min: 1, max: MAX_MASTERS}));
 const workersForm = makeNodeForm(AWS_WORKERS, validate.int({min: 1, max: MAX_WORKERS}));


### PR DESCRIPTION
This is a radio input with a default value, so the validator is redundant. We don't use validators like this for our other radio inputs.