### PR TITLE
Fixes that were missed in #2972

### DIFF
--- a/modules/bootkube-ut2/assets.tf
+++ b/modules/bootkube-ut2/assets.tf
@@ -56,7 +56,7 @@ data "template_file" "kubeconfig" {
   template = "${file("${path.module}/resources/kubeconfig")}"
 
   vars {
-    kube_ca_cert = "${base64encode(var.kube_ca_cert_pem)}"
+    root_ca_cert = "${base64encode(var.root_ca_cert_pem)}"
     admin_cert   = "${base64encode(var.admin_cert_pem)}"
     admin_key    = "${base64encode(var.admin_key_pem)}"
     server       = "${var.kube_apiserver_url}"
@@ -74,7 +74,7 @@ data "template_file" "kubeconfig-kubelet" {
   template = "${file("${path.module}/resources/kubeconfig-kubelet")}"
 
   vars {
-    kube_ca_cert                   = "${base64encode(var.kube_ca_cert_pem)}"
+    root_ca_cert                   = "${base64encode(var.root_ca_cert_pem)}"
     kubelet_bootstrap_token_id     = "${random_string.kubelet_bootstrap_token_id.result}"
     kubelet_bootstrap_token_secret = "${random_string.kubelet_bootstrap_token_secret.result}"
     server                         = "${var.kube_apiserver_url}"

--- a/modules/bootkube-ut2/resources/kubeconfig
+++ b/modules/bootkube-ut2/resources/kubeconfig
@@ -4,7 +4,7 @@ clusters:
 - name: ${cluster_name}
   cluster:
     server: ${server}
-    certificate-authority-data: ${kube_ca_cert}
+    certificate-authority-data: ${root_ca_cert}
 users:
 - name: admin
   user:

--- a/modules/bootkube-ut2/resources/kubeconfig-kubelet
+++ b/modules/bootkube-ut2/resources/kubeconfig-kubelet
@@ -4,7 +4,7 @@ clusters:
 - name: ${cluster_name}
   cluster:
     server: ${server}
-    certificate-authority-data: ${kube_ca_cert}
+    certificate-authority-data: ${root_ca_cert}
 users:
 - name: kubelet
   user:

--- a/modules/tls/ca/self-signed/main.tf
+++ b/modules/tls/ca/self-signed/main.tf
@@ -13,9 +13,9 @@ resource "tls_self_signed_cert" "root_ca" {
   private_key_pem = "${tls_private_key.root_ca.private_key_pem}"
 
   subject {
-    common_name  = "root-ca"
-    organization = "${uuid()}"
-    organization = "tectonic"
+    common_name         = "root-ca"
+    organization        = "${uuid()}"
+    organizational_unit = "tectonic"
   }
 
   is_ca_certificate = true
@@ -45,8 +45,13 @@ resource "tls_cert_request" "etcd_ca" {
   private_key_pem = "${tls_private_key.etcd_ca.private_key_pem}"
 
   subject {
-    common_name  = "etcd-ca"
-    organization = "etcd"
+    common_name         = "etcd-ca"
+    organization        = "${uuid()}"
+    organizational_unit = "etcd"
+  }
+
+  lifecycle {
+    ignore_changes = ["subject"]
   }
 }
 
@@ -79,8 +84,13 @@ resource "tls_cert_request" "kube_ca" {
   private_key_pem = "${tls_private_key.kube_ca.private_key_pem}"
 
   subject {
-    common_name  = "kube-ca"
-    organization = "bootkube"
+    common_name         = "kube-ca"
+    organization        = "${uuid()}"
+    organizational_unit = "bootkube"
+  }
+
+  lifecycle {
+    ignore_changes = ["subject"]
   }
 }
 
@@ -113,8 +123,13 @@ resource "tls_cert_request" "aggregator_ca" {
   private_key_pem = "${tls_private_key.aggregator_ca.private_key_pem}"
 
   subject {
-    common_name  = "aggregator"
-    organization = "bootkube"
+    common_name         = "aggregator"
+    organization        = "${uuid()}"
+    organizational_unit = "bootkube"
+  }
+
+  lifecycle {
+    ignore_changes = ["subject"]
   }
 }
 

--- a/modules/tls/ca/user-provided/assets.tf
+++ b/modules/tls/ca/user-provided/assets.tf
@@ -14,12 +14,12 @@ resource "local_file" "kube_ca_cert" {
 }
 
 resource "local_file" "aggregator_ca_key" {
-  content  = "${file(var.aggregator_key_pem_path)}"
+  content  = "${file(var.aggregator_ca_key_pem_path)}"
   filename = "./generated/tls/aggregator-ca.key"
 }
 
 resource "local_file" "aggregator_ca_cert" {
-  content  = "${file(var.aggregator_cert_pem_path)}"
+  content  = "${file(var.aggregator_ca_cert_pem_path)}"
   filename = "./generated/tls/aggregator-ca.crt"
 }
 

--- a/modules/tls/ca/user-provided/outputs.tf
+++ b/modules/tls/ca/user-provided/outputs.tf
@@ -2,26 +2,38 @@ output "root_ca_cert_pem" {
   value = "${file(var.root_ca_cert_pem_path)}"
 }
 
-output "root_ca_key_pem" {
-  value = "${file(var.kube_ca_key_pem_path)}"
-}
-
 output "kube_ca_cert_pem" {
   value = "${file(var.kube_ca_cert_pem_path)}"
 }
 
 output "kube_ca_key_pem" {
-  value = "${file(var.aggregator_key_pem_path)}"
+  value = "${file(var.kube_ca_key_pem_path)}"
+}
+
+output "kube_ca_key_alg" {
+  value = "${var.kube_ca_key_alg}"
 }
 
 output "aggregator_ca_cert_pem" {
-  value = "${file(var.aggregator_cert_pem_path)}"
+  value = "${file(var.aggregator_ca_cert_pem_path)}"
 }
 
 output "aggregator_ca_key_pem" {
-  value = "${file(var.aggregator_key_pem_path)}"
+  value = "${file(var.aggregator_ca_key_pem_path)}"
+}
+
+output "aggregator_ca_key_alg" {
+  value = "${var.aggregator_ca_key_alg}"
 }
 
 output "etcd_ca_cert_pem" {
   value = "${file(var.etcd_ca_cert_pem_path)}"
+}
+
+output "etcd_ca_key_pem" {
+  value = "${file(var.etcd_ca_key_pem_path)}"
+}
+
+output "etcd_ca_key_alg" {
+  value = "${var.etcd_ca_key_alg}"
 }

--- a/modules/tls/ca/user-provided/variables.tf
+++ b/modules/tls/ca/user-provided/variables.tf
@@ -2,16 +2,17 @@ variable "root_ca_cert_pem_path" {
   type = "string"
 }
 
-variable "root_ca_key_pem_path" {
-  type = "string"
-}
-
 variable "etcd_ca_cert_pem_path" {
   type = "string"
 }
 
 variable "etcd_ca_key_pem_path" {
   type = "string"
+}
+
+variable "etcd_ca_key_alg" {
+  type    = "string"
+  default = "RSA"
 }
 
 variable "kube_ca_cert_pem_path" {
@@ -22,10 +23,20 @@ variable "kube_ca_key_pem_path" {
   type = "string"
 }
 
+variable "kube_ca_key_alg" {
+  type    = "string"
+  default = "RSA"
+}
+
 variable "aggregator_ca_cert_pem_path" {
   type = "string"
 }
 
 variable "aggregator_ca_key_pem_path" {
   type = "string"
+}
+
+variable "aggregator_ca_key_alg" {
+  type    = "string"
+  default = "RSA"
 }


### PR DESCRIPTION
Fixes that were missed in #2972

* bootkube-ut2: update trust in kubeconfigs to root-ca
* tls: update user-provided variables and outputs
* also fix the duplicated organization for root-ca.