### PR TITLE
Bump Tectonic Console to v6.0.1.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -73,7 +73,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.8.1"
     calico                       = "quay.io/calico/node:v2.6.1"
     calico_cni                   = "quay.io/calico/cni:v1.11.0"
-    console                      = "quay.io/coreos/tectonic-console:v5.0.4"
+    console                      = "quay.io/coreos/tectonic-console:v6.0.1"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.1"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
This version of console has all the styling cleanup, bug fixes, and k8s 1.9 compatibility changes that we want.
