### PR TITLE
*: remove unused s3 bucket name option

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -7,7 +7,6 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
 | tectonic_autoscaling_group_extra_tags | (optional) Extra AWS tags to be applied to created autoscaling group resources. This is a list of maps having the keys `key`, `value` and `propagate_at_launch`.<br><br>Example: `[ { key = "foo", value = "bar", propagate_at_launch = true } ]` | list | `<list>` |
-| tectonic_aws_assets_s3_bucket_name | (optional) Unique name under which the Amazon S3 bucket will be created. Bucket name must start with a lower case name and is limited to 63 characters. The Tectonic Installer uses the bucket to store tectonic assets and kubeconfig. If name is not provided the installer will construct the name using "tectonic_cluster_name", current AWS region and "tectonic_base_domain" | string | `` |
 | tectonic_aws_config_version | (internal) This declares the version of the AWS configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
 | tectonic_aws_ec2_ami_override | (optional) AMI override for all nodes. Example: `ami-foobar123`. | string | `` |
 | tectonic_aws_etcd_ec2_type | Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance | string | `t2.medium` |

--- a/installer/pkg/config/aws/aws.go
+++ b/installer/pkg/config/aws/aws.go
@@ -2,7 +2,6 @@ package aws
 
 // AWS converts AWS related config.
 type AWS struct {
-	AssetsS3BucketName        string              `json:"tectonic_aws_assets_s3_bucket_name,omitempty" yaml:"assetsS3BucketName,omitempty"`
 	AutoScalingGroupExtraTags []map[string]string `json:"tectonic_autoscaling_group_extra_tags,omitempty" yaml:"autoScalingGroupExtraTags,omitempty"`
 	EC2AMIOverride            string              `json:"tectonic_aws_ec2_ami_override,omitempty" yaml:"ec2AMIOverride,omitempty"`
 	Etcd                      `json:",inline" yaml:"etcd,omitempty"`
@@ -10,9 +9,9 @@ type AWS struct {
 	ExtraTags                 map[string]string `json:"tectonic_aws_extra_tags,omitempty" yaml:"extraTags,omitempty"`
 	InstallerRole             string            `json:"tectonic_aws_installer_role,omitempty" yaml:"installerRole,omitempty"`
 	Master                    `json:",inline" yaml:"master,omitempty"`
-	PrivateEndpoints          *bool   `json:"tectonic_aws_private_endpoints,omitempty" yaml:"privateEndpoints,omitempty"`
+	PrivateEndpoints          *bool  `json:"tectonic_aws_private_endpoints,omitempty" yaml:"privateEndpoints,omitempty"`
 	Profile                   string `json:"tectonic_aws_profile,omitempty" yaml:"profile,omitempty"`
-	PublicEndpoints           *bool   `json:"tectonic_aws_public_endpoints,omitempty" yaml:"publicEndpoints,omitempty"`
+	PublicEndpoints           *bool  `json:"tectonic_aws_public_endpoints,omitempty" yaml:"publicEndpoints,omitempty"`
 	Region                    string `json:"tectonic_aws_region,omitempty" yaml:"region,omitempty"`
 	SSHKey                    string `json:"tectonic_aws_ssh_key,omitempty" yaml:"sshKey,omitempty"`
 	VPCCIDRBlock              string `json:"tectonic_aws_vpc_cidr_block,omitempty" yaml:"vpcCIDRBlock,omitempty"`

--- a/steps/variables-aws.tf
+++ b/steps/variables-aws.tf
@@ -60,17 +60,6 @@ EOF
   default = []
 }
 
-variable "tectonic_aws_assets_s3_bucket_name" {
-  type    = "string"
-  default = ""
-
-  description = <<EOF
-(optional) Unique name under which the Amazon S3 bucket will be created. Bucket name must start with a lower case name and is limited to 63 characters.
-The Tectonic Installer uses the bucket to store tectonic assets and kubeconfig.
-If name is not provided the installer will construct the name using "tectonic_cluster_name", current AWS region and "tectonic_base_domain"
-EOF
-}
-
 variable "tectonic_aws_master_extra_sg_ids" {
   description = <<EOF
 (optional) List of additional security group IDs for master nodes.


### PR DESCRIPTION
Now that assets are no longer distributed using an assets bucket, we can
eliminate this option, which is not even used today.

Part of: INST-974