### PR TITLE
Cli: get terraform binary from inside the package

### DIFF
--- a/installer/pkg/workflow/BUILD.bazel
+++ b/installer/pkg/workflow/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     srcs = [
         "convert.go",
         "destroy.go",
+        "executor.go",
         "init.go",
         "install.go",
         "terraform.go",

--- a/installer/pkg/workflow/executor.go
+++ b/installer/pkg/workflow/executor.go
@@ -1,0 +1,106 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+// executor enables calling TerraForm from Go, across platforms, with any
+// additional providers/provisioners that the currently executing binary
+// exposes.
+//
+// The TerraForm binary is expected to be in the executing binary's folder, in
+// the current working directory or in the PATH.
+type executor struct {
+	binaryPath string
+}
+
+// Set the binary names for different platforms
+const (
+	tfBinUnix    = "terraform"
+	tfBinWindows = "terraform.exe"
+)
+
+// errBinaryNotFound denotes the fact that the TerraForm binary could not be
+// found on disk.
+var errBinaryNotFound = errors.New(
+	"TerraForm not in executable's folder, cwd nor PATH",
+)
+
+// newExecutor initializes a new Executor.
+func newExecutor() (*executor, error) {
+	ex := new(executor)
+
+	// Find the TerraForm binary.
+	binPath, err := tfBinaryPath()
+	if err != nil {
+		return nil, err
+	}
+
+	ex.binaryPath = binPath
+	return ex, nil
+}
+
+// Execute runs the given command and arguments against TerraForm.
+//
+// An error is returned if the TerraForm binary could not be found, or if the
+// TerraForm call itself failed, in which case, details can be found in the
+// output.
+func (ex *executor) execute(clusterDir string, args ...string) error {
+	// Prepare TerraForm command by setting up the command, configuration,
+	// and the working directory
+	if clusterDir == "" {
+		return fmt.Errorf("clusterDir is unset. Quitting")
+	}
+
+	cmd := exec.Command(ex.binaryPath, args...)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Dir = clusterDir
+
+	// Start TerraForm.
+	return cmd.Run()
+}
+
+// tfBinatyPath searches for a TerraForm binary on disk:
+// - in the executing binary's folder,
+// - in the current working directory,
+// - in the PATH.
+// The first to be found is the one returned.
+func tfBinaryPath() (string, error) {
+	// Depending on the platform, the expected binary name is different.
+	binaryFileName := tfBinUnix
+	if runtime.GOOS == "windows" {
+		binaryFileName = tfBinWindows
+	}
+
+	// Look into the executable's folder.
+	if execFolderPath, err := filepath.Abs(filepath.Dir(os.Args[0])); err == nil {
+		path := filepath.Join(execFolderPath, binaryFileName)
+		if stat, err := os.Stat(path); err == nil && !stat.IsDir() {
+			return path, nil
+		}
+	}
+
+	// Look into cwd.
+	if workingDirectory, err := os.Getwd(); err == nil {
+		path := filepath.Join(workingDirectory, binaryFileName)
+		if stat, err := os.Stat(path); err == nil && !stat.IsDir() {
+			return path, nil
+		}
+	}
+
+	// If we still haven't found the executable, look for it
+	// in the PATH.
+	if path, err := exec.LookPath(binaryFileName); err == nil {
+		return filepath.Abs(path)
+	}
+
+	return "", errBinaryNotFound
+}

--- a/installer/pkg/workflow/terraform.go
+++ b/installer/pkg/workflow/terraform.go
@@ -3,18 +3,21 @@ package workflow
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
 func terraformExec(clusterDir string, args ...string) error {
-	tf := exec.Command("terraform", args...)
-	tf.Dir = clusterDir
-	tf.Stdin = os.Stdin
-	tf.Stdout = os.Stdout
-	tf.Stderr = os.Stderr
+	// Create an executor
+	ex, err := newExecutor()
+	if err != nil {
+		return fmt.Errorf("Could not create Terraform executor: %s", err)
+	}
 
-	return tf.Run()
+	err = ex.execute(clusterDir, args...)
+	if err != nil {
+		return fmt.Errorf("Failed to run Terraform: %s", err)
+	}
+	return nil
 }
 
 func tfApply(clusterDir, state, templateDir string) error {

--- a/tests/rspec/spec/spec_helper.rb
+++ b/tests/rspec/spec/spec_helper.rb
@@ -41,12 +41,6 @@ RSpec.configure do |config|
   succeeded = system("tar -zxvf #{tar_gz} -C #{tar_gz_dir} > /dev/null")
   raise 'failed to untar build tarball' unless succeeded
 
-  # Add terraform binary to path
-  ENV['PATH'] =
-    File.join(File.dirname(ENV['RELEASE_TARBALL_PATH']), 'tectonic/tectonic-installer', Gem::Platform.local.os) +
-    ':' +
-    ENV['PATH']
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
This PR resolves an issue whereby the tectonic binary didn't necessarily use the packages terraform binary