### PR TITLE
Retrieve Jenkins console logs without verifying SSL cert

### DIFF
--- a/tests/jenkins-jobs/scripts/log-analyzer-copy.sh
+++ b/tests/jenkins-jobs/scripts/log-analyzer-copy.sh
@@ -113,7 +113,8 @@ case "${action}" in
     ;;
 
   "jenkins-logs")
-    curl -u  "${LOG_ANALYZER_USER}:${LOG_ANALYZER_PASSWORD}" "${BUILD_URL}consoleText" >> "${jenkins_filename}"
+    # We use --insecure to support development Jenkins instances without a valid SSL cert.
+    curl --insecure --user  "${LOG_ANALYZER_USER}:${LOG_ANALYZER_PASSWORD}" "${BUILD_URL}consoleText" >> "${jenkins_filename}"
     ;;
 esac
 


### PR DESCRIPTION
To support development of this Jenkinsfile on other instances that may not have a valid SSL cert, we retrieve the consoleText with the `--insecure` flag.