### PR TITLE
Clean workspace in post action only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,19 +100,19 @@ pipeline {
         branch 'master'
       }
       steps {
-          forcefullyCleanWorkspace()
-          withCredentials(quayCreds) {
-            ansiColor('xterm') {
-              unstash 'tectonic-tarball'
-              sh """
-                docker build -t quay.io/coreos/tectonic-installer:master -f images/tectonic-installer/Dockerfile .
-                docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
-                docker push quay.io/coreos/tectonic-installer:master
-                docker logout quay.io
-              """
-              cleanWs notFailBuild: true
-            }
+        withCredentials(quayCreds) {
+          ansiColor('xterm') {
+            unstash 'tectonic-tarball'
+            sh """
+              docker build -t quay.io/coreos/tectonic-installer:master -f images/tectonic-installer/Dockerfile .
+              docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
+              docker push quay.io/coreos/tectonic-installer:master
+              docker logout quay.io
+            """
+            cleanWs notFailBuild: true
           }
+        }
+        forcefullyCleanWorkspace()
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,7 +112,6 @@ pipeline {
             cleanWs notFailBuild: true
           }
         }
-        forcefullyCleanWorkspace()
       }
     }
 


### PR DESCRIPTION
Currently docker container cannot be built since we are forcefully removing workspace before building container and Dockerfile cannot be found.
This PR causes to rely on cleaning workspace in post action only.
Most of the lines have indentation changed and only one line is removed.

This cannot be tested on any other branch than "master".