### PR TITLE
modules/container_linux: avoid shell

### DIFF
--- a/modules/container_linux/main.tf
+++ b/modules/container_linux/main.tf
@@ -1,3 +1,4 @@
 data "external" "version" {
+  count   = "${var.release_version == "latest" ? 1 : 0}"
   program = ["sh", "-c", "curl https://${var.release_channel}.release.core-os.net/amd64-usr/current/version.txt | sed -n 's/COREOS_VERSION=\\(.*\\)$/{\"version\": \"\\1\"}/p'"]
 }

--- a/modules/container_linux/outputs.tf
+++ b/modules/container_linux/outputs.tf
@@ -1,3 +1,13 @@
+locals {
+  // Create a map that matches the structure of the output of the external data source
+  // so we can avoid running the shell script and still parse the output consistently.
+  // Here, we jsonencode because ternaries can only operate on flat data types and
+  // Terraform `merge` and `element` do not play nicely with maps.
+  json = "${var.release_version == "latest" ? jsonencode(data.external.version.*.result) : jsonencode(map("version", var.release_version))}"
+}
+
 output "version" {
-  value = "${var.release_version == "latest" ? data.external.version.result["version"] : var.release_version}"
+  // Parse out the version from the well-known JSON of format:
+  // {"version":"<version>"}
+  value = "${replace(local.json, "/.*\"version\":\"(.*)\".*/", "$1")}"
 }


### PR DESCRIPTION
Due to the way Terraform ternary expressions are evaluated, even if you
specify a Container Linux version to install, Terraform will invoke the
container_linux module external data source and try to run `curl` and
make an HTTP request. If the host is offline or does not have `curl`
installed, then this module will fail. This commit enables this module
to be circumvented by explicitly defining the Container Linux version to
install. Furthermore, this enables non-unix hosts to use the module.

Due to Terraform's limited support for maps, there is no way to interpolate
a list of maps using `join`, `element`, `merge`, etc. This approach serializes
the maps and extracts the version using the known format of the map.

cc @mxinden @enxebre 