### PR TITLE
Fix nightly builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,6 @@ pipeline {
       steps {
         withCredentials(quayCreds) {
           ansiColor('xterm') {
-            unstash 'tectonic-tarball'
             sh """
               docker build -t quay.io/coreos/tectonic-installer:master -f images/tectonic-installer/Dockerfile .
               docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
                    ./tests/run.sh
                    cp bazel-bin/tectonic-dev.tar.gz .
                  """
+              // Produce an artifact which can be downloaded via web UI
               stash name: 'tectonic-tarball', includes: 'tectonic-dev.tar.gz'
             }
           }


### PR DESCRIPTION
Fix Jenkis pipeline to enable nightly build on master branch.

This cannot be tested as PR, and will be tested manually via Jenkins Web interface with builds on master branch.