### PR TITLE
frontend: Fix AWS custom subnet validation bug when AWS region changes

### DIFF
--- a/installer/frontend/aws-actions.js
+++ b/installer/frontend/aws-actions.js
@@ -107,10 +107,14 @@ export const getDefaultSubnets = (body, creds, isNow) => (dispatch, getState) =>
         return;
       }
 
+      // TODO: This will overwrite any user entered subnet CIDRs if the page is refreshed. Once this bug is fixed, the
+      //       Nightwatch tests will also need to be updated since they reflect the effect of this bug.
+      dispatch(configActions.batchSetIn([
+        [AWS_CONTROLLER_SUBNETS, _.fromPairs(_.map(subnets.public, s => [s.availabilityZone, s.instanceCIDR]))],
+        [AWS_WORKER_SUBNETS, _.fromPairs(_.map(subnets.private, s => [s.availabilityZone, s.instanceCIDR]))],
+      ]));
+
       // Use addIn to preserve any existing values
-      const add = (path, v) => dispatch(configActions.addIn(path, v));
-      add(AWS_CONTROLLER_SUBNETS, _.fromPairs(_.map(subnets.public, s => [s.availabilityZone, s.instanceCIDR])));
-      add(AWS_CONTROLLER_SUBNET_IDS, {});
-      add(AWS_WORKER_SUBNETS, _.fromPairs(_.map(subnets.private, s => [s.availabilityZone, s.instanceCIDR])));
-      add(AWS_WORKER_SUBNET_IDS, {});
+      dispatch(configActions.addIn(AWS_CONTROLLER_SUBNET_IDS, {}));
+      dispatch(configActions.addIn(AWS_WORKER_SUBNET_IDS, {}));
     });

--- a/installer/frontend/ui-tests/output/aws-custom-vpc.tfvars
+++ b/installer/frontend/ui-tests/output/aws-custom-vpc.tfvars
@@ -9,7 +9,7 @@
   },
   "tectonic_aws_master_custom_subnets": {
     "us-west-1a": "10.0.0.0/19",
-    "us-west-1c": "10.0.32.0/20"
+    "us-west-1c": "10.0.32.0/19"
   },
   "tectonic_aws_master_ec2_type": "t2.medium",
   "tectonic_aws_master_root_volume_size": 30,
@@ -20,7 +20,7 @@
   "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
   "tectonic_aws_worker_custom_subnets": {
     "us-west-1a": "10.0.64.0/19",
-    "us-west-1c": "10.0.96.0/20"
+    "us-west-1c": "10.0.96.0/19"
   },
   "tectonic_aws_worker_ec2_type": "t2.medium",
   "tectonic_aws_worker_root_volume_size": 30,

--- a/installer/frontend/ui-tests/output/aws-external-etcd.tfvars
+++ b/installer/frontend/ui-tests/output/aws-external-etcd.tfvars
@@ -7,7 +7,7 @@
   },
   "tectonic_aws_master_custom_subnets": {
     "us-west-1a": "10.0.0.0/19",
-    "us-west-1c": "10.0.32.0/20"
+    "us-west-1c": "10.0.32.0/19"
   },
   "tectonic_aws_master_ec2_type": "m3.large",
   "tectonic_aws_master_root_volume_iops": 2000,
@@ -19,7 +19,7 @@
   "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
   "tectonic_aws_worker_custom_subnets": {
     "us-west-1a": "10.0.64.0/19",
-    "us-west-1c": "10.0.96.0/20"
+    "us-west-1c": "10.0.96.0/19"
   },
   "tectonic_aws_worker_ec2_type": "m3.medium",
   "tectonic_aws_worker_root_volume_size": 100,


### PR DESCRIPTION
Change the action to always overwrite the AWS subnets so that the subnet keys (which include the AWS AZs) are updated when the AWS region is changed.

The bug was introduced by #2620, so this PR partially reverts #2620. Unfortunately, this brings back the original bug where any user entered subnet CIDRs are overwritten if the page is refreshed. Fixing that will require a larger code change.