### PR TITLE
Add Tectonic CLI cluster configuration examples to tarball

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -192,7 +192,9 @@ load("//:variables.bzl", "PLATFORMS")
 pkg_tar(
     name = "tarball_examples",
     package_dir = "examples",
-    srcs = ["//examples:terraform.tfvars." + p for p in PLATFORMS],
+    # As long as we are not auto-generating the tectonic cli configuration
+    # examples, make sure to add the manually created once to the tarball.
+    srcs = ["//examples:terraform.tfvars." + p for p in PLATFORMS] + ["//examples:tectonic_cli_configs"],
 )
 
 filegroup(

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -12,3 +12,9 @@ EXAMPLES = {p: (PLATFORMS[p] + "/variables.tf", "terraform.tfvars." + p) for p i
     tools = ["//contrib/terraform-examples:terraform-examples"],
     visibility = ["//visibility:public"],
 ) for example in EXAMPLES.items()]
+
+filegroup(
+    name= "tectonic_cli_configs",
+    srcs = glob(["tectonic.*.yaml"]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
As long as we are not auto-generating the Tectonic CLI cluster
configuration examples, add the existing manually created ones to the
tarball.

