### PR TITLE
*: collapse two endpoints booleans into one field

### DIFF
--- a/Documentation/variables/aws.md
+++ b/Documentation/variables/aws.md
@@ -9,6 +9,7 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_autoscaling_group_extra_tags | (optional) Extra AWS tags to be applied to created autoscaling group resources. This is a list of maps having the keys `key`, `value` and `propagate_at_launch`.<br><br>Example: `[ { key = "foo", value = "bar", propagate_at_launch = true } ]` | list | `<list>` |
 | tectonic_aws_config_version | (internal) This declares the version of the AWS configuration variables. It has no impact on generated assets but declares the version contract of the configuration. | string | `1.0` |
 | tectonic_aws_ec2_ami_override | (optional) AMI override for all nodes. Example: `ami-foobar123`. | string | `` |
+| tectonic_aws_endpoints | (optional) If set to "all", the default, then both public and private ingress resources (ELB, A-records) will be created. If set to "private", then only private-facing ingress resources (ELB, A-records) will be created. No public-facing ingress resources will be created. If set to "public", then only public-facing ingress resources (ELB, A-records) will be created. No private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone. | string | `all` |
 | tectonic_aws_etcd_ec2_type | Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance | string | `t2.medium` |
 | tectonic_aws_etcd_extra_sg_ids | (optional) List of additional security group IDs for etcd nodes.<br><br>Example: `["sg-51530134", "sg-b253d7cc"]` | list | `<list>` |
 | tectonic_aws_etcd_iam_role_name | (optional) Name of IAM role to use for the instance profiles of etcd nodes. The name is also the last part of a role's ARN.<br><br>Example:  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer  * Role Name = tectonic-installer | string | `` |
@@ -28,9 +29,8 @@ This document gives an overview of variables used in the AWS platform of the Tec
 | tectonic_aws_master_root_volume_iops | The amount of provisioned IOPS for the root block device of master nodes. Ignored if the volume type is not io1. | string | `100` |
 | tectonic_aws_master_root_volume_size | The size of the volume in gigabytes for the root block device of master nodes. | string | `30` |
 | tectonic_aws_master_root_volume_type | The type of volume for the root block device of master nodes. | string | `gp2` |
-| tectonic_aws_private_endpoints | (optional) If set to true, create private-facing ingress resources (ELB, A-records). If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone. | string | `true` |
+
 | tectonic_aws_profile | (optional) This declares the AWS credentials profile to use. | string | `default` |
-| tectonic_aws_public_endpoints | (optional) If set to true, create public-facing ingress resources (ELB, A-records). If set to false, no public-facing ingress resources will be created. | string | `true` |
 | tectonic_aws_region | The target AWS region for the cluster. | string | `eu-west-1` |
 | tectonic_aws_ssh_key | Name of an SSH key located within the AWS region. Example: coreos-user. | string | - |
 | tectonic_aws_vpc_cidr_block | Block of IP addresses used by the VPC. This should not overlap with any other networks, such as a private datacenter connected via Direct Connect. | string | `10.0.0.0/16` |

--- a/installer/pkg/config/aws/aws.go
+++ b/installer/pkg/config/aws/aws.go
@@ -1,9 +1,22 @@
 package aws
 
