### PR TITLE
Bump Tectonic Console to v6.0.4.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -73,7 +73,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.8.1"
     calico                       = "quay.io/calico/node:v2.6.1"
     calico_cni                   = "quay.io/calico/cni:v1.11.0"
-    console                      = "quay.io/coreos/tectonic-console:v6.0.1"
+    console                      = "quay.io/coreos/tectonic-console:v6.0.5"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.1"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"


### PR DESCRIPTION
A few bug fixes and style tweaks.