### PR TITLE
installer: For missing license / pull secret, log as INFO with filenames

### DIFF
--- a/installer/api/handlers_tectonic.go
+++ b/installer/api/handlers_tectonic.go
@@ -337,16 +337,18 @@ func tectonicFactsHandler(w http.ResponseWriter, req *http.Request, ctx *Context
 		dir = filepath.Dir(ex)
 	}
 
-	license, err := ioutil.ReadFile(filepath.Join(dir, "license.txt"))
+	licensePath := filepath.Join(dir, "license.txt")
+	license, err := ioutil.ReadFile(licensePath)
 	if err != nil {
 		license = nil
-		log.Warningf("Tectonic license not found in %s", dir)
+		log.Infof("Tectonic license not found at %s", licensePath)
 	}
 
-	pullSecret, err := ioutil.ReadFile(filepath.Join(dir, "pull_secret.json"))
+	pullSecretPath := filepath.Join(dir, "pull_secret.json")
+	pullSecret, err := ioutil.ReadFile(pullSecretPath)
 	if err != nil {
 		pullSecret = nil
-		log.Warningf("Pull secret not found in %s", dir)
+		log.Infof("Pull secret not found at %s", pullSecretPath)
 	}
 
 	type response struct {


### PR DESCRIPTION
(PR for `track-1` branch)

Change log messages output when the license and pull secret files are not found:
  - Instead of WARNING level, output as INFO level (not visible in terminal with default logging level)
  - Include the expected filenames, not just the expected directory

cc: @sym3tri, @aaronlevy 