### PR TITLE
config.tf: bump node controller operator

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -61,7 +61,7 @@ variable "tectonic_container_images" {
     awscli                               = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
     gcloudsdk                            = "google/cloud-sdk:178.0.0-alpine"
     bootkube                             = "quay.io/coreos/bootkube:v0.10.0"
-    tnc_operator                         = "quay.io/coreos/tectonic-node-controller-operator-dev:6b54f3e13862531c33b44b322a05a06ec84d074d"
+    tnc_operator                         = "quay.io/coreos/tectonic-node-controller-operator-dev:5ba1c26983f72f024e447632a1d71910032fa2f6"
     etcd_cert_signer                     = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"
     etcd                                 = "quay.io/coreos/etcd:v3.2.14"
     hyperkube                            = "quay.io/coreos/hyperkube:v1.9.3_coreos.0"


### PR DESCRIPTION
This new version includes the removal of the following:

  - coreos-metadata.service - This metadata from this service (typically
        the public IP address) isn't actually used by etcd.
  - k8s-node-bootstrap.yaml - This service used to be responsible for
        installing the correct version of docker and kubelet. Now that
        TNC exists, it can inject the correct versions directly.
  - runtime-mappings.yaml - This was used by k8s-node-bootstrap as a
        fallback for when it was unable to contact the cluster.
