### PR TITLE
Bump track-1 K8s conformance tests to 1.9.6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ originalCommitId = 'UNKNOWN'
 pipeline {
   agent none
   environment {
-    KUBE_CONFORMANCE_IMAGE = 'quay.io/coreos/kube-conformance:v1.8.4_coreos.0'
+    KUBE_CONFORMANCE_IMAGE = 'quay.io/coreos/kube-conformance:v1.9.6_coreos.0'
     LOGSTASH_BUCKET = 'log-analyzer-tectonic-installer'
   }
   options {

--- a/images/kubernetes-e2e/Dockerfile
+++ b/images/kubernetes-e2e/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y rsync && rm -rf /var/lib/apt/lists/*
 
 # Git Repository Configuration
 ARG E2E_REPO=https://github.com/coreos/kubernetes
-ARG E2E_REF=v1.8.4+coreos.0
+ARG E2E_REF=v1.9.6+coreos.0
 
 # clone Kubernetes repository
 RUN mkdir -p ${GOPATH}/src/k8s.io && \
@@ -21,5 +21,5 @@ RUN GOLDFLAGS="--s -w" make all WHAT="cmd/kubectl vendor/github.com/onsi/ginkgo/
 
 # testing defaults
 ENV KUBE_OS_DISTRIBUTION=coreos KUBERNETES_CONFORMANCE_TEST=Y HOME=/go/src/k8s.io/kubernetes SKEW=false FOCUS=Conformance
-CMD KUBECONFIG=/kubeconfig go run hack/e2e.go -- -v --test --check-version-skew=${SKEW} --test_args="--ginkgo.focus=\[${FOCUS}\] ${TEST_ARGS}"
+CMD KUBECONFIG=/kubeconfig go run hack/e2e.go -- -v 1 --test --check-version-skew=${SKEW} --test_args="--ginkgo.focus=\[${FOCUS}\] ${TEST_ARGS}"
 

--- a/images/kubernetes-e2e/build.sh
+++ b/images/kubernetes-e2e/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set +ex
+
+# Update this version in cadence with the KUBE_CONFORMANCE_IMAGE in the Jenkinsfile
+E2E_REF="v1.9.6_coreos.0"
+
+# Replace '_' with '+'
+E2E_REF_VER="${E2E_REF/_/+}"
+docker build \
+  --tag="quay.io/coreos/kube-conformance:${E2E_REF}" \
+  --build-arg="E2E_REF=${E2E_REF_VER}" \
+  .


### PR DESCRIPTION
Bump track-1 K8s conformance tests to 1.9.6, and adds a script to build + tag it.