### PR TITLE
fix docs for containerized builds on systems with SELinux enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ These instructions can be used for AWS:
 
     *Note*: the project can optionally be built without installing Bazel, provided Docker is installed:
     ```shell
-    docker run --rm -v $PWD:$PWD -w $PWD quay.io/coreos/tectonic-builder:bazel-v0.3 bazel --output_base=.cache build tarball
+    docker run --rm -v $PWD:$PWD:Z -w $PWD quay.io/coreos/tectonic-builder:bazel-v0.3 bazel --output_base=.cache build tarball
     ```
 
 2. Extract the tarball


### PR DESCRIPTION
This shouldn't cause any problems on systems without SELinux, but will allow to get rid of permission errors on systems like Fedora 28.

Currently command

```
docker run --rm -v $PWD:$PWD -w $PWD quay.io/coreos/tectonic-builder:bazel-v0.3 bazel --output_base=.cache build tarball
```

Causes errors similar to this one:
```
Error: Output base directory '/home/paulfantom/Development/CoreOS/tectonic-installer/.cache' could not be created: (error: 13): Permission denied
```