### PR TITLE
Add tectonic tarball instead of repo to tectonic installer docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -367,6 +367,7 @@ pipeline {
           withCredentials(quayCreds) {
             ansiColor('xterm') {
               unstash 'clean-repo'
+              unstash 'tectonic.tar.gz'
               sh """
                 docker build -t quay.io/coreos/tectonic-installer:master -f images/tectonic-installer/Dockerfile .
                 docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io

--- a/images/tectonic-installer/Dockerfile
+++ b/images/tectonic-installer/Dockerfile
@@ -1,14 +1,7 @@
-FROM golang:1.9.2-stretch
+FROM alpine:3.7
 
-ENV TERRAFORM_VERSION="0.11.1"
-
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y -q \
-    unzip
-
-# Install Terraform
-RUN curl https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
-
-ENV PROJECT_DIR /go/src/github.com/coreos/tectonic-installer
-
-ADD . $PROJECT_DIR/
+# Docker build does not follow symlinks (see
+# https://github.com/moby/moby/issues/1676) Make sure to first copy the tarball
+# from bazel-bin/tectonic.tar.gz to the docker build context folder of your
+# choice (e.g. the root of the repository).
+ADD tectonic.tar.gz /


### PR DESCRIPTION
Previously the quay.io/coreos/tectonic-installer:master image contained
the entire Tectonic installer repository. Instead with this patch, only
the Tectonic tarball build by Bazel is added to the image on /tectonic.

This commit got lost somehow and was already proposed and merged in https://github.com/coreos/tectonic-installer/pull/3028.