### PR TITLE
installer: validate libvirt

### DIFF
--- a/examples/tectonic.libvirt.yaml
+++ b/examples/tectonic.libvirt.yaml
@@ -1,6 +1,6 @@
 admin:
-  email: "a@b.c"
-  password: "verysecure"
+  email: a@b.c
+  password: verysecure
 # The base DNS domain of the cluster. It must NOT contain a trailing period. Some
 # DNS providers will automatically add this if necessary.
 #
@@ -15,12 +15,12 @@ admin:
 baseDomain: 
 
 libvirt:
-  uri: "qemu:///system"
+  uri: qemu:///system
   network:
     name: tectonic
     ifName: tt0
-    dnsServer: "8.8.8.8"
-    ipRange: "192.168.124.0/24"
+    dnsServer: 8.8.8.8
+    ipRange: 192.168.124.0/24
   sshKey: "ssh-rsa ..."
   imagePath: /path/to/image
 

--- a/installer/pkg/config-generator/ignition.go
+++ b/installer/pkg/config-generator/ignition.go
@@ -96,7 +96,7 @@ func (c *ConfigGenerator) embedUserBlock(ignCfg *ignconfigtypes.Config) {
 		userBlock := ignconfigtypes.User{
 			Name: "core",
 			SSHAuthorizedKeys: []string{
-				c.Libvirt.SshKey,
+				c.Libvirt.SSHKey,
 			},
 		}
 

--- a/installer/pkg/config/cluster.go
+++ b/installer/pkg/config/cluster.go
@@ -35,6 +35,12 @@ var defaultCluster = Cluster{
 		Channel: ContainerLinuxChannelStable,
 		Version: ContainerLinuxVersionLatest,
 	},
+	Libvirt: libvirt.Libvirt{
+		Network: libvirt.Network{
+			DNSServer: libvirt.DefaultDNSServer,
+			IfName:    libvirt.DefaultIfName,
+		},
+	},
 	Networking: Networking{
 		MTU:         "1480",
 		PodCIDR:     "10.2.0.0/16",

--- a/installer/pkg/config/libvirt/libvirt.go
+++ b/installer/pkg/config/libvirt/libvirt.go
@@ -7,32 +7,39 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 )
 
+const (
+	// DefaultDNSServer is the default DNS server for libvirt.
+	DefaultDNSServer = "8.8.8.8"
+	// DefaultIfName is the default interface name for libvirt.
+	DefaultIfName = "osbr0"
+)
+
 // Libvirt-specific configuration
 type Libvirt struct {
-	URI          string `json:"tectonic_libvirt_uri,omitempty" yaml:"uri"`
-	SshKey       string `json:"tectonic_libvirt_ssh_key,omitempty" yaml:"sshKey"`
-	QowImagePath string `json:"tectonic_coreos_qow_path,omitempty" yaml:"imagePath"`
-	Network      `json:",inline" yaml:"network"`
-	MasterIPs    []string `json:"tectonic_libvirt_master_ips,omitempty" yaml:"masterIps"`
+	URI           string `json:"tectonic_libvirt_uri,omitempty" yaml:"uri"`
+	SSHKey        string `json:"tectonic_libvirt_ssh_key,omitempty" yaml:"sshKey"`
+	QCOWImagePath string `json:"tectonic_coreos_qcow_path,omitempty" yaml:"imagePath"`
+	Network       `json:",inline" yaml:"network"`
+	MasterIPs     []string `json:"tectonic_libvirt_master_ips,omitempty" yaml:"masterIPs"`
 }
 
 type Network struct {
 	Name      string `json:"tectonic_libvirt_network_name,omitempty" yaml:"name"`
 	IfName    string `json:"tectonic_libvirt_network_if,omitempty" yaml"ifName"`
-	DnsServer string `json:"tectonic_libvirt_resolver,omitempty" yaml:"dnsServer"`
-	IpRange   string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
+	DNSServer string `json:"tectonic_libvirt_resolver,omitempty" yaml:"dnsServer"`
+	IPRange   string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
 }
 
 // Fill in any variables for terraform
 func (l *Libvirt) TFVars(masterCount int) error {
-	_, network, err := net.ParseCIDR(l.Network.IpRange)
+	_, network, err := net.ParseCIDR(l.Network.IPRange)
 	if err != nil {
-		return fmt.Errorf("failed to parse libvirt.network.iprange: %v", err)
+		return fmt.Errorf("failed to parse libvirt network ipRange: %v", err)
 	}
 
 	if len(l.MasterIPs) > 0 {
 		if len(l.MasterIPs) != masterCount {
-			return fmt.Errorf("length of MasterIPs does't match master count")
+			return fmt.Errorf("length of MasterIPs doesn't match master count")
 		} else {
 			return nil
 		}
@@ -41,7 +48,7 @@ func (l *Libvirt) TFVars(masterCount int) error {
 	for i := 0; i < masterCount; i++ {
 		ip, err := cidr.Host(network, i+10)
 		if err != nil {
-			return fmt.Errorf("failed to generate masterips: %v", err)
+			return fmt.Errorf("failed to generate master IPs: %v", err)
 		}
 		l.MasterIPs = append(l.MasterIPs, ip.String())
 	}

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -27,6 +27,8 @@
   "tectonic_aws_worker_root_volume_iops": 100,
   "tectonic_aws_worker_root_volume_size": 30,
   "tectonic_aws_worker_root_volume_type": "gp2",
+  "tectonic_libvirt_network_if": "osbr0",
+  "tectonic_libvirt_resolver": "8.8.8.8",
   "tectonic_ignition_master": "ignition-master.ign",
   "tectonic_ignition_worker": "ignition-worker.ign",
   "tectonic_ignition_etcd": "ignition-etcd.ign"

--- a/modules/libvirt/volume/main.tf
+++ b/modules/libvirt/volume/main.tf
@@ -1,5 +1,5 @@
-# Create a QOW volume from the downloaded path
+# Create a QCOW volume from the downloaded path
 resource "libvirt_volume" "coreos_base" {
   name   = "coreos_base"
-  source = "file://${var.coreos_qow_path}"
+  source = "file://${var.coreos_qcow_path}"
 }

--- a/modules/libvirt/volume/variables.tf
+++ b/modules/libvirt/volume/variables.tf
@@ -1,4 +1,4 @@
-variable "coreos_qow_path" {
+variable "coreos_qcow_path" {
   description = "The path on disk to the coreos disk image"
   type        = "string"
 }

--- a/steps/topology/libvirt/main.tf
+++ b/steps/topology/libvirt/main.tf
@@ -23,7 +23,7 @@ resource "libvirt_network" "tectonic_net" {
 module "libvirt_base_volume" {
   source = "../../../modules/libvirt/volume"
 
-  coreos_qow_path = "${var.tectonic_coreos_qow_path}"
+  coreos_qcow_path = "${var.tectonic_coreos_qcow_path}"
 }
 
 locals {

--- a/steps/variables-libvirt.tf
+++ b/steps/variables-libvirt.tf
@@ -11,7 +11,6 @@ variable "tectonic_libvirt_network_name" {
 variable "tectonic_libvirt_network_if" {
   type        = "string"
   description = "The name of the bridge to use"
-  default     = "tt0"
 }
 
 variable "tectonic_libvirt_ip_range" {
@@ -22,12 +21,11 @@ variable "tectonic_libvirt_ip_range" {
 variable "tectonic_libvirt_resolver" {
   type        = "string"
   description = "the upstream dns resolver"
-  default     = "8.8.8.8"
 }
 
-variable "tectonic_coreos_qow_path" {
+variable "tectonic_coreos_qcow_path" {
   type        = "string"
-  description = "path to a container linux qow image"
+  description = "path to a container linux qcow image"
 }
 
 variable "tectonic_libvirt_master_ips" {


### PR DESCRIPTION
This commit adds validation for all libvirt fields. Additionally, it
moves the default values for these validated fields from Terraform to
Golang so that the defaults are handled consistently and we do not
accidentally omit configuration values by forgetting to plumb values
through Terraform.

Addresses: INST-1089

CC @enxebre @squeed 

We need to set up our libvirt smoke tests so we can properly test future changes like this.