### PR TITLE
Fix paths in .bazelrc for Bazel >0.12.x

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-startup --output_base $PWD/build
-build --color=yes --workspace_status_command=$PWD/buildvars.sh
+startup --output_base build
+build --color=yes --workspace_status_command "${PWD}/buildvars.sh"

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-startup --output_base ./build
-build --color=yes --workspace_status_command=./buildvars.sh
+startup --output_base $PWD/build
+build --color=yes --workspace_status_command=$PWD/buildvars.sh


### PR DESCRIPTION
This change is needed to build with Bazel versions 0.12.x and beyond.

The reason is that Bazel seems to have introduced a change in the way paths in .bazelrc are evaluated.