### PR TITLE
inst-1093: fix rm-assets race conditions

### DIFF
--- a/modules/ignition/resources/services/rm-assets.service
+++ b/modules/ignition/resources/services/rm-assets.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Clean up install assets from S3
 ConditionPathExists=/opt/tectonic
+Requires=tectonic.service
 After=bootkube.service tectonic.service
 
 [Service]


### PR DESCRIPTION
this PR fixes inst-1093 rm-assets service runs even after tectonic.service failed.