### PR TITLE
expect 3 etcd nodes instead of 0

### DIFF
--- a/examples/tectonic.aws.yaml
+++ b/examples/tectonic.aws.yaml
@@ -322,7 +322,7 @@ nodePools:
     # If set to zero, the count of etcd nodes will be determined automatically.
     #
     # Note: This is not supported on bare metal.
-  - count: 0
+  - count: 3
     name: etcd
 
     # The number of master nodes to be created.


### PR DESCRIPTION
Current example aws deployment expects 0 etcd nodes which causes failure to provision cluster. Change to 3, so it will work as expected.