### PR TITLE
 installer/pkg/config: validate cluster name

### DIFF
--- a/installer/pkg/config/BUILD.bazel
+++ b/installer/pkg/config/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//installer/pkg/validate:go_default_library",
         "//installer/vendor/github.com/coreos/ignition/config/v2_0:go_default_library",
         "//installer/vendor/github.com/coreos/tectonic-config/config/tectonic-network:go_default_library",
+        "//installer/vendor/github.com/Sirupsen/logrus:go_default_library",
         "//installer/vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )

--- a/installer/pkg/workflow/BUILD.bazel
+++ b/installer/pkg/workflow/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
     deps = [
         "//installer/pkg/config:go_default_library",
         "//installer/pkg/config-generator:go_default_library",
-        "//installer/vendor/github.com/Sirupsen/logrus:go_default_library",
         "//installer/vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )

--- a/installer/pkg/workflow/init.go
+++ b/installer/pkg/workflow/init.go
@@ -72,34 +72,38 @@ func generateTerraformVariablesStep(m *metadata) error {
 func prepareWorspaceStep(m *metadata) error {
 	dir, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("Failed to get current directory because: %s", err)
+		return fmt.Errorf("failed to get current directory: %v", err)
 	}
 
 	if m.configFilePath == "" {
-		return errors.New("no configFilePath given for preparing the workspace")
+		return errors.New("a path to a config file is required")
 	}
 
 	// load initial cluster config to get cluster.Name
-	clusterName, err := getClusterNameFromConfig(m.configFilePath)
+	cluster, err := readClusterConfig(m.configFilePath, "")
 	if err != nil {
-		return fmt.Errorf("failed to get cluster name for config file %s: %v", m.configFilePath, err)
+		return fmt.Errorf("failed to get configuration from file %q: %v", m.configFilePath, err)
+	}
+
+	if err := cluster.ValidateAndLog(); err != nil {
+		return err
 	}
 
 	// generate clusterDir folder
-	clusterDir := filepath.Join(dir, *clusterName)
+	clusterDir := filepath.Join(dir, cluster.Name)
 	m.clusterDir = clusterDir
 	if stat, err := os.Stat(clusterDir); err == nil && stat.IsDir() {
-		return fmt.Errorf("cluster directory already exists at %s", clusterDir)
+		return fmt.Errorf("cluster directory already exists at %q", clusterDir)
 	}
 
 	if err := os.MkdirAll(clusterDir, os.ModeDir|0755); err != nil {
-		return fmt.Errorf("failed to create cluster directory at %s", clusterDir)
+		return fmt.Errorf("failed to create cluster directory at %q", clusterDir)
 	}
 
 	// put config file under the clusterDir folder
 	configFilePath := filepath.Join(clusterDir, configFileName)
 	if err := copyFile(m.configFilePath, configFilePath); err != nil {
-		return fmt.Errorf("failed to create cluster config at %s: %v", clusterDir, err)
+		return fmt.Errorf("failed to create cluster config at %q: %v", clusterDir, err)
 	}
 
 	// generate the internal config file under the clusterDir folder

--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/coreos/tectonic-installer/installer/pkg/config"
 	configgenerator "github.com/coreos/tectonic-installer/installer/pkg/config-generator"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 const (
@@ -149,17 +147,6 @@ func readClusterConfig(configFilePath string, internalFilePath string) (*config.
 	return cfg, nil
 }
 
-func getClusterNameFromConfig(configFilePath string) (*string, error) {
-	if configFilePath == "" {
-		return nil, errors.New("no configFilePath given for getting cluster Name")
-	}
-	cluster, err := readClusterConfig(configFilePath, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to read cluster config for while getting cluster name: %v", err)
-	}
-	return &cluster.Name, nil
-}
-
 func readClusterConfigStep(m *metadata) error {
 	if m.clusterDir == "" {
 		errors.New("no cluster dir given for reading config")
@@ -172,12 +159,8 @@ func readClusterConfigStep(m *metadata) error {
 		return err
 	}
 
-	if errs := cluster.Validate(); len(errs) != 0 {
-		log.Errorf("Found %d errors in the cluster definition:", len(errs))
-		for i, err := range errs {
-			log.Errorf("error %d: %v", i+1, err)
-		}
-		return fmt.Errorf("found %d cluster definition errors", len(errs))
+	if err := cluster.ValidateAndLog(); err != nil {
+		return err
 	}
 
 	m.cluster = *cluster


### PR DESCRIPTION
This commit adds cluster name validation and also ensures that running `tectonic init` performs config validation.

Fixes: INST-991

Should be merged AFTER #3233, as the first commit is just that PR
cc @enxebre @alexsomesan 