### PR TITLE
operator: Add toleration to the operators for everything

### DIFF
--- a/modules/tectonic/resources/manifests/updater/operators/kube-version-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/kube-version-operator.yaml
@@ -17,6 +17,8 @@ spec:
         k8s-app: kube-version-operator
         tectonic-app-version-name: kubernetes
     spec:
+      tolerations:
+      - operator: "Exists"
       containers:
       - name: kube-version-operator
         image: ${kube_version_operator_image}

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-alm-operator.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         k8s-app: tectonic-alm-operator
     spec:
+      tolerations:
+      - operator: "Exists"
       imagePullSecrets:
         - name: coreos-pull-secret
       containers:

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-channel-operator.yaml
@@ -20,9 +20,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
+      - operator: "Exists"
       containers:
       - name: tectonic-channel-operator
         image: ${tectonic_channel_operator_image}

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-cluo-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-cluo-operator.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         k8s-app: tectonic-cluo-operator
     spec:
+      tolerations:
+      - operator: "Exists"
       containers:
       - name: tectonic-cluo-operator
         image: ${tectonic_cluo_operator_image}

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-etcd-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-etcd-operator.yaml
@@ -17,6 +17,8 @@ spec:
         k8s-app: tectonic-etcd-operator
         tectonic-app-version-name: tectonic-etcd
     spec:
+      tolerations:
+      - operator: "Exists"
       containers:
       - image: ${tectonic_etcd_operator_image}
         name: tectonic-etcd-operator

--- a/modules/tectonic/resources/manifests/updater/operators/tectonic-prometheus-operator.yaml
+++ b/modules/tectonic/resources/manifests/updater/operators/tectonic-prometheus-operator.yaml
@@ -17,6 +17,8 @@ spec:
         k8s-app: tectonic-prometheus-operator
         tectonic-app-version-name: tectonic-monitoring
     spec:
+      tolerations:
+      - operator: "Exists"
       containers:
       - image: ${tectonic_prometheus_operator_image}
         name: tectonic-prometheus-operator


### PR DESCRIPTION
Customers will add their own taints to nodes, which can block
our operators, so we need to add the omnipotent toleration here
to make our operators schedulable.

Fix https://jira.coreos.com/browse/CORS-681