### PR TITLE
installer/pkg/config/aws: fix merge

### DIFF
--- a/installer/pkg/config/aws/aws.go
+++ b/installer/pkg/config/aws/aws.go
@@ -22,9 +22,7 @@ type AWS struct {
 	ExtraTags                 map[string]string `json:"tectonic_aws_extra_tags,omitempty" yaml:"extraTags,omitempty"`
 	InstallerRole             string            `json:"tectonic_aws_installer_role,omitempty" yaml:"installerRole,omitempty"`
 	Master                    `json:",inline" yaml:"master,omitempty"`
-	PrivateEndpoints          *bool  `json:"tectonic_aws_private_endpoints,omitempty" yaml:"privateEndpoints,omitempty"`
 	Profile                   string `json:"tectonic_aws_profile,omitempty" yaml:"profile,omitempty"`
-	PublicEndpoints           *bool  `json:"tectonic_aws_public_endpoints,omitempty" yaml:"publicEndpoints,omitempty"`
 	Region                    string `json:"tectonic_aws_region,omitempty" yaml:"region,omitempty"`
 	SSHKey                    string `json:"tectonic_aws_ssh_key,omitempty" yaml:"sshKey,omitempty"`
 	VPCCIDRBlock              string `json:"tectonic_aws_vpc_cidr_block,omitempty" yaml:"vpcCIDRBlock,omitempty"`


### PR DESCRIPTION
It seems that due to all of the rebasing of the cleanup and validation
changes, some fields we not properly merged. These two fields should be
eliminated. The are the last references to
`tectonic_aws_public_endpoints` and `tectonic_aws_private_endpoints` in
the repository.

cc @enxebre @trawler 