### PR TITLE
tests: Trim all Jenkins string parameters in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,12 +89,14 @@ pipeline {
     string(
       name: 'builder_image',
       defaultValue: defaultBuilderImage,
-      description: 'tectonic-builder docker image to use for builds'
+      description: 'tectonic-builder docker image to use for builds',
+      trim: true,
     )
     string(
       name: 'hyperkube_image',
       defaultValue: '',
-      description: 'Hyperkube image. Please define the param like: {hyperkube="<HYPERKUBE_IMAGE>"}'
+      description: 'Hyperkube image. Please define the param like: {hyperkube="<HYPERKUBE_IMAGE>"}',
+      trim: true,
     )
     booleanParam(
       name: 'RUN_CONFORMANCE_TESTS',
@@ -114,7 +116,8 @@ pipeline {
     string(
       name: 'COMPONENT_TEST_IMAGES',
       defaultValue: '',
-      description: 'List of container images for component tests to run (comma-separated)'
+      description: 'List of container images for component tests to run (comma-separated)',
+      trim: true,
     )
     booleanParam(
       name: 'PLATFORM/AWS',
@@ -151,12 +154,14 @@ pipeline {
     string(
       name: 'SLACK_CHANNEL',
       defaultValue: '#team-installer',
-      description: 'Slack channel to notify on failure.'
+      description: 'Slack channel to notify on failure.',
+      trim: true,
     )
     string(
       name : 'GITHUB_REPO',
       defaultValue: 'coreos/tectonic-installer',
-      description: 'Github repository'
+      description: 'Github repository',
+      trim: true,
     )
   }
 


### PR DESCRIPTION
Once we run update to a Jenkins version with https://github.com/jenkinsci/jenkins/pull/3106 we can use the trim option in all our string Jenkins parameters.