### PR TITLE
modules/bootkube: explicitly depend on docker

### DIFF
--- a/modules/bootkube/resources/bootkube.service
+++ b/modules/bootkube/resources/bootkube.service
@@ -2,7 +2,8 @@
 Description=Bootstrap a Kubernetes cluster
 ConditionPathExists=!/opt/tectonic/init_bootkube.done
 Wants=kubelet.service
-After=kubelet.service
+Requires=docker.service
+After=kubelet.service docker.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
bootkube.sh makes heavy use of docker but doesn't wait until it's ready.
This worked on Container Linux because docker was socket activated.
That's not the case on RHCOS right now, so we need to be explicit.
