### PR TITLE
fix: Loosen Tectonic's Azure Resource Group capture

### DIFF
--- a/modules/azure/vnet/variables.tf
+++ b/modules/azure/vnet/variables.tf
@@ -1,7 +1,7 @@
 // This var is for internal use only.
 // It is to be considered a constant, because Terraform can't acutally define constants.
 variable "const_id_to_group_name_regex" {
-  default     = "//subscriptions/[-\\w]+/resourceGroups/([-\\w]+)/providers/[.\\w]+/[.\\w]+/([.\\w-]+)/"
+  default     = "/^/subscriptions/[-\\w]+/resourceGroups/([\\w()-\\.]+)/providers/[.\\w]+/[.\\w]+/([.\\w-]+)$/"
   type        = "string"
   description = "(internal) A regular expression that parses Azure resource IDs into component identifiers."
 }

--- a/modules/dns/azure/variables.tf
+++ b/modules/dns/azure/variables.tf
@@ -1,7 +1,7 @@
 // This var is for internal use only.
 // It is to be considered a constant, because Terraform can't acutally define constants.
 variable "const_id_to_group_name_regex" {
-  default     = "/^/subscriptions/[-\\w]+/resourceGroups/([-\\w]+)/providers/[.\\w]+/[.\\w]+/([.\\w-]+)$/"
+  default     = "/^/subscriptions/[-\\w]+/resourceGroups/([\\w()-\\.]+)/providers/[.\\w]+/[.\\w]+/([.\\w-]+)$/"
   type        = "string"
   description = "(internal) A regular expression that parses Azure resource IDs into component identifiers."
 }


### PR DESCRIPTION
Previously, Tectonic was failing to create DNS records and vnets if a
user passed in a resource ID that used a Resource Group name with
parentheses or periods. These are valid in a Resource Group
name according to the Azure naming conventions:
> Alphanumeric, underscore, parentheses, hyphen, and period (except at
end) [source](https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#general)

This change loosens the capture group to include the allowed
punctuation.

Tested with Terraform 0.11.7

Before creating your PR, please make sure to add the appropriate GitHub labels
like e.g. `run-smoke-tests` + `platform/<xxx>`. For more details see
[tests/README.md](../tests/README.md).

(In case you don't have permissions to add labels, please ask a
[Maintainer](../MAINTAINERS).)
