### PR TITLE
modules: eliminate bootstrap cleanup race

### DIFF
--- a/modules/ignition/resources/services/rm-assets.service
+++ b/modules/ignition/resources/services/rm-assets.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Clean up install assets from S3
 ConditionPathExists=/opt/tectonic
+After=bootkube.service tectonic.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This PR eliminates a race where sometimes the /opt/tectonic cleanup occurred before the bootkube and tectonic services had finished, causing bootstrapping to fail. This PR reverts a change from b2e0bcf2f26141706cbf96e508afd14ee351af7c to ensure correctness since the rm-assets service once again depends on bootkube and tectonic.

Without this change, sometimes the bootstrap node will fail to bootstrap the cluster and no containers will  run.

cc @enxebre @yifan-gu 