### PR TITLE
[WIP] *: Replace wrong usage of cluster_name with dns_name

### DIFF
--- a/modules/aws/master-asg/master.tf
+++ b/modules/aws/master-asg/master.tf
@@ -61,7 +61,7 @@ resource "aws_autoscaling_group" "masters" {
 
 data "ignition_config" "tnc_master" {
   append {
-    source = "http://${var.cluster_name}-tnc.${var.base_domain}/ign/v1/role/master"
+    source = "http://${var.dns_name}-tnc.${var.base_domain}/ign/v1/role/master"
   }
 
   files = ["${data.ignition_file.kubelet_master_kubeconfig.id}"]

--- a/modules/aws/master-asg/variables.tf
+++ b/modules/aws/master-asg/variables.tf
@@ -109,3 +109,8 @@ variable "kubeconfig_content" {
   type    = "string"
   default = ""
 }
+
+variable "dns_name" {
+  type    = "string"
+  default = ""
+}

--- a/modules/dns/powerdns/records.tf
+++ b/modules/dns/powerdns/records.tf
@@ -7,7 +7,7 @@ provider "powerdns" {
 resource "powerdns_record" "api_internal" {
   count = "${var.tectonic_private_endpoints}"
   zone  = "${var.base_domain}"
-  name  = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-api.${var.base_domain}."
+  name  = "${var.dns_name}-api.${var.base_domain}."
   ttl   = 60
   type  = "ALIAS"
 
@@ -17,7 +17,7 @@ resource "powerdns_record" "api_internal" {
 resource "powerdns_record" "api_external" {
   count   = "${var.tectonic_public_endpoints}"
   zone    = "${var.base_domain}"
-  name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-api.${var.base_domain}."
+  name    = "${var.dns_name}-api.${var.base_domain}."
   type    = "ALIAS"
   ttl     = 60
   records = ["${var.api_external_elb_dns_name}."]
@@ -26,7 +26,7 @@ resource "powerdns_record" "api_external" {
 resource "powerdns_record" "ingress_public" {
   count   = "${var.tectonic_public_endpoints}"
   zone    = "${var.base_domain}"
-  name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}.${var.base_domain}."
+  name    = "${var.dns_name}.${var.base_domain}."
   type    = "ALIAS"
   ttl     = 60
   records = ["${var.console_elb_dns_name}."]
@@ -35,7 +35,7 @@ resource "powerdns_record" "ingress_public" {
 resource "powerdns_record" "ingress_private" {
   count = "${var.tectonic_private_endpoints}"
   zone  = "${var.base_domain}"
-  name  = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}.${var.base_domain}."
+  name  = "${var.dns_name}.${var.base_domain}."
   type  = "ALIAS"
   ttl   = 60
 
@@ -47,7 +47,7 @@ resource "powerdns_record" "ingress_private" {
 resource "powerdns_record" "etcd" {
   count   = "${var.etcd_count}"
   zone    = "${var.base_domain}"
-  name    = "${var.cluster_name}-etcd-${count.index}.${var.base_domain}."
+  name    = "${var.dns_name}-etcd-${count.index}.${var.base_domain}."
   type    = "A"
   ttl     = 60
   records = ["${var.etcd_ip_addresses[count.index]}"]

--- a/modules/dns/powerdns/variables.tf
+++ b/modules/dns/powerdns/variables.tf
@@ -83,7 +83,7 @@ variable "tectonic_extra_tags" {
   description = "(optional) Extra tags to be applied to created resources."
 }
 
-variable "custom_dns_name" {
+variable "dns_name" {
   type        = "string"
   default     = ""
   description = "DNS prefix used to construct the console and API server endpoints."

--- a/modules/dns/route53/etcd.tf
+++ b/modules/dns/route53/etcd.tf
@@ -3,6 +3,6 @@ resource "aws_route53_record" "etcd_a_nodes" {
   type    = "A"
   ttl     = "60"
   zone_id = "${local.zone_id}"
-  name    = "${var.cluster_name}-etcd-${count.index}"
+  name    = "${var.dns_name}-etcd-${count.index}"
   records = ["${var.etcd_ip_addresses[count.index]}"]
 }

--- a/modules/dns/route53/master.tf
+++ b/modules/dns/route53/master.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "master_nodes" {
   count   = "${var.elb_alias_enabled ? 0 : var.master_count}"
   zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.cluster_name}-master-${count.index}"
+  name    = "${var.dns_name}-master-${count.index}"
   type    = "A"
   ttl     = "60"
   records = ["${var.master_ip_addresses[count.index]}"]

--- a/modules/dns/route53/tectonic.tf
+++ b/modules/dns/route53/tectonic.tf
@@ -39,7 +39,7 @@ resource "aws_route53_record" "tectonic_api" {
 resource "aws_route53_record" "tectonic_api_external" {
   count   = "${var.elb_alias_enabled ? var.tectonic_public_endpoints : 0}"
   zone_id = "${local.public_zone_id}"
-  name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-api.${var.base_domain}"
+  name    = "${var.dns_name}-api.${var.base_domain}"
   type    = "A"
 
   alias {
@@ -52,7 +52,7 @@ resource "aws_route53_record" "tectonic_api_external" {
 resource "aws_route53_record" "tectonic_api_internal" {
   count   = "${var.elb_alias_enabled ? var.tectonic_private_endpoints : 0}"
   zone_id = "${local.private_zone_id}"
-  name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}-api.${var.base_domain}"
+  name    = "${var.dns_name}-api.${var.base_domain}"
   type    = "A"
 
   alias {
@@ -65,7 +65,7 @@ resource "aws_route53_record" "tectonic_api_internal" {
 resource "aws_route53_record" "tectonic-console" {
   count   = "${var.elb_alias_enabled ? 0 : 1}"
   zone_id = "${local.public_zone_id}"
-  name    = "${var.cluster_name}"
+  name    = "${var.dns_name}"
   type    = "A"
   ttl     = "60"
   records = ["${var.worker_ip_addresses}"]
@@ -74,7 +74,7 @@ resource "aws_route53_record" "tectonic-console" {
 resource "aws_route53_record" "tectonic_ingress_public" {
   count   = "${var.elb_alias_enabled ? var.tectonic_public_endpoints : 0}"
   zone_id = "${local.public_zone_id}"
-  name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}.${var.base_domain}"
+  name    = "${var.dns_name}.${var.base_domain}"
   type    = "A"
 
   alias {
@@ -87,7 +87,7 @@ resource "aws_route53_record" "tectonic_ingress_public" {
 resource "aws_route53_record" "tectonic_ingress_private" {
   count   = "${var.elb_alias_enabled ? var.tectonic_private_endpoints : 0}"
   zone_id = "${local.private_zone_id}"
-  name    = "${var.custom_dns_name == "" ? var.cluster_name : var.custom_dns_name}.${var.base_domain}"
+  name    = "${var.dns_name}.${var.base_domain}"
   type    = "A"
 
   alias {

--- a/modules/dns/route53/variables.tf
+++ b/modules/dns/route53/variables.tf
@@ -83,7 +83,7 @@ variable "tectonic_extra_tags" {
   description = "(optional) Extra tags to be applied to created resources."
 }
 
-variable "custom_dns_name" {
+variable "dns_name" {
   type        = "string"
   default     = ""
   description = "DNS prefix used to construct the console and API server endpoints."

--- a/modules/dns/route53/worker.tf
+++ b/modules/dns/route53/worker.tf
@@ -1,7 +1,7 @@
 resource "aws_route53_record" "worker_nodes" {
   count   = "${var.elb_alias_enabled ? 0 : var.worker_count}"
   zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.cluster_name}-worker-${count.index}"
+  name    = "${var.dns_name}-worker-${count.index}"
   type    = "A"
   ttl     = "60"
   records = ["${var.worker_ip_addresses[count.index]}"]
@@ -11,7 +11,7 @@ resource "aws_route53_record" "worker_nodes_public" {
   // hack: worker_public_ips_enabled is a workaround for https://github.com/hashicorp/terraform/issues/10857
   count   = "${var.worker_public_ips_enabled ? var.worker_count : 0}"
   zone_id = "${data.aws_route53_zone.tectonic.zone_id}"
-  name    = "${var.cluster_name}-worker-${count.index}-public"
+  name    = "${var.dns_name}-worker-${count.index}-public"
   type    = "A"
   ttl     = "60"
   records = ["${var.worker_public_ips[count.index]}"]

--- a/modules/govcloud/etcd/ignition.tf
+++ b/modules/govcloud/etcd/ignition.tf
@@ -31,7 +31,7 @@ Environment=REBOOT_STRATEGY=etcd-lock
 Environment="LOCKSMITHD_ETCD_CAFILE=/etc/ssl/etcd/ca.crt"
 Environment="LOCKSMITHD_ETCD_KEYFILE=/etc/ssl/etcd/client.key"
 Environment="LOCKSMITHD_ETCD_CERTFILE=/etc/ssl/etcd/client.crt"
-Environment="LOCKSMITHD_ENDPOINT=https://${var.cluster_name}-etcd-${count.index}.${var.base_domain}:2379"
+Environment="LOCKSMITHD_ENDPOINT=https://${var.dns_name}-etcd-${count.index}.${var.base_domain}:2379"
 EOF
     },
   ]

--- a/modules/govcloud/etcd/variables.tf
+++ b/modules/govcloud/etcd/variables.tf
@@ -101,3 +101,8 @@ variable "ign_systemd_default_env_id" {
   type    = "string"
   default = ""
 }
+
+variable "dns_name" {
+  type    = "string"
+  default = ""
+}

--- a/platforms/govcloud/main.tf
+++ b/platforms/govcloud/main.tf
@@ -66,6 +66,7 @@ module "etcd" {
   ssh_key                    = "${var.tectonic_govcloud_ssh_key}"
   subnets                    = "${module.vpc.worker_subnet_ids}"
   dns_server_ip              = "${var.tectonic_govcloud_dns_server_ip}"
+  dns_name = "${var.tectonic_dns_name}"
 }
 
 module "ignition_masters" {
@@ -223,7 +224,7 @@ module "dns" {
   cluster_name                   = "${var.tectonic_cluster_name}"
   console_elb_dns_name           = "${module.vpc.aws_console_dns_name}"
   console_elb_zone_id            = "${module.vpc.aws_elb_console_zone_id}"
-  custom_dns_name                = "${var.tectonic_dns_name}"
+  dns_name                = "${var.tectonic_dns_name}"
   elb_alias_enabled              = true
   etcd_count                     = "${length(data.template_file.etcd_hostname_list.*.id)}"
   etcd_ip_addresses              = "${module.etcd.ip_addresses}"

--- a/platforms/govcloud/tectonic.tf
+++ b/platforms/govcloud/tectonic.tf
@@ -1,3 +1,7 @@
+locals {
+  dns_name = "${var.tectonic_dns_name == "" ? var.tectonic_cluster_name : var.tectonic_dns_name}"
+}
+
 data "template_file" "etcd_hostname_list" {
   count    = "${var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : length(data.aws_availability_zones.azs.names) == 5 ? 5 : 3}"
   template = "${var.tectonic_cluster_name}-etcd-${count.index}.${var.tectonic_base_domain}"
@@ -59,7 +63,9 @@ module "tectonic" {
 
   cluster_name = "${var.tectonic_cluster_name}"
 
+  # TODO: base_address == dns_name.base_domain Could be refactored
   base_address       = "${module.dns.ingress_internal_fqdn}"
+  dns_name = "${local.dns_name}"
   kube_apiserver_url = "https://${module.dns.api_internal_fqdn}:443"
   service_cidr       = "${var.tectonic_service_cidr}"
 

--- a/steps/assets/tectonic.tf
+++ b/steps/assets/tectonic.tf
@@ -10,8 +10,8 @@ provider "aws" {
 }
 
 locals {
-  ingress_internal_fqdn = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}"
-  api_internal_fqdn     = "${var.tectonic_cluster_name}-api.${var.tectonic_base_domain}"
+  ingress_internal_fqdn = "${var.tectonic_dns_name}.${var.tectonic_base_domain}"
+  api_internal_fqdn     = "${var.tectonic_dns_name}-api.${var.tectonic_base_domain}"
   bucket_name           = "${var.tectonic_cluster_name}-tnc.${var.tectonic_base_domain}"
   bucket_assets_key     = "assets.zip"
 }
@@ -20,7 +20,7 @@ data "aws_availability_zones" "azs" {}
 
 data "template_file" "etcd_hostname_list" {
   count    = "${var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : length(data.aws_availability_zones.azs.names) == 5 ? 5 : 3}"
-  template = "${var.tectonic_cluster_name}-etcd-${count.index}.${var.tectonic_base_domain}"
+  template = "${var.tectonic_dns_name}-etcd-${count.index}.${var.tectonic_base_domain}"
 }
 
 module "bootkube" {


### PR DESCRIPTION
By default the Tectonic installer uses the cluster name with the base
domain (`<cluster_name>.<base_domain>`) as the url for the console, api,
tnc, ... In addition the Tectonic installer has the feature to specify a
custom dns name, which will be prefixed to the base domain instead of
the cluster name when set.

This was not consistently done in the Terraform code. Instead, sometimes
the cluster name would be used even though the dns name was set. This
patch introduces consistent usage of dns name, which is either set to
the input dns name, or if empty to the cluster name.

**This is a work in progress implementation.** Waiting for proper scheduling into Sprint (INST-999).

//CC @squat @spangenberg 