### PR TITLE
tests: Sanitize user input via Jenkins parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,7 +185,7 @@ pipeline {
                 */
                 if (params.SPECIFIC_GIT_COMMIT == '') {
                   checkout scm
-                  originalCommitId = sh(returnStdout: true, script: 'git rev-parse origin/"\${BRANCH_NAME}"').trim()
+                  originalCommitId = sh(returnStdout: true, script: 'git rev-parse "origin/${BRANCH_NAME}"').trim()
                 } else {
                   checkout([
                     $class: 'GitSCM',
@@ -194,7 +194,7 @@ pipeline {
                   ])
                   // In case params.SPECIFIC_GIT_COMMIT is a mutable tag instead
                   // of a sha
-                  originalCommitId = sh(returnStdout: true, script: "git rev-parse ${params.SPECIFIC_GIT_COMMIT}").trim()
+                  originalCommitId = sh(returnStdout: true, script: 'git rev-parse "${SPECIFIC_GIT_COMMIT}"').trim()
                 }
 
                 echo "originalCommitId: ${originalCommitId}"


### PR DESCRIPTION
To prevent issues via malformed user input, interpolate the shell
commands via bash env variables [1], instead of groovy string interpolation.

An alternative via a Groovy function was suggested by @coverprice [2]:
```
def shellEscape(s) {
    '\'' + s.replace('\'', '\'\\\'\'') + '\''
}
originalCommitId = sh(returnStdout: true, script: "git rev-parse " +
shellEscape(params.SPECIFIC_GIT_COMMIT)).trim()
```

Both seem to be valid options. I suggest the solution via basic bash
primitives, for its simplicity.

[1] See https://stackoverflow.com/a/4273137/4011134

[2]
https://github.com/coreos/tectonic-installer/pull/3061#discussion_r171965414

@coverprice What do you think?

Thanks @lucab for the bash security 101!
