### PR TITLE
tests: Adjust log archive step to new cli folder structure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -473,7 +473,7 @@ def runRSpecTest(testFilePath, dockerArgs, credentials) {
       } finally {
         reportStatusToGithub((err == null) ? 'success' : 'failure', testFilePath, originalCommitId)
         step([$class: "TapPublisher", testResults: "templogfiles/*", outputTapToConsole: true, planRequired: false])
-        archiveArtifacts allowEmptyArchive: true, artifacts: 'bazel-bin/tectonic/build/**/logs/**'
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'bazel-bin/tectonic/**/logs/**'
         withDockerContainer(params.builder_image) {
          withCredentials(credsUI) {
           script {
@@ -524,7 +524,7 @@ def runRSpecTestBareMetal(testFilePath, credentials) {
       } finally {
         reportStatusToGithub((err == null) ? 'success' : 'failure', testFilePath, originalCommitId)
         step([$class: "TapPublisher", testResults: "../../templogfiles/*", outputTapToConsole: true, planRequired: false])
-        archiveArtifacts allowEmptyArchive: true, artifacts: 'bazel-bin/tectonic/build/**/logs/**'
+        archiveArtifacts allowEmptyArchive: true, artifacts: 'bazel-bin/tectonic/**/logs/**'
         withCredentials(credsUI) {
           script {
             try {


### PR DESCRIPTION
With the new Tectonic cli flow, the cluster `build` folder does not
exist anymore. Instead the cli creates a folder on the top level with
the name of the cluster, containing all relevant files.

For now we need to support both flows. For AWS the Tectonic CLI is used.
For Azure and all other platforms we still use plain terraform.