### PR TITLE
tectonic-alm-operator: update deployment for newer x-operator base image

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -27,9 +27,8 @@ spec:
       containers:
       - name: tectonic-alm-operator
         image: ${tectonic_alm_operator_image}
-        command:
-        - /app/x-operator/cmd/xoperator/tectonic-x-operator.binary
-        - '--operator-name=tectonic-alm-operator'
-        - '--appversion-name=tectonic-alm-operator'
-        - '--v=2'
-        - '-manifest-dir=/manifests'
+        args:
+        - --manifest-dir=/manifests
+        - --operator-name=tectonic-alm-operator
+        - --appversion-name=tectonic-alm-operator
+        - --v=2


### PR DESCRIPTION
This fixes tectonic-alm-operator crashlooping