### PR TITLE
Bazel output

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
-startup --output_base build
+startup --output_base .build
 build --color=yes --workspace_status_command "${PWD}/buildvars.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,13 @@ tectonic-*.tar.gz
 tectonic-license.txt
 terraform.tfstate*
 terraform.tfvars
-build/
 bin/
 bin_test/
 matchbox/
 /contrib/govcloud/vpn.conf
 
 # Bazel
+.build/
 bazel-bin
 bazel-out
 bazel-genfiles


### PR DESCRIPTION
Fix INST-1061.
Change bazel ouput to .build so bazel subsequent runs will ignore the hidden folder