### PR TITLE
examples: add admin section to aws config

### DIFF
--- a/examples/tectonic.aws.yaml
+++ b/examples/tectonic.aws.yaml
@@ -1,3 +1,6 @@
+admin:
+  email: "a@b.c"
+  password: "verysecure"
 aws:
   # (optional) Unique name under which the Amazon S3 bucket will be created. Bucket name must start with a lower case name and is limited to 63 characters.
   # The Tectonic Installer uses the bucket to store tectonic assets and kubeconfig.


### PR DESCRIPTION
Without this, tectonic.service on the master will fail due to kubectl
validation errors on rbac/binding-admin.yaml.

I wasted a pretty amazing amount of time due to this omission.
