### PR TITLE
installer: clean up use of Platform type

### DIFF
--- a/examples/tectonic.aws.yaml
+++ b/examples/tectonic.aws.yaml
@@ -280,7 +280,7 @@ nodePools:
     name: worker
 
 # The platform used for deploying.
-platform: AWS
+platform: aws
 
 # The path the pull secret file in JSON format.
 # This is known to be a "Docker pull secret" as produced by the docker login [1] command.

--- a/installer/pkg/config-generator/ignition.go
+++ b/installer/pkg/config-generator/ignition.go
@@ -113,7 +113,7 @@ func (c *ConfigGenerator) appendCertificateAuthority(ignCfg *ignconfigtypes.Conf
 }
 
 func (c *ConfigGenerator) embedUserBlock(ignCfg *ignconfigtypes.Config) {
-	if c.Platform.String() == config.PlatformLibvirt.String() {
+	if c.Platform == config.PlatformLibvirt {
 		userBlock := ignconfigtypes.PasswdUser{
 			Name: "core",
 			SSHAuthorizedKeys: []ignconfigtypes.SSHAuthorizedKey{
@@ -131,14 +131,14 @@ func (c *ConfigGenerator) getTNCURL(role string) string {
 	// cloud platforms put this behind a load balancer which remaps ports;
 	// libvirt doesn't do that - use the tnc port directly
 	port := 80
-	if c.Platform.String() == config.PlatformLibvirt.String() {
+	if c.Platform == config.PlatformLibvirt {
 		port = 49500
 	}
 
 	// XXX: The bootstrap node on AWS uses a CNAME to redirect TNC-bound
 	// traffic to S3. Because of this, HTTPS cannot be used.
 	scheme := "https"
-	if c.Platform.String() == config.PlatformAWS.String() && role == "master" {
+	if c.Platform == config.PlatformAWS && role == "master" {
 		scheme = "http"
 	}
 

--- a/installer/pkg/workflow/fixtures/aws.basic.yaml
+++ b/installer/pkg/workflow/fixtures/aws.basic.yaml
@@ -43,7 +43,7 @@ nodePools:
     count: 2
   - name: worker
     count: 3
-platform: AWS
+platform: aws
 pullSecretPath:
 worker:
   nodePools:

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -10,7 +10,7 @@
   "tectonic_networking": "canal",
   "tectonic_service_cidr": "10.3.0.0/16",
   "tectonic_cluster_cidr": "10.2.0.0/16",
-  "tectonic_platform": "AWS",
+  "tectonic_platform": "aws",
   "tectonic_worker_count": 3,
   "tectonic_aws_endpoints": "all",
   "tectonic_aws_etcd_ec2_type": "m4.large",

--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -55,7 +55,7 @@ func findStepTemplates(stepName string, platform config.Platform) (string, error
 		return "", fmt.Errorf("error looking up step %s templates: %v", stepName, err)
 	}
 	for _, path := range []string{
-		filepath.Join(base, stepsBaseDir, stepName, platform.String()),
+		filepath.Join(base, stepsBaseDir, stepName, platformPath(platform)),
 		filepath.Join(base, stepsBaseDir, stepName)} {
 
 		stat, err := os.Stat(path)
@@ -71,6 +71,16 @@ func findStepTemplates(stepName string, platform config.Platform) (string, error
 		return path, nil
 	}
 	return "", os.ErrNotExist
+}
+
+func platformPath(platform config.Platform) string {
+	switch platform {
+	case config.PlatformLibvirt:
+		return "libvirt"
+	case config.PlatformAWS:
+		return "aws"
+	}
+	panic("invalid platform")
 }
 
 func generateClusterConfigMaps(m *metadata) error {


### PR DESCRIPTION
This moves the validation of the platform up to the point of
unmarshalling, reducing the risk that a developer may end up with an
unexpected platform.
