### PR TITLE
installer,tests: standardize CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ These instructions can be used for the official stable platforms listed above, a
 
 8. Teardown Tectonic cluster
     ```shell
-    tectonic destroy $CLUSTER_NAME
+    tectonic destroy --dir=$CLUSTER_NAME
     ```
 
 

--- a/installer/cmd/tectonic/main.go
+++ b/installer/cmd/tectonic/main.go
@@ -20,7 +20,7 @@ var (
 	clusterInstallDirFlag          = clusterInstallCommand.Flag("dir", "Cluster directory").Default(".").ExistingDir()
 
 	clusterDestroyCommand = kingpin.Command("destroy", "Destroy an existing Tectonic cluster")
-	clusterDestroyDirFlag = clusterDestroyCommand.Arg("dir", "Cluster directory").Default(".").ExistingDir()
+	clusterDestroyDirFlag = clusterDestroyCommand.Flag("dir", "Cluster directory").Default(".").ExistingDir()
 )
 
 func main() {

--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -193,7 +193,7 @@ class AwsCluster < Cluster
         env = env_variables
         env['TF_DESTROY_OPTIONS'] = '-no-color'
         env['TF_INIT_OPTIONS'] = '-no-color'
-        return run_tectonic_cli(env, 'destroy', @name)
+        return run_tectonic_cli(env, 'destroy', "--dir=#{@name}")
       end
     end
 


### PR DESCRIPTION
Standardize the arguments for the CLI.

All commands should either accept a `--dir` flag or a `<dir>` argument; we must pick one.

cc @alexsomesan @mxinden 