### PR TITLE
Azure custom vnet config

### DIFF
--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -1,21 +1,29 @@
+locals {
+  # A regular expression that parses a Azure subnet id to extract subnet name.
+  const_id_to_subnet_name_regex = "/^/subscriptions/[-\\w]+/resourceGroups/[-\\w]+/providers/Microsoft.Network/virtualNetworks/[.\\w]+/subnets/([.\\w-]+)$/"
+
+  # A regular expression that parses Azure resource IDs into component identifiers
+  const_id_to_group_name_regex = "/^/subscriptions/[-\\w]+/resourceGroups/([\\w()-\\.]+)/providers/[.\\w]+/[.\\w]+/([.\\w-]+)$/"
+}
+
 output "vnet_id" {
-  value = "${var.external_vnet_id == "" ? element(concat(azurerm_virtual_network.tectonic_vnet.*.name, list("")), 0) : replace(var.external_vnet_id, var.const_id_to_group_name_regex, "$2")}"
+  value = "${var.external_vnet_id == "" ? element(concat(azurerm_virtual_network.tectonic_vnet.*.name, list("")), 0) : replace(var.external_vnet_id, local.const_id_to_group_name_regex, "$2")}"
 }
 
 output "master_subnet" {
-  value = "${var.external_vnet_id == "" ?  element(concat(azurerm_subnet.master_subnet.*.id, list("")), 0) : var.external_master_subnet_id}"
+  value = "${var.external_master_subnet_id == "" ?  element(concat(azurerm_subnet.master_subnet.*.id, list("")), 0) : var.external_master_subnet_id}"
 }
 
 output "worker_subnet" {
-  value = "${var.external_vnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.id, list("")), 0) : var.external_worker_subnet_id}"
+  value = "${var.external_worker_subnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.id, list("")), 0) : var.external_worker_subnet_id}"
 }
 
 output "worker_subnet_name" {
-  value = "${var.external_vnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.name, list("")), 0) : replace(var.external_worker_subnet_id, var.const_id_to_subnet_name_regex, "$1")}"
+  value = "${var.external_worker_subnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.name, list("")), 0) : replace(var.external_worker_subnet_id, local.const_id_to_subnet_name_regex, "$1")}"
 }
 
 output "vnet_resource_group" {
-  value = "${var.external_vnet_id == "" ?  "" : replace(var.external_vnet_id, var.const_id_to_group_name_regex, "$1")}"
+  value = "${var.external_vnet_id == "" ?  "" : replace(var.external_vnet_id, local.const_id_to_group_name_regex, "$1")}"
 }
 
 # TODO: Allow user to provide their own network

--- a/modules/azure/vnet/outputs.tf
+++ b/modules/azure/vnet/outputs.tf
@@ -1,5 +1,5 @@
 output "vnet_id" {
-  value = "${var.external_vnet_id == "" ? element(concat(azurerm_virtual_network.tectonic_vnet.*.name, list("")), 0) : var.external_vnet_id}"
+  value = "${var.external_vnet_id == "" ? element(concat(azurerm_virtual_network.tectonic_vnet.*.name, list("")), 0) : replace(var.external_vnet_id, var.const_id_to_group_name_regex, "$2")}"
 }
 
 output "master_subnet" {
@@ -11,7 +11,7 @@ output "worker_subnet" {
 }
 
 output "worker_subnet_name" {
-  value = "${var.external_vnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.name, list("")), 0) : replace(var.external_vnet_id, var.const_id_to_group_name_regex, "$2")}"
+  value = "${var.external_vnet_id == "" ?  element(concat(azurerm_subnet.worker_subnet.*.name, list("")), 0) : replace(var.external_worker_subnet_id, var.const_id_to_subnet_name_regex, "$1")}"
 }
 
 output "vnet_resource_group" {

--- a/modules/azure/vnet/variables.tf
+++ b/modules/azure/vnet/variables.tf
@@ -6,6 +6,12 @@ variable "const_id_to_group_name_regex" {
   description = "(internal) A regular expression that parses Azure resource IDs into component identifiers."
 }
 
+variable "const_id_to_subnet_name_regex" {
+  default     = "/^/subscriptions/[-\\w]+/resourceGroups/[-\\w]+/providers/Microsoft.Network/virtualNetworks/[.\\w]+/subnets/([.\\w-]+)$/"
+  type        = "string"
+  description = "(internal) A regular expression that parses a Azure subnet id to extract subnet name."
+}
+
 variable "cluster_name" {
   type = "string"
 }

--- a/modules/azure/vnet/variables.tf
+++ b/modules/azure/vnet/variables.tf
@@ -1,17 +1,3 @@
-// This var is for internal use only.
-// It is to be considered a constant, because Terraform can't acutally define constants.
-variable "const_id_to_group_name_regex" {
-  default     = "/^/subscriptions/[-\\w]+/resourceGroups/([\\w()-\\.]+)/providers/[.\\w]+/[.\\w]+/([.\\w-]+)$/"
-  type        = "string"
-  description = "(internal) A regular expression that parses Azure resource IDs into component identifiers."
-}
-
-variable "const_id_to_subnet_name_regex" {
-  default     = "/^/subscriptions/[-\\w]+/resourceGroups/[-\\w]+/providers/Microsoft.Network/virtualNetworks/[.\\w]+/subnets/([.\\w-]+)$/"
-  type        = "string"
-  description = "(internal) A regular expression that parses a Azure subnet id to extract subnet name."
-}
-
 variable "cluster_name" {
   type = "string"
 }


### PR DESCRIPTION
Fork of https://github.com/coreos/tectonic-installer/pull/3188 in order to rebase correctly.

The cloud config /etc/kubernetes/cloud/config for Azure had id's in vnetName and subnetName when custom vnet (tectonic_azure_external_vnet_id) was used, instead of just names. This fixes this issue by extracting names from the vnet id and subnet id, to correctly generate cloud config for Azure.

Fixes #3192