### PR TITLE
tests: Append instead of write to log file

### DIFF
--- a/tests/rspec/lib/aws_cluster.rb
+++ b/tests/rspec/lib/aws_cluster.rb
@@ -235,7 +235,7 @@ class AwsCluster < Cluster
 
       # Save output in logs/
       FileUtils.mkdir_p(File.dirname(tectonic_logs))
-      save_to_file = File.open(tectonic_logs, 'w+')
+      save_to_file = File.open(tectonic_logs, 'a')
       save_to_file << output
       save_to_file.close
 


### PR DESCRIPTION
Log output of the tectonic cli commands are redirected to a log file.
Instead of overwriting that file on each run, append to it. E.g.
`tectonic install` can be repeated twice. Archiving the logs of both
runs is helpful for debugging.