### PR TITLE
Bump Tectonic Console to v6.0.5 for 1.9.6.

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -73,7 +73,7 @@ variable "tectonic_container_images" {
     bootkube                     = "quay.io/coreos/bootkube:v0.8.1"
     calico                       = "quay.io/calico/node:v2.6.1"
     calico_cni                   = "quay.io/calico/cni:v1.11.0"
-    console                      = "quay.io/coreos/tectonic-console:v6.0.1"
+    console                      = "quay.io/coreos/tectonic-console:v6.0.5"
     error_server                 = "quay.io/coreos/tectonic-error-server:1.1"
     etcd                         = "quay.io/coreos/etcd:v3.1.8"
     etcd_operator                = "quay.io/coreos/etcd-operator:v0.5.0"

--- a/config.tf
+++ b/config.tf
@@ -88,7 +88,7 @@ variable "tectonic_container_images" {
     kubednsmasq                  = "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.8"
     kubedns_sidecar              = "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.8"
     kube_version                 = "quay.io/coreos/kube-version:0.1.0"
-    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.9.6-kvo.3"
+    kube_version_operator        = "quay.io/coreos/kube-version-operator:v1.9.6-kvo.4"
     node_agent                   = "quay.io/coreos/node-agent:cd69b4a0f65b0d3a3b30edfce3bb184fd2a22c26"
     pod_checkpointer             = "quay.io/coreos/pod-checkpointer:e22cc0e3714378de92f45326474874eb602ca0ac"
     stats_emitter                = "quay.io/coreos/tectonic-stats:6e882361357fe4b773adbf279cddf48cb50164c1"


### PR DESCRIPTION
Cherry-pick of #3194
