### PR TITLE
Remove public resources in private VPC deployment

### DIFF
--- a/installer/pkg/config/aws/aws.go
+++ b/installer/pkg/config/aws/aws.go
@@ -10,9 +10,9 @@ type AWS struct {
 	ExtraTags                 map[string]string `json:"tectonic_aws_extra_tags,omitempty" yaml:"extraTags,omitempty"`
 	InstallerRole             string            `json:"tectonic_aws_installer_role,omitempty" yaml:"installerRole,omitempty"`
 	Master                    `json:",inline" yaml:"master,omitempty"`
-	PrivateEndpoints          bool   `json:"tectonic_aws_private_endpoints,omitempty" yaml:"privateEndpoints,omitempty"`
+	PrivateEndpoints          *bool   `json:"tectonic_aws_private_endpoints,omitempty" yaml:"privateEndpoints,omitempty"`
 	Profile                   string `json:"tectonic_aws_profile,omitempty" yaml:"profile,omitempty"`
-	PublicEndpoints           bool   `json:"tectonic_aws_public_endpoints,omitempty" yaml:"publicEndpoints,omitempty"`
+	PublicEndpoints           *bool   `json:"tectonic_aws_public_endpoints,omitempty" yaml:"publicEndpoints,omitempty"`
 	Region                    string `json:"tectonic_aws_region,omitempty" yaml:"region,omitempty"`
 	SSHKey                    string `json:"tectonic_aws_ssh_key,omitempty" yaml:"sshKey,omitempty"`
 	VPCCIDRBlock              string `json:"tectonic_aws_vpc_cidr_block,omitempty" yaml:"vpcCIDRBlock,omitempty"`


### PR DESCRIPTION
False values for booleans are omitted when marshaling JSON in golang.
https://github.com/golang/go/issues/13284

fixes INST-1083