### PR TITLE
Correct bazel invocation example

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -38,12 +38,13 @@ To add a new dependency:
 ```
 glide install -v
 glide-vc --use-lock-file --no-tests --only-code
-bazel run gazelle
+bazel run //:gazelle
 ```
 
 If it worked correctly it should:
 - Clone your new dep to the `/vendor` dir, and check out the ref you specified.
 - Update `glide.lock` to include your new package, adds any transitive dependencies, and updates its hash.
+- Regenerate BUILD.bazel files.
 
 For the sake of your fellow reviewers, commit vendored code changes as a separate commit from any other changes.
 
@@ -54,5 +55,5 @@ Should you need to regenerate or repair the vendored code en-mass from their sou
 ```
 glide install -v
 glide-vc --use-lock-file --no-tests --only-code
-bazel run gazelle
+bazel run //:gazelle
 ```

--- a/installer/README.md
+++ b/installer/README.md
@@ -36,8 +36,10 @@ To add a new dependency:
 - Revendor the dependencies:
 
 ```
+rm glide.lock
 glide install -v
 glide-vc --use-lock-file --no-tests --only-code
+git checkout vendor/golang.org/x/crypto/ssh/terminal/BUILD.bazel vendor/github.com/Sirupsen/logrus/BUILD.bazel
 bazel run //:gazelle
 ```
 
@@ -50,10 +52,5 @@ For the sake of your fellow reviewers, commit vendored code changes as a separat
 
 #### Regenerate or Repair Vendored Code
 
-Should you need to regenerate or repair the vendored code en-mass from their source repositories, you can run:
-
-```
-glide install -v
-glide-vc --use-lock-file --no-tests --only-code
-bazel run //:gazelle
-```
+Should you need to regenerate or repair the vendored code en-mass from their source repositories, you can run
+the same steps above under "Revendor the dependencies:".

--- a/installer/README.md
+++ b/installer/README.md
@@ -53,4 +53,4 @@ For the sake of your fellow reviewers, commit vendored code changes as a separat
 #### Regenerate or Repair Vendored Code
 
 Should you need to regenerate or repair the vendored code en-mass from their source repositories, you can run
-the same steps above under "Revendor the dependencies:".
+the same steps above under "Revendor the dependencies".


### PR DESCRIPTION
Updates the `installer/README.md` example of invoking gazelle, such that it can be run from inside the installer directory.

@yifan-gu also found that:

- 2 customized `BAZEL.build` files with `# gazelle:ignore` directives are removed by the `glide install -v` step, and must be restored with `git checkout ...` before running `bazel run //:gazelle`. Otherwise Gazelle will regenerate BUILD.bazel files for them that won't work.
- Remove the `glide.lock` is necessary before running `glide install -v`, otherwise the lock file won't be updated.