### PR TITLE
modulus,steps: enable existing vpc

### DIFF
--- a/modules/dns/route53/variables.tf
+++ b/modules/dns/route53/variables.tf
@@ -53,7 +53,7 @@ variable "api_ip_addresses" {
   type        = "list"
 }
 
-variable "tectonic_extra_tags" {
+variable "extra_tags" {
   type        = "map"
   description = "(optional) Extra tags to be applied to created resources."
 }
@@ -70,7 +70,7 @@ EOF
   default = false
 }
 
-variable "tectonic_external_vpc_id" {
+variable "external_vpc_id" {
   type = "string"
 
   description = <<EOF
@@ -81,28 +81,23 @@ Example: `vpc-123456`
 EOF
 }
 
-variable "tectonic_private_endpoints" {
+variable "private_endpoints" {
   description = <<EOF
 (optional) If set to true, create private-facing ingress resources (ELB, A-records).
 If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
 EOF
 }
 
-variable "tectonic_public_endpoints" {
+variable "public_endpoints" {
   description = <<EOF
 (optional) If set to true, create public-facing ingress resources (ELB, A-records).
 If set to false, no public-facing ingress resources will be created.
 EOF
 }
 
-variable "tectonic_external_private_zone" {
-  description = <<EOF
-(optional) If set, the given Route53 zone ID will be used as the internal (private) zone.
-This zone will be used to create etcd DNS records as well as internal API and internal Ingress records.
-If set, no additional private zone will be created.
-
-# Example: `"Z1ILINNUJGTAO1"`
-EOF
+variable "private_zone_id" {
+  description = "Route53 Private Zone ID"
+  type        = "string"
 }
 
 variable "api_external_elb_dns_name" {

--- a/steps/etcd/aws/inputs.tf
+++ b/steps/etcd/aws/inputs.tf
@@ -20,5 +20,5 @@ locals {
   sg_id              = "${data.terraform_remote_state.topology.etcd_sg_id}"
   subnet_ids_workers = "${data.terraform_remote_state.topology.subnet_ids_workers}"
   s3_bucket          = "${data.terraform_remote_state.topology.s3_bucket}"
-  private_zone_id    = "${data.terraform_remote_state.topology.private_zone_id}"
+  private_zone_id    = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : data.terraform_remote_state.topology.private_zone_id}"
 }

--- a/steps/tnc_dns/aws/inputs.tf
+++ b/steps/tnc_dns/aws/inputs.tf
@@ -7,7 +7,7 @@ data "terraform_remote_state" "topology" {
 }
 
 locals {
-  private_zone_id           = "${data.terraform_remote_state.topology.private_zone_id}"
+  private_zone_id           = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : data.terraform_remote_state.topology.private_zone_id}"
   tnc_s3_bucket_domain_name = "${data.terraform_remote_state.topology.tnc_s3_bucket_domain_name}"
   tnc_elb_dns_name          = "${data.terraform_remote_state.topology.tnc_elb_dns_name}"
   tnc_elb_zone_id           = "${data.terraform_remote_state.topology.tnc_elb_zone_id}"

--- a/steps/topology/aws/main.tf
+++ b/steps/topology/aws/main.tf
@@ -20,6 +20,7 @@ module "container_linux" {
 
 # TNC
 resource "aws_route53_zone" "tectonic_int" {
+  count         = "${var.tectonic_aws_private_endpoints ? "${var.tectonic_aws_external_private_zone == "" ? 1 : 0 }" : 0}"
   vpc_id        = "${module.vpc.vpc_id}"
   name          = "${var.tectonic_base_domain}"
   force_destroy = true
@@ -56,21 +57,21 @@ module "vpc" {
 module "dns" {
   source = "../../../modules/dns/route53"
 
-  api_external_elb_dns_name      = "${module.vpc.aws_api_external_dns_name}"
-  api_external_elb_zone_id       = "${module.vpc.aws_elb_api_external_zone_id}"
-  api_internal_elb_dns_name      = "${module.vpc.aws_api_internal_dns_name}"
-  api_internal_elb_zone_id       = "${module.vpc.aws_elb_api_internal_zone_id}"
-  api_ip_addresses               = "${module.vpc.aws_lbs}"
-  base_domain                    = "${var.tectonic_base_domain}"
-  cluster_id                     = "${var.tectonic_cluster_id}"
-  cluster_name                   = "${var.tectonic_cluster_name}"
-  console_elb_dns_name           = "${module.vpc.aws_console_dns_name}"
-  console_elb_zone_id            = "${module.vpc.aws_elb_console_zone_id}"
-  elb_alias_enabled              = true
-  master_count                   = "${var.tectonic_master_count}"
-  tectonic_external_private_zone = "${join("", aws_route53_zone.tectonic_int.*.zone_id)}"
-  tectonic_external_vpc_id       = "${module.vpc.vpc_id}"
-  tectonic_extra_tags            = "${var.tectonic_aws_extra_tags}"
-  tectonic_private_endpoints     = "${var.tectonic_aws_private_endpoints}"
-  tectonic_public_endpoints      = "${var.tectonic_aws_public_endpoints}"
+  api_external_elb_dns_name = "${module.vpc.aws_api_external_dns_name}"
+  api_external_elb_zone_id  = "${module.vpc.aws_elb_api_external_zone_id}"
+  api_internal_elb_dns_name = "${module.vpc.aws_api_internal_dns_name}"
+  api_internal_elb_zone_id  = "${module.vpc.aws_elb_api_internal_zone_id}"
+  api_ip_addresses          = "${module.vpc.aws_lbs}"
+  base_domain               = "${var.tectonic_base_domain}"
+  cluster_id                = "${var.tectonic_cluster_id}"
+  cluster_name              = "${var.tectonic_cluster_name}"
+  console_elb_dns_name      = "${module.vpc.aws_console_dns_name}"
+  console_elb_zone_id       = "${module.vpc.aws_elb_console_zone_id}"
+  elb_alias_enabled         = true
+  master_count              = "${var.tectonic_master_count}"
+  private_zone_id           = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : join("", aws_route53_zone.tectonic_int.*.zone_id)}"
+  external_vpc_id           = "${module.vpc.vpc_id}"
+  extra_tags                = "${var.tectonic_aws_extra_tags}"
+  private_endpoints         = "${var.tectonic_aws_private_endpoints}"
+  public_endpoints          = "${var.tectonic_aws_public_endpoints}"
 }

--- a/steps/topology/aws/outputs.tf
+++ b/steps/topology/aws/outputs.tf
@@ -31,7 +31,7 @@ output "worker_sg_id" {
 
 # TNC
 output "private_zone_id" {
-  value = "${aws_route53_zone.tectonic_int.id}"
+  value = "${join("", aws_route53_zone.tectonic_int.*.zone_id)}"
 }
 
 output "tnc_elb_dns_name" {


### PR DESCRIPTION
This commit enables the existing VPC functionality that was already
built into the installer by fixing several bugs related to the
processing of AWS private zone IDs.

Thanks to @yifan-gu's recent changes in https://github.com/coreos/tectonic-installer/pull/3219.

cc @yifan-gu @enxebre 