### PR TITLE
azure-terraform: custom vnet resource group

### DIFF
--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -14,6 +14,10 @@ output "worker_subnet_name" {
   value = "${var.external_vnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.name, list("")), 0) : replace(var.external_vnet_id, var.const_id_to_group_name_regex, "$2")}"
 }
 
+output "vnet_resource_group" {
+  value = "${var.external_vnet_id == "" ?  "" : replace(var.external_vnet_id, var.const_id_to_group_name_regex, "$1")}"
+}
+
 # TODO: Allow user to provide their own network
 output "etcd_cidr" {
   value = "${element(concat(azurerm_subnet.master_subnet.*.address_prefix, list("")), 0)}"

--- a/platforms/azure/main.tf
+++ b/platforms/azure/main.tf
@@ -96,6 +96,7 @@ data "null_data_source" "cloud_provider" {
     "subscriptionId"             = "${data.azurerm_client_config.current.subscription_id}"
     "tenantId"                   = "${data.azurerm_client_config.current.tenant_id}"
     "vnetName"                   = "${module.vnet.vnet_id}"
+    "vnetResourceGroup"          = "${module.vnet.vnet_resource_group}"
   }
 }
 


### PR DESCRIPTION
Fork of https://github.com/coreos/tectonic-installer/pull/3198 in order to rebase correctly.

If you provide your own CA certificate and there are one or more
intermediate certificates in the chain, this chain must be added
to all generated server certificates in order for them to be valid.
This pr allows users to set the variable tectonic_cert_chain and
get the behavior described above.