### PR TITLE
add travis CI platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: bash
 services:
   - docker
 env:
-  - BAZEL_IMG="quay.io/coreos/tectonic-builder:bazel-v0.3"
+  global:
+    - BAZEL_IMG="quay.io/coreos/tectonic-builder:bazel-v0.3"
 branches:
   only:
     - master
@@ -16,12 +17,12 @@ jobs:
       # YAML lint
     - script: >
         docker run -t -v $(pwd):/workdir 
-        giantswarm/yamllint --config-data 
+        quay.io/coreos/yamllint --config-data 
         '{extends: default, rules: {line-length: {level: warning, max: 120}}}' 
         ./examples/ ./installer/
       # Go lint
-      #- script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint -set_exit_status installer/..."
-    - script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint installer/..."
+      #- script: "docker run -v $PWD:$PWD -w $PWD quay.io/coreos/golang-testing golint -set_exit_status installer/..."
+    - script: "docker run -v $PWD:$PWD -w $PWD quay.io/coreos/golang-testing golint installer/..."
       # Terraform tests
     - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test terraform_fmt --test_output=all"
       # Installer unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         '{extends: default, rules: {line-length: {level: warning, max: 120}}}' 
         ./examples/ ./installer/
       # Go lint
-    #- script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint -set_exit_status installer/..."
+      #- script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint -set_exit_status installer/..."
     - script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint installer/..."
       # Terraform tests
     - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test terraform_fmt --test_output=all"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ jobs:
       # Installer unit tests
     - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test installer:cli_units --test_output=all"
     - stage: Build
-      script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel --output_base=.cache build tarball"
+      script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel build tarball"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
   include:
     - stage: Lint & Test
       # Terraform lint
-      script: docker run -v $(pwd):/data -t wata727/tflint
+      script: docker run -v $(pwd):/data -t quay.io/coreos/tflint
       # YAML lint
     - script: >
         docker run -t -v $(pwd):/workdir 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+---
+sudo: required
+language: bash
+services:
+  - docker
+env:
+  - BAZEL_IMG="quay.io/coreos/tectonic-builder:bazel-v0.3"
+branches:
+  only:
+    - master
+jobs:
+  include:
+    - stage: Lint & Test
+      # Terraform lint
+      script: docker run -v $(pwd):/data -t wata727/tflint
+      # YAML lint
+    - script: >
+        docker run -t -v $(pwd):/workdir 
+        giantswarm/yamllint --config-data 
+        '{extends: default, rules: {line-length: {level: warning, max: 120}}}' 
+        ./examples/ ./installer/
+      # Go lint
+    #- script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint -set_exit_status installer/..."
+    - script: "docker run -v $PWD:$PWD -w $PWD appleboy/golang-testing golint installer/..."
+      # Terraform tests
+    - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test terraform_fmt --test_output=all"
+      # Installer unit tests
+    - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test installer:cli_units --test_output=all"
+    - stage: Build
+      script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel --output_base=.cache build tarball"

--- a/examples/tectonic.libvirt.yaml
+++ b/examples/tectonic.libvirt.yaml
@@ -12,7 +12,7 @@ admin:
 # To use Azure-provided DNS, `BaseDomain` should be set to `""`
 # If using DNS records, ensure that `BaseDomain` is set to a properly configured external DNS zone.
 # Instructions for configuring delegated domains for Azure DNS can be found here: https://docs.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns
-baseDomain: 
+baseDomain:
 
 libvirt:
   uri: "qemu:///system"


### PR DESCRIPTION
Run basic tests in travis-ci platform. This runs same tests as Jenkins instance in "basic" mode, adds 3 types of linters (terraform, yaml, go), and builds package.
This doesn't deploy anything to AWS so it is meant to be run on every PR.

Linters:
- `tflint` is used to lint terraform files in whole repository
- `yamllint` is used to lint every file in `examples` and `installer` directories and subdirectories. It is permissive about line length.
- `golint` recursively checks go files in `installer` directory. For now it is set to be in permissive mode (enforcing version is commented-out) due to some errors in [libvirt.go](installer/pkg/config/libvirt/libvirt.go) file.