### PR TITLE
cli: plumb-through per-platform steps

### DIFF
--- a/installer/pkg/config/cluster.go
+++ b/installer/pkg/config/cluster.go
@@ -40,7 +40,7 @@ type Cluster struct {
 	Name                string `json:"tectonic_cluster_name,omitempty" yaml:"name,omitempty"`
 	Networking          `json:",inline" yaml:"networking,omitempty"`
 	NodePools           `json:"-" yaml:"nodePools"`
-	Platform            string `json:"-" yaml:"platform,omitempty"`
+	Platform            string `json:"tectonic_platform" yaml:"platform,omitempty"`
 	Proxy               `json:",inline" yaml:"proxy,omitempty"`
 	PullSecretPath      string `json:"tectonic_pull_secret_path,omitempty" yaml:"pullSecretPath,omitempty"`
 	TLSValidityPeriod   int    `json:"tectonic_tls_validity_period,omitempty" yaml:"tlsValidityPeriod,omitempty"`

--- a/installer/pkg/workflow/destroy.go
+++ b/installer/pkg/workflow/destroy.go
@@ -20,42 +20,42 @@ func NewDestroyWorkflow(clusterDir string) Workflow {
 }
 
 func destroyAssetsStep(m *metadata) error {
-	return runDestroyStep(m.clusterDir, assetsStep)
+	return runDestroyStep(m, assetsStep)
 }
 
 func destroyEtcdStep(m *metadata) error {
-	return runDestroyStep(m.clusterDir, etcdStep)
+	return runDestroyStep(m, etcdStep)
 }
 
 func destroyBootstrapStep(m *metadata) error {
-	return runDestroyStep(m.clusterDir, bootstrapStep)
+	return runDestroyStep(m, bootstrapStep)
 }
 
 func destroyTNCDNSStep(m *metadata) error {
-	return destroyTNCDNS(m.clusterDir)
+	return destroyTNCDNS(m)
 }
 
 func destroyTopologyStep(m *metadata) error {
-	return runDestroyStep(m.clusterDir, topologyStep)
+	return runDestroyStep(m, topologyStep)
 }
 
 func destroyJoinWorkersStep(m *metadata) error {
-	return runDestroyStep(m.clusterDir, joinWorkersStep)
+	return runDestroyStep(m, joinWorkersStep)
 }
 
 func destroyJoinMastersStep(m *metadata) error {
-	return runDestroyStep(m.clusterDir, joinMastersStep)
+	return runDestroyStep(m, joinMastersStep)
 }
 
-func runDestroyStep(clusterDir, step string, extraArgs ...string) error {
-	if !hasStateFile(clusterDir, step) {
+func runDestroyStep(m *metadata, step string, extraArgs ...string) error {
+	if !hasStateFile(m.clusterDir, step) {
 		// there is no statefile, therefore nothing to destroy for this step
 		return nil
 	}
-	templateDir, err := findTemplates(step)
+	templateDir, err := findStepTemplates(step, m.cluster.Platform)
 	if err != nil {
 		return err
 	}
 
-	return tfDestroy(clusterDir, step, templateDir, extraArgs...)
+	return tfDestroy(m.clusterDir, step, templateDir, extraArgs...)
 }

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -8,6 +8,7 @@
   "tectonic_networking": "canal",
   "tectonic_service_cidr": "10.3.0.0/16",
   "tectonic_cluster_cidr": "10.2.0.0/16",
+  "tectonic_platform": "AWS",
   "tectonic_tls_validity_period": 26280,
   "tectonic_worker_count": 3,
   "tectonic_aws_etcd_ec2_type": "m4.large",

--- a/installer/pkg/workflow/install.go
+++ b/installer/pkg/workflow/install.go
@@ -67,51 +67,51 @@ func NewInstallJoinWorkflow(clusterDir string) Workflow {
 }
 
 func installAssetsStep(m *metadata) error {
-	return runInstallStep(m.clusterDir, assetsStep)
+	return runInstallStep(m, assetsStep)
 }
 
 func installTopologyStep(m *metadata) error {
-	return runInstallStep(m.clusterDir, topologyStep)
+	return runInstallStep(m, topologyStep)
 }
 
 func installBootstrapStep(m *metadata) error {
-	return runInstallStep(m.clusterDir, bootstrapStep)
+	return runInstallStep(m, bootstrapStep)
 }
 
 func installTNCCNAMEStep(m *metadata) error {
 	if !clusterIsBootstrapped(m.clusterDir) {
-		return createTNCCNAME(m.clusterDir)
+		return createTNCCNAME(m)
 	}
 	return nil
 }
 
 func installTNCARecordStep(m *metadata) error {
-	return createTNCARecord(m.clusterDir)
+	return createTNCARecord(m)
 }
 
 func installEtcdStep(m *metadata) error {
-	return runInstallStep(m.clusterDir, etcdStep)
+	return runInstallStep(m, etcdStep)
 }
 
 func installJoinMastersStep(m *metadata) error {
 	// TODO: import will fail after a first run, error is ignored for now
 	importAutoScalingGroup(m)
-	return runInstallStep(m.clusterDir, joinMastersStep)
+	return runInstallStep(m, joinMastersStep)
 }
 
 func installJoinWorkersStep(m *metadata) error {
-	return runInstallStep(m.clusterDir, joinWorkersStep)
+	return runInstallStep(m, joinWorkersStep)
 }
 
-func runInstallStep(clusterDir, step string, extraArgs ...string) error {
-	templateDir, err := findTemplates(step)
+func runInstallStep(m *metadata, step string, extraArgs ...string) error {
+	templateDir, err := findStepTemplates(step, m.cluster.Platform)
 	if err != nil {
 		return err
 	}
-	if err := tfInit(clusterDir, templateDir); err != nil {
+	if err := tfInit(m.clusterDir, templateDir); err != nil {
 		return err
 	}
-	return tfApply(clusterDir, step, templateDir, extraArgs...)
+	return tfApply(m.clusterDir, step, templateDir, extraArgs...)
 }
 
 func generateIgnConfigStep(m *metadata) error {


### PR DESCRIPTION
This lays the groundwork for per-platform steps.

If step FOO is desired, prefer `steps/FOO/aws`, but fall back to `steps/FOO` if missing.