### PR TITLE
change default CI build actions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,12 +49,12 @@ pipeline {
   parameters {
     booleanParam(
       name: 'RUN_SMOKE_TESTS',
-      defaultValue: true,
+      defaultValue: false,
       description: ''
     )
     booleanParam(
       name: 'PLATFORM/AWS',
-      defaultValue: true,
+      defaultValue: false,
       description: ''
     )
     booleanParam(


### PR DESCRIPTION
For some reason the defult action for Jenkins build is to run smoke tests, this possibly can cause to execute tests on AWS even when labels aren't set.
This PR changes default behavior to not run smoke tests.