+// Endpoints is the type of the AWS endpoints.
+type Endpoints string
+
+const (
+	// EndpointsAll represents the configuration for using both private and public endpoints.
+	EndpointsAll Endpoints = "all"
+	// EndpointsPrivate represents the configuration for using only private endpoints.
+	EndpointsPrivate Endpoints = "private"
+	// EndpointsPublic represents the configuration for using only public endpoints.
+	EndpointsPublic Endpoints = "public"
+)
+
 // AWS converts AWS related config.
 type AWS struct {
 	AutoScalingGroupExtraTags []map[string]string `json:"tectonic_autoscaling_group_extra_tags,omitempty" yaml:"autoScalingGroupExtraTags,omitempty"`
 	EC2AMIOverride            string              `json:"tectonic_aws_ec2_ami_override,omitempty" yaml:"ec2AMIOverride,omitempty"`
+	Endpoints                 Endpoints           `json:"tectonic_aws_endpoints,omitempty" yaml:"endpoints,omitempty"`
 	Etcd                      `json:",inline" yaml:"etcd,omitempty"`
 	External                  `json:",inline" yaml:"external,omitempty"`
 	ExtraTags                 map[string]string `json:"tectonic_aws_extra_tags,omitempty" yaml:"extraTags,omitempty"`

--- a/installer/pkg/config/cluster.go
+++ b/installer/pkg/config/cluster.go
@@ -28,12 +28,15 @@ const (
 	// IgnitionEtcd is the relative path to the ign etcd cfg from the tf working directory
 	IgnitionEtcd = "ignition-etcd.ign"
 	// PlatformAWS is the platform for a cluster launched on AWS.
-	PlatformAWS = "aws"
+	PlatformAWS Platform = "aws"
 	// PlatformLibvirt is the platform for a cluster launched on libvirt.
-	PlatformLibvirt = "libvirt"
+	PlatformLibvirt Platform = "libvirt"
 )
 
 var defaultCluster = Cluster{
+	AWS: aws.AWS{
+		Endpoints: aws.EndpointsAll,
+	},
 	Networking: Networking{
 		MTU:         "1480",
 		PodCIDR:     "10.2.0.0/16",

--- a/installer/pkg/config/types.go
+++ b/installer/pkg/config/types.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/coreos/tectonic-config/config/tectonic-network"
+
 // Admin converts admin related config.
 type Admin struct {
 	Email    string `json:"tectonic_admin_email" yaml:"email,omitempty"`
@@ -61,10 +63,10 @@ type Master struct {
 
 // Networking converts networking related config.
 type Networking struct {
-	Type        string `json:"tectonic_networking,omitempty" yaml:"type,omitempty"`
-	MTU         string `json:"-" yaml:"mtu,omitempty"`
-	ServiceCIDR string `json:"tectonic_service_cidr,omitempty" yaml:"serviceCIDR,omitempty"`
-	PodCIDR     string `json:"tectonic_cluster_cidr,omitempty" yaml:"podCIDR,omitempty"`
+	Type        tectonicnetwork.NetworkType `json:"tectonic_networking,omitempty" yaml:"type,omitempty"`
+	MTU         string                      `json:"-" yaml:"mtu,omitempty"`
+	ServiceCIDR string                      `json:"tectonic_service_cidr,omitempty" yaml:"serviceCIDR,omitempty"`
+	PodCIDR     string                      `json:"tectonic_cluster_cidr,omitempty" yaml:"podCIDR,omitempty"`
 }
 
 // Worker converts worker related config.

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -13,6 +13,7 @@
   "tectonic_platform": "AWS",
   "tectonic_tls_validity_period": 26280,
   "tectonic_worker_count": 3,
+  "tectonic_aws_endpoints": "all",
   "tectonic_aws_etcd_ec2_type": "m4.large",
   "tectonic_aws_etcd_root_volume_iops": 100,
   "tectonic_aws_etcd_root_volume_size": 30,

--- a/modules/aws/vpc/master-elb.tf
+++ b/modules/aws/vpc/master-elb.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "tnc" {
-  count           = "${var.private_master_endpoints}"
+  count           = "${var.private_master_endpoints ? 1 : 0}"
   name            = "${var.cluster_name}-tnc"
   subnets         = ["${local.master_subnet_ids}"]
   internal        = true
@@ -32,7 +32,7 @@ resource "aws_elb" "tnc" {
 }
 
 resource "aws_elb" "api_internal" {
-  count           = "${var.private_master_endpoints}"
+  count           = "${var.private_master_endpoints ? 1 : 0}"
   name            = "${var.cluster_name}-int"
   subnets         = ["${local.master_subnet_ids}"]
   internal        = true
@@ -65,7 +65,7 @@ resource "aws_elb" "api_internal" {
 }
 
 resource "aws_elb" "api_external" {
-  count           = "${var.public_master_endpoints}"
+  count           = "${var.public_master_endpoints ? 1 : 0}"
   name            = "${var.cluster_name}-ext"
   subnets         = ["${local.master_subnet_ids}"]
   internal        = false

--- a/modules/dns/route53/tectonic.tf
+++ b/modules/dns/route53/tectonic.tf
@@ -1,3 +1,8 @@
+locals {
+  public_endpoints_count  = "${var.public_endpoints ? 1 : 0}"
+  private_endpoints_count = "${var.private_endpoints ? 1 : 0}"
+}
+
 data "aws_route53_zone" "tectonic" {
   name = "${var.base_domain}"
 }
@@ -20,7 +25,7 @@ resource "aws_route53_record" "tectonic_api" {
 }
 
 resource "aws_route53_record" "tectonic_api_external" {
-  count   = "${var.elb_alias_enabled ? var.public_endpoints : 0}"
+  count   = "${var.elb_alias_enabled ? local.public_endpoints_count : 0}"
   zone_id = "${local.public_zone_id}"
   name    = "${var.cluster_name}-api.${var.base_domain}"
   type    = "A"
@@ -33,7 +38,7 @@ resource "aws_route53_record" "tectonic_api_external" {
 }
 
 resource "aws_route53_record" "tectonic_api_internal" {
-  count   = "${var.elb_alias_enabled ? var.private_endpoints : 0}"
+  count   = "${var.elb_alias_enabled ? local.private_endpoints_count : 0}"
   zone_id = "${var.private_zone_id}"
   name    = "${var.cluster_name}-api.${var.base_domain}"
   type    = "A"
@@ -55,7 +60,7 @@ resource "aws_route53_record" "tectonic-console" {
 }
 
 resource "aws_route53_record" "tectonic_ingress_public" {
-  count   = "${var.elb_alias_enabled ? var.public_endpoints : 0}"
+  count   = "${var.elb_alias_enabled ? local.public_endpoints_count : 0}"
   zone_id = "${local.public_zone_id}"
   name    = "${var.cluster_name}.${var.base_domain}"
   type    = "A"
@@ -68,7 +73,7 @@ resource "aws_route53_record" "tectonic_ingress_public" {
 }
 
 resource "aws_route53_record" "tectonic_ingress_private" {
-  count   = "${var.elb_alias_enabled ? var.private_endpoints : 0}"
+  count   = "${var.elb_alias_enabled ? local.private_endpoints_count : 0}"
   zone_id = "${var.private_zone_id}"
   name    = "${var.cluster_name}.${var.base_domain}"
   type    = "A"

--- a/modules/dns/route53/variables.tf
+++ b/modules/dns/route53/variables.tf
@@ -55,7 +55,7 @@ variable "api_ip_addresses" {
 
 variable "extra_tags" {
   type        = "map"
-  description = "(optional) Extra tags to be applied to created resources."
+  description = "Extra tags to be applied to created resources."
 }
 
 // AWS specific internal zone variables
@@ -74,7 +74,7 @@ variable "external_vpc_id" {
   type = "string"
 
   description = <<EOF
-(optional) ID of an existing VPC to launch nodes into.
+ID of an existing VPC to launch nodes into.
 If unset a new VPC is created.
 
 Example: `vpc-123456`
@@ -83,14 +83,14 @@ EOF
 
 variable "private_endpoints" {
   description = <<EOF
-(optional) If set to true, create private-facing ingress resources (ELB, A-records).
+If set to true, create private-facing ingress resources (ELB, A-records).
 If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
 EOF
 }
 
 variable "public_endpoints" {
   description = <<EOF
-(optional) If set to true, create public-facing ingress resources (ELB, A-records).
+If set to true, create public-facing ingress resources (ELB, A-records).
 If set to false, no public-facing ingress resources will be created.
 EOF
 }

--- a/steps/masters/aws/main.tf
+++ b/steps/masters/aws/main.tf
@@ -1,3 +1,8 @@
+locals {
+  private_endpoints = "${var.tectonic_aws_endpoints == "public" ? false : true}"
+  public_endpoints  = "${var.tectonic_aws_endpoints == "private" ? false : true}"
+}
+
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
   profile = "${var.tectonic_aws_profile}"
@@ -32,8 +37,8 @@ module "masters" {
   instance_count               = "${var.tectonic_bootstrap == "true" ? 1 : var.tectonic_master_count}"
   master_iam_role              = "${var.tectonic_aws_master_iam_role_name}"
   master_sg_ids                = "${concat(var.tectonic_aws_master_extra_sg_ids, list(local.sg_id))}"
-  private_endpoints            = "${var.tectonic_aws_private_endpoints}"
-  public_endpoints             = "${var.tectonic_aws_public_endpoints}"
+  private_endpoints            = "${local.private_endpoints}"
+  public_endpoints             = "${local.public_endpoints}"
   root_volume_iops             = "${var.tectonic_aws_master_root_volume_iops}"
   root_volume_size             = "${var.tectonic_aws_master_root_volume_size}"
   root_volume_type             = "${var.tectonic_aws_master_root_volume_type}"

--- a/steps/topology/aws/main.tf
+++ b/steps/topology/aws/main.tf
@@ -1,3 +1,8 @@
+locals {
+  private_endpoints = "${var.tectonic_aws_endpoints == "public" ? false : true}"
+  public_endpoints  = "${var.tectonic_aws_endpoints == "private" ? false : true}"
+}
+
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
   profile = "${var.tectonic_aws_profile}"
@@ -20,7 +25,7 @@ module "container_linux" {
 
 # TNC
 resource "aws_route53_zone" "tectonic_int" {
-  count         = "${var.tectonic_aws_private_endpoints ? "${var.tectonic_aws_external_private_zone == "" ? 1 : 0 }" : 0}"
+  count         = "${local.private_endpoints ? "${var.tectonic_aws_external_private_zone == "" ? 1 : 0 }" : 0}"
   vpc_id        = "${module.vpc.vpc_id}"
   name          = "${var.tectonic_base_domain}"
   force_destroy = true
@@ -50,8 +55,8 @@ module "vpc" {
   new_master_subnet_configs = "${var.tectonic_aws_master_custom_subnets}"
   new_worker_subnet_configs = "${var.tectonic_aws_worker_custom_subnets}"
 
-  private_master_endpoints = "${var.tectonic_aws_private_endpoints}"
-  public_master_endpoints  = "${var.tectonic_aws_public_endpoints}"
+  private_master_endpoints = "${local.private_endpoints}"
+  public_master_endpoints  = "${local.public_endpoints}"
 }
 
 module "dns" {
@@ -72,6 +77,6 @@ module "dns" {
   private_zone_id           = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : join("", aws_route53_zone.tectonic_int.*.zone_id)}"
   external_vpc_id           = "${module.vpc.vpc_id}"
   extra_tags                = "${var.tectonic_aws_extra_tags}"
-  private_endpoints         = "${var.tectonic_aws_private_endpoints}"
-  public_endpoints          = "${var.tectonic_aws_public_endpoints}"
+  private_endpoints         = "${local.private_endpoints}"
+  public_endpoints          = "${local.public_endpoints}"
 }

--- a/steps/variables-aws.tf
+++ b/steps/variables-aws.tf
@@ -105,21 +105,13 @@ EOF
   default = ""
 }
 
-variable "tectonic_aws_private_endpoints" {
-  default = true
+variable "tectonic_aws_endpoints" {
+  default = "all"
 
   description = <<EOF
-(optional) If set to true, create private-facing ingress resources (ELB, A-records).
-If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
-EOF
-}
-
-variable "tectonic_aws_public_endpoints" {
-  default = true
-
-  description = <<EOF
-(optional) If set to true, create public-facing ingress resources (ELB, A-records).
-If set to false, no public-facing ingress resources will be created.
+(optional) If set to "all", the default, then both public and private ingress resources (ELB, A-records) will be created.
+If set to "private", then only create private-facing ingress resources (ELB, A-records). No public-facing ingress resources will be created.
+If set to "public", then only create public-facing ingress resources (ELB, A-records). No private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
 EOF
 }
 

--- a/tests/smoke/aws/vars/aws-basic.tfvars.json
+++ b/tests/smoke/aws/vars/aws-basic.tfvars.json
@@ -5,7 +5,7 @@
   "tectonic_aws_master_ec2_type": "m4.large",
   "tectonic_aws_master_root_volume_size": 32,
   "tectonic_aws_master_root_volume_type": "gp2",
-  "tectonic_aws_private_endpoints": false,
+  "tectonic_aws_endpoints": "public",
   "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
   "tectonic_aws_worker_ec2_type": "m4.large",
   "tectonic_aws_worker_root_volume_size": 32,

--- a/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
+++ b/tests/smoke/aws/vars/aws-vpc-internal.tfvars.json
@@ -1,6 +1,6 @@
 {
     "tectonic_aws_etcd_ec2_type": "m4.large",
-    "tectonic_aws_public_endpoints": false,
+    "tectonic_aws_endpoints": "private",
     "tectonic_aws_master_ec2_type": "m4.large",
     "tectonic_aws_vpc_cidr_block": "10.0.0.0/16",
     "tectonic_aws_worker_ec2_type": "m4.large",


### PR DESCRIPTION
This commit merges two dependent configuration options,
tectonic_aws_private_endpoints and tectonic_aws_public_endpoints, into
one single option: tectonic_aws_endpoints. This ensures users cannot end
up with a cluster without entirely endpoints. This commit also adds
validation of the endpoints field to ensure it is one of the accepted
values.

Fixes: INST-924