### PR TITLE
Cherry-pick of #3229 from 1.9.6 to track-1

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -27,8 +27,9 @@ spec:
       containers:
       - name: tectonic-alm-operator
         image: ${tectonic_alm_operator_image}
-        args:
-        - --manifest-dir=/manifests
-        - --operator-name=tectonic-alm-operator
-        - --appversion-name=tectonic-alm-operator
-        - --v=2
+        command:
+        - /app/x-operator/cmd/xoperator/xoperator
+        - '--operator-name=tectonic-alm-operator'
+        - '--appversion-name=tectonic-alm-operator'
+        - '--v=2'
+        - '-manifest-dir=/manifests'


### PR DESCRIPTION
Since TCO is using 2-way merge for the containers in the manifest,
using args alone will not remove the old deployment's command,
thus new deployment spec end up with both command and args,
which will causes error during the upgrade.