### PR TITLE
Fixes issue tectonic-forum issue 251

### DIFF
--- a/modules/dns/route53/tectonic.tf
+++ b/modules/dns/route53/tectonic.tf
@@ -1,5 +1,6 @@
 data "aws_route53_zone" "tectonic" {
   name = "${var.base_domain}"
+  private_zone = true
 }
 
 locals {


### PR DESCRIPTION
Fix issue: https://github.com/coreos/tectonic-forum/issues/251

"data.aws_route53_zone.tectonic: no matching Route53Zone found" during install