### PR TITLE
Restored update-payload module into tarball_terraform_configuration

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -99,7 +99,7 @@ genrule(
 pkg_tar(
     name = "tarball_terraform_configuration",
     mode = "0644",
-    srcs =  glob(["modules/**"], exclude=["modules/update-payload/**"]) + glob(["steps/**"]) + ["config.tf"],
+    srcs =  glob(["modules/**"]) + glob(["steps/**"]) + ["config.tf"],
     strip_prefix = ".",
 )
 


### PR DESCRIPTION
The Release Automation Jenkins uses the Bazel tarball built by Installer Jenkins to create a release package, and requires the update-payload Terraform module to perform this. The update-payload module was previously excluded from the tarball, and this PR restores it